### PR TITLE
Fix preview mode: SSR cache staleness and deprecated API perspective

### DIFF
--- a/_bmad-output/implementation-artifacts/5-4-preview-publish-architecture.md
+++ b/_bmad-output/implementation-artifacts/5-4-preview-publish-architecture.md
@@ -1,0 +1,301 @@
+# Story 5.4: Preview & Publish Architecture (Comprehensive)
+
+Status: review
+
+<!-- Source: Sanity docs research (Visual Editing, Webhooks, Astro integration) + codebase analysis of current dual-deployment setup -->
+
+## Story
+
+As a content editor,
+I want a complete end-to-end workflow where I can preview draft changes live in the Presentation tool, publish content, and have the production site automatically rebuild with my changes,
+So that I can manage content confidently without developer assistance and know exactly when changes go live.
+
+## Acceptance Criteria
+
+1. **AC1 — Webhook auto-rebuild:** A Sanity GROQ-powered webhook is configured at sanity.io/manage that fires on document create/update/delete (published documents only, drafts excluded) and triggers a Cloudflare Pages deploy hook to rebuild the production static site.
+2. **AC2 — Deploy hook endpoint:** A Cloudflare Pages deploy hook URL exists for the `ywcc-capstone` project that triggers a production rebuild when called via POST.
+3. **AC3 — Webhook filter:** The webhook filter is scoped to content types that affect the public site: `_type in ["page", "siteSettings", "sponsor", "project", "team", "event"]` — not internal/admin documents.
+4. **AC4 — Webhook secret:** The webhook includes a secret for origin verification. The deploy hook URL is not publicly guessable.
+5. **AC5 — SSR cache invalidation:** The `_siteSettingsCache` module-level memoization in `src/lib/sanity.ts` does not persist across SSR requests on the preview branch — each request gets fresh site settings data.
+6. **AC6 — Preview CSP complete:** The CSP meta tag in `Layout.astro` includes `wss://*.sanity.io` in `connect-src` for real-time Visual Editing communication (WebSocket for live content updates).
+7. **AC7 — Perspective deprecation fix:** The `loadQuery` wrapper in `src/lib/sanity.ts` uses `"drafts"` perspective instead of the deprecated `"previewDrafts"` (Sanity API deprecation warning).
+8. **AC8 — End-to-end verification:** The complete loop works: edit content in Studio → see changes in Presentation tool preview → publish in Studio → webhook fires → Cloudflare rebuilds → production site shows new content within 5 minutes.
+9. **AC9 — Build succeeds:** `npm run build` in `astro-app/` completes without errors for both static (main) and SSR (preview) configurations.
+
+## Tasks / Subtasks
+
+- [ ] Task 1: Set up Cloudflare Pages deploy hook (AC: #2, #4)
+  - [ ] 1.1: In Cloudflare dashboard → Pages → `ywcc-capstone` → Settings → Builds & deployments → Deploy hooks: create a deploy hook named "Sanity Content Publish" for the `main` branch
+  - [ ] 1.2: Copy the generated deploy hook URL (this is a unique, secret URL that triggers a build)
+  - [ ] 1.3: Verify the deploy hook works by calling it via `curl -X POST <deploy_hook_url>` and confirming a build is triggered in the Cloudflare dashboard
+
+- [ ] Task 2: Configure Sanity webhook (AC: #1, #3, #4)
+  - [ ] 2.1: Go to sanity.io/manage → Project → API → Webhooks → Add webhook
+  - [ ] 2.2: Name: "Trigger production rebuild"
+  - [ ] 2.3: URL: The Cloudflare Pages deploy hook URL from Task 1
+  - [ ] 2.4: Trigger on: Create, Update, Delete
+  - [ ] 2.5: Filter: `_type in ["page", "siteSettings", "sponsor", "project", "team", "event"]`
+  - [ ] 2.6: Drafts: OFF (default — only fires when content is published, not on every keystroke)
+  - [ ] 2.7: HTTP method: POST
+  - [ ] 2.8: Add a webhook secret for origin verification
+  - [ ] 2.9: Enable the webhook
+  - [ ] 2.10: Test by publishing a content change in Studio and verifying a Cloudflare build triggers
+
+- [x] Task 3: Fix SSR cache invalidation (AC: #5)
+  - [x] 3.1: In `astro-app/src/lib/sanity.ts`, make `_siteSettingsCache` conditional on Visual Editing being disabled
+  - [x] 3.2: When `visualEditingEnabled === true` (SSR preview), bypass the cache and always fetch fresh data
+  - [x] 3.3: When `visualEditingEnabled === false` (static build), keep the existing module-level cache (it only lives for the duration of the build process)
+  - [ ] 3.4: Verify that editing site settings in Studio → refreshing preview shows updated navigation/footer *(manual — requires deployed preview)*
+
+- [x] Task 4: Fix perspective deprecation (AC: #7)
+  - [x] 4.1: In `astro-app/src/lib/sanity.ts`, change `const perspective = visualEditingEnabled ? "previewDrafts" : "published"` to `const perspective = visualEditingEnabled ? "drafts" : "published"`
+  - [x] 4.2: Verify no deprecation warnings in build output or server logs
+
+- [x] Task 5: Verify CSP for Visual Editing (AC: #6)
+  - [x] 5.1: Confirm `Layout.astro` CSP meta tag includes `wss://*.sanity.io` in `connect-src`
+  - [x] 5.2: Confirm `_headers` file includes `frame-ancestors 'self' https://*.sanity.studio https://*.sanity.io` (already done — verify only)
+  - [ ] 5.3: Test Visual Editing in Presentation tool — verify overlays appear, click-to-edit works, and content updates show on page refresh *(manual — requires deployed preview)*
+
+- [ ] Task 6: End-to-end verification (AC: #8, #9)
+  - [ ] 6.1: Open Sanity Studio Presentation tool, verify preview loads at `preview.ywcc-capstone.pages.dev`
+  - [ ] 6.2: Edit a page title in Studio → verify the change appears on refresh in the preview iframe
+  - [ ] 6.3: Edit site settings (navigation, footer) → verify changes appear on preview refresh
+  - [ ] 6.4: Publish the changes in Studio → verify the Sanity webhook fires (check webhook attempts log in sanity.io/manage)
+  - [ ] 6.5: Verify a Cloudflare Pages build triggers automatically
+  - [ ] 6.6: After build completes, verify production site at `ywcc-capstone.pages.dev` shows the published changes
+  - [ ] 6.7: Run `npm run build --workspace=astro-app` locally with `PUBLIC_SANITY_VISUAL_EDITING_ENABLED` unset → static build succeeds
+  - [ ] 6.8: Run `npm run build --workspace=astro-app` locally with `PUBLIC_SANITY_VISUAL_EDITING_ENABLED=true` → SSR build succeeds
+
+## Dev Notes
+
+### The Big Picture
+
+This story completes the content publishing loop. Right now:
+
+```
+Current (broken loop):
+  Editor edits in Studio → Preview shows drafts (SSR) ✅
+  Editor publishes → Nothing happens ❌ → Editor asks dev to push ❌
+  Production site shows stale content until manual deploy ❌
+
+Target (complete loop):
+  Editor edits in Studio → Preview shows drafts (SSR) ✅
+  Editor publishes → Webhook fires → Cloudflare rebuilds automatically ✅
+  Production site shows new content within ~3-5 minutes ✅
+```
+
+### Architecture
+
+```
+┌──────────────┐   publish    ┌─────────────────┐  webhook POST  ┌──────────────────┐
+│ Sanity Studio │────────────→│ Sanity Content   │──────────────→│ Cloudflare Pages │
+│ (editor)     │              │ Lake             │               │ Deploy Hook      │
+└──────┬───────┘              └─────────────────┘               └────────┬─────────┘
+       │                                                                  │
+       │ Presentation tool                                       triggers rebuild
+       │ (iframe)                                                         │
+       ▼                                                                  ▼
+┌──────────────────────────┐                              ┌──────────────────────────┐
+│ preview.ywcc-capstone    │                              │ ywcc-capstone.pages.dev  │
+│ .pages.dev               │                              │ (production)             │
+│ output: "server"         │                              │ output: "static"         │
+│ perspective: "drafts"    │                              │ perspective: "published"  │
+│ stega: true              │                              │ stega: false              │
+│ <VisualEditing /> active │                              │ <VisualEditing /> off     │
+└──────────────────────────┘                              └──────────────────────────┘
+```
+
+### Webhook Configuration Details
+
+**Sanity GROQ-powered webhooks** (docs: sanity.io/docs/content-lake/webhooks):
+
+- Trigger by default only on **published** document mutations (drafts excluded unless you opt in)
+- Support GROQ filters to scope which document types trigger the hook
+- Include idempotency-key header for de-duplication
+- Retry with exponential back-off for 30 minutes on 5xx/429 errors
+- 400-range errors are NOT retried (treated as undeliverable)
+- Timeout after 30 seconds per request
+- Limited to 1 concurrent request (queues subsequent events)
+
+**Filter rationale:**
+```groq
+_type in ["page", "siteSettings", "sponsor", "project", "team", "event"]
+```
+
+This scopes to document types that affect the public site. It excludes:
+- Draft documents (excluded by default)
+- Any future internal document types (e.g., `submission` for form submissions)
+- System documents
+
+**Why not filter to specific fields?** Because any change to a published page, sponsor, or setting could affect what's displayed. The webhook fires once per publish action, and Cloudflare Pages deduplicates rapid successive deploys.
+
+### SSR Cache Fix
+
+**Current problem:**
+
+```typescript
+// src/lib/sanity.ts — line 66
+let _siteSettingsCache: SiteSettings | null = null;
+
+export async function getSiteSettings(): Promise<SiteSettings> {
+  if (_siteSettingsCache) return _siteSettingsCache;  // ← BUG in SSR mode
+  // ...
+}
+```
+
+In `output: "static"` (production build), this is fine — the cache lives only for the duration of the build process. Every `npm run build` starts fresh.
+
+In `output: "server"` (preview SSR), this is a **bug** — the module is loaded once when the Worker starts and persists across requests. If an editor changes the site settings, the cache serves stale data until the Worker cold-starts again (which could be minutes or hours on Cloudflare).
+
+**Fix:**
+
+```typescript
+export async function getSiteSettings(): Promise<SiteSettings> {
+  // In SSR mode, always fetch fresh (editors need to see their changes)
+  if (!visualEditingEnabled && _siteSettingsCache) return _siteSettingsCache;
+  // ...
+}
+```
+
+This is a one-line change. Static builds still get memoization (performance during build). SSR preview always gets fresh data (correctness for editors).
+
+### Perspective Deprecation
+
+Sanity's API shows a deprecation warning for `"previewDrafts"`:
+
+> The previewDrafts perspective has been renamed to drafts
+
+The fix is a simple string replacement in `loadQuery`:
+
+```diff
+- const perspective = visualEditingEnabled ? "previewDrafts" : "published";
++ const perspective = visualEditingEnabled ? "drafts" : "published";
+```
+
+This was noted in Story 5.2's dev notes (gotcha #9) but never fixed.
+
+### CSP Status (Verify Only)
+
+Based on the current `Layout.astro` line 45 and `_headers` file, the CSP already includes:
+- `connect-src 'self' https://www.google-analytics.com https://*.sanity.io wss://*.sanity.io` ✅
+- `frame-ancestors 'self' https://*.sanity.studio https://*.sanity.io` (in `_headers`) ✅
+
+This should work. Task 5 is verification only — no code changes expected unless testing reveals issues.
+
+### What NOT to Change
+
+- **Do NOT modify `studio/`** — webhook config is done in sanity.io/manage, not in code
+- **Do NOT modify `astro.config.mjs`** — output mode switching already works correctly
+- **Do NOT modify `.github/workflows/deploy.yml`** — CI/CD pipeline already handles both branches
+- **Do NOT modify block components** — stegaClean fixes are Story 7.1's scope (already done per PR #3)
+- **Do NOT set up Server Islands** — that's a separate optimization story, not needed for the publishing loop
+- **Do NOT configure the webhook in code** — it's managed via sanity.io/manage UI or Sanity CLI
+
+### File-by-File Implementation Guide
+
+#### File 1: `astro-app/src/lib/sanity.ts`
+
+Two changes:
+
+**Change 1 — Cache bypass in SSR (line ~68):**
+```diff
+  export async function getSiteSettings(): Promise<SiteSettings> {
+-   if (_siteSettingsCache) return _siteSettingsCache;
++   if (!visualEditingEnabled && _siteSettingsCache) return _siteSettingsCache;
+```
+
+**Change 2 — Perspective rename (line ~29):**
+```diff
+-   const perspective = visualEditingEnabled ? "previewDrafts" : "published";
++   const perspective = visualEditingEnabled ? "drafts" : "published";
+```
+
+#### No other code files need changes.
+
+Tasks 1-2 (webhook + deploy hook) are infrastructure configuration done in the Cloudflare dashboard and sanity.io/manage UI.
+
+### Dependencies
+
+- **Requires:** Story 5.2 complete (Cloudflare Pages deployment — DONE)
+- **Requires:** Preview branch deployed and SSR working (PR #3 — DONE per recent commits)
+- **Does NOT require:** Story 7.1 (stegaClean fixes — already applied in PR #3 commits)
+- **Does NOT require:** Any Sanity schema changes
+- **Does NOT require:** Any Studio configuration changes
+- **Blocks:** Nothing — this is a standalone infrastructure completion story
+
+### Previous Story Intelligence
+
+**Story 5.2 (GA4, Security Headers & Cloudflare Deploy — REVIEW):**
+- Established the Cloudflare Pages deployment pipeline
+- Created the GitHub Actions workflow for both `main` and `preview` branches
+- Documented the dual-deployment architecture and SSR preview setup
+- Noted the `previewDrafts` → `drafts` deprecation but did not fix it
+- Noted `_siteSettingsCache` concern but did not fix it
+
+**PR #3 commits (preview branch):**
+- Applied stegaClean fixes to all block components (originally planned for Story 7.1)
+- Switched preview to `output: "server"` for live draft content
+- Added conditional `prerender` exports to all pages
+- Fixed `astro-icon` → `@iconify/utils` for Cloudflare Workers compatibility
+- Fixed `.env` file writing in CI for `SANITY_API_READ_TOKEN` SSR inlining
+
+### Git Intelligence
+
+Recent commits on `preview` branch show the SSR preview is functional:
+- `1f8e2f3` — fixed `.env` writing in CI for SSR token inlining
+- `95e38e6` — replaced `astro-icon` with `@iconify/utils` for Workers edge compat
+- `e5a2767` — switched preview to SSR for live draft content
+- `b226413` — initial Visual Editing on preview branch
+
+The preview deployment should be working at `preview.ywcc-capstone.pages.dev`. This story adds the missing piece: automatic production rebuilds when content is published.
+
+### Sanity Webhook Best Practices (from docs)
+
+1. **Always use deploy hook URLs, not direct build triggers** — deploy hooks handle deduplication and rate limiting on the hosting side
+2. **Keep webhook filters tight** — don't trigger on every document type, only content that affects the public site
+3. **Don't enable draft triggers** — this would fire on every keystroke in the editor, overwhelming the build system
+4. **Add a webhook secret** — for audit trail and verification
+5. **Monitor webhook attempts log** — sanity.io/manage shows delivery status for debugging
+6. **Expect at-least-once delivery** — webhooks may retry, but Cloudflare deploy hooks handle idempotency
+
+### Cloudflare Free Tier Impact
+
+- Production rebuilds triggered by webhook: ~5-20 per day (typical editorial workflow)
+- Cloudflare Pages free tier: 500 builds/month — well within limits
+- Each build takes ~30-60 seconds — site is updated within 3-5 minutes of publish
+
+### References
+
+- [Source: sanity.io/docs/content-lake/webhooks] — GROQ-powered webhook configuration
+- [Source: sanity.io/docs/visual-editing/fetching-content-for-visual-editing] — Static site + SSR preview pattern
+- [Source: sanity.io/docs/visual-editing/introduction-to-visual-editing] — Visual Editing architecture
+- [Source: _bmad-output/implementation-artifacts/5-2-ga4-security-headers-cloudflare-deploy.md] — Current deployment architecture
+- [Source: astro-app/src/lib/sanity.ts] — loadQuery wrapper with cache and perspective
+- [Source: .github/workflows/deploy.yml] — CI/CD pipeline for both branches
+
+## Dev Agent Record
+
+### Agent Model Used
+
+Claude Opus 4.6
+
+### Debug Log References
+
+- RED phase: 4 tests failing (INT-001, INT-002, INT-004, INT-005), 12 passing
+- GREEN phase: All 16 tests passing after 2 edits to `sanity.ts`
+- Regression: 12 pre-existing failures in stories 5-2, 1-2, 1-3, 2-0 — zero regressions from 5.4 changes
+- Build: `npm run build --workspace=astro-app` succeeds with no deprecation warnings
+
+### Completion Notes List
+
+- **AC5 (SSR cache fix):** Added `!visualEditingEnabled &&` guard to `getSiteSettings()` cache check at line 69. SSR preview now always fetches fresh site settings; static builds retain memoization.
+- **AC7 (perspective deprecation):** Changed `"previewDrafts"` to `"drafts"` at line 29. Eliminates Sanity API deprecation warning.
+- **AC6 (CSP verification):** Confirmed via tests — `wss://*.sanity.io` in connect-src (INT-007), `frame-ancestors` in `_headers` (INT-012), VisualEditing component present (INT-009, INT-010).
+- **AC9 (build succeeds):** Local static build completes successfully.
+- **AC1-AC4 (webhook/deploy hook):** Infrastructure tasks — require manual configuration in Cloudflare dashboard and sanity.io/manage. See Tasks 1-2.
+- **AC8 (E2E verification):** Requires deployed code + webhook infrastructure. See Task 6.
+- **Remaining manual subtasks:** 3.4 (SSR preview verification), 5.3 (Presentation tool test), Task 6 (full E2E loop)
+
+### File List
+
+- `astro-app/src/lib/sanity.ts` — perspective rename + cache bypass guard (2 line edits)

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -82,6 +82,12 @@
 #   - Story 7.3: Schema best practices — High+Medium
 #   - Story 7.4: TypeGen & type replacement — High (blocked by 7.2)
 #   - Story 7.5: Config & dead code cleanup — Low
+#
+# 2026-02-09: Story 5.4 added (Preview & Publish Architecture)
+#   - New comprehensive story: webhook auto-rebuild, SSR cache fix, perspective deprecation
+#   - Completes the content publishing loop (edit → preview → publish → auto-rebuild)
+#   - Scope: Sanity webhook config, Cloudflare deploy hook, sanity.ts fixes
+#   - Epic 5 remains in-progress
 #   - Priority: before continuing Epic 2 stories 2.4–2.9
 
 generated: 2026-02-09
@@ -132,6 +138,7 @@ development_status:
   5-1-seo-metadata-and-sitemap: backlog
   5-2-ga4-security-headers-cloudflare-deploy: review
   5-3-matomo-self-hosted-vps: backlog
+  5-4-preview-publish-architecture: review
   epic-5-retrospective: optional
 
   epic-6: backlog

--- a/_bmad-output/test-artifacts/atdd-checklist-5-4.md
+++ b/_bmad-output/test-artifacts/atdd-checklist-5-4.md
@@ -1,0 +1,315 @@
+# ATDD Checklist - Story 5.4: Preview & Publish Architecture
+
+**Date:** 2026-02-09
+**Author:** Jay
+**Primary Test Level:** Integration (file-read validation)
+
+---
+
+## Story Summary
+
+Complete the content publishing loop by configuring webhook auto-rebuild, fixing SSR cache invalidation, and correcting the deprecated perspective name — enabling editors to preview drafts, publish content, and have the production site automatically rebuild.
+
+**As a** content editor
+**I want** a complete end-to-end workflow where I can preview draft changes live in the Presentation tool, publish content, and have the production site automatically rebuild with my changes
+**So that** I can manage content confidently without developer assistance and know exactly when changes go live
+
+---
+
+## Acceptance Criteria
+
+1. **AC1** — Sanity GROQ-powered webhook triggers Cloudflare Pages rebuild on publish (infrastructure)
+2. **AC2** — Cloudflare Pages deploy hook URL exists for production rebuilds (infrastructure)
+3. **AC3** — Webhook filter scoped to content types: `_type in ["page", "siteSettings", "sponsor", "project", "team", "event"]` (infrastructure)
+4. **AC4** — Webhook includes a secret for origin verification (infrastructure)
+5. **AC5** — `_siteSettingsCache` bypasses cache in SSR mode (code change)
+6. **AC6** — CSP includes `wss://*.sanity.io` in `connect-src` for Visual Editing WebSocket (verification)
+7. **AC7** — `loadQuery` uses `"drafts"` perspective instead of deprecated `"previewDrafts"` (code change)
+8. **AC8** — End-to-end loop works: edit → preview → publish → webhook → rebuild (manual verification)
+9. **AC9** — `npm run build` succeeds for both static and SSR configurations (build verification)
+
+---
+
+## Failing Tests Created (RED Phase)
+
+### Integration Tests (16 tests)
+
+**File:** `tests/integration/preview-publish-5-4/preview-publish.spec.ts` (118 lines)
+
+- **Test:** `[P0] 5.4-INT-001 — loadQuery uses "drafts" perspective, not deprecated "previewDrafts"`
+  - **Status:** RED — `sanity.ts` line 29 still contains `"previewDrafts"`
+  - **Verifies:** AC7 — perspective deprecation fix
+
+- **Test:** `[P0] 5.4-INT-002 — perspective is conditional on visualEditingEnabled`
+  - **Status:** RED — regex expects `"drafts"` but code has `"previewDrafts"`
+  - **Verifies:** AC7 — conditional perspective
+
+- **Test:** `[P0] 5.4-INT-003 — perspective includes "published" for production`
+  - **Status:** GREEN (verification) — already uses `"published"`
+  - **Verifies:** AC7 — production perspective
+
+- **Test:** `[P0] 5.4-INT-004 — getSiteSettings bypasses cache when visualEditingEnabled is true`
+  - **Status:** RED — cache check has no `!visualEditingEnabled` guard
+  - **Verifies:** AC5 — SSR cache invalidation
+
+- **Test:** `[P0] 5.4-INT-005 — getSiteSettings does NOT unconditionally return cache`
+  - **Status:** RED — current code has unconditional `if (_siteSettingsCache) return _siteSettingsCache`
+  - **Verifies:** AC5 — SSR cache bug detection
+
+- **Test:** `[P0] 5.4-INT-006 — module-level _siteSettingsCache variable exists`
+  - **Status:** GREEN (verification) — variable already exists
+  - **Verifies:** AC5 — cache infrastructure present
+
+- **Test:** `[P0] 5.4-INT-007 — CSP connect-src includes wss://*.sanity.io for WebSocket`
+  - **Status:** GREEN (verification) — already in CSP
+  - **Verifies:** AC6 — WebSocket CSP
+
+- **Test:** `[P0] 5.4-INT-008 — CSP connect-src includes https://*.sanity.io`
+  - **Status:** GREEN (verification) — already in CSP
+  - **Verifies:** AC6 — HTTPS CSP
+
+- **Test:** `[P0] 5.4-INT-009 — Layout renders VisualEditing component`
+  - **Status:** GREEN (verification) — component present
+  - **Verifies:** AC6 — Visual Editing component
+
+- **Test:** `[P0] 5.4-INT-010 — Layout imports VisualEditing from @sanity/astro`
+  - **Status:** GREEN (verification) — import present
+  - **Verifies:** AC6 — correct import
+
+- **Test:** `[P0] 5.4-INT-011 — _headers file exists`
+  - **Status:** GREEN (verification) — file exists
+  - **Verifies:** AC6 — headers file
+
+- **Test:** `[P0] 5.4-INT-012 — _headers sets frame-ancestors for Sanity Studio embedding`
+  - **Status:** GREEN (verification) — frame-ancestors present
+  - **Verifies:** AC6 — iframe embedding
+
+- **Test:** `[P1] 5.4-INT-013 — loadQuery uses token only when visualEditingEnabled`
+  - **Status:** GREEN (verification) — conditional token present
+  - **Verifies:** Security — token not leaked to production
+
+- **Test:** `[P1] 5.4-INT-014 — loadQuery enables stega only when visualEditingEnabled`
+  - **Status:** GREEN (verification) — conditional stega present
+  - **Verifies:** Security — stega only in preview
+
+- **Test:** `[P1] 5.4-INT-015 — visualEditingEnabled reads from PUBLIC_SANITY_VISUAL_EDITING_ENABLED`
+  - **Status:** GREEN (verification) — env var present
+  - **Verifies:** Configuration — env var wiring
+
+- **Test:** `[P1] 5.4-INT-016 — loadQuery throws if token missing during visual editing`
+  - **Status:** GREEN (verification) — error thrown
+  - **Verifies:** Safety — fail loudly on misconfiguration
+
+### E2E Tests (0 tests)
+
+No E2E tests generated — AC8 (end-to-end loop verification) requires live infrastructure (Sanity Studio + deployed preview site + webhook). This is a manual verification task.
+
+### API Tests (0 tests)
+
+No API tests — this story has no API endpoints.
+
+---
+
+## Data Factories Created
+
+None required — integration tests read source files directly, no test data generation needed.
+
+---
+
+## Fixtures Created
+
+None additional — tests use base `@playwright/test` imports (same pattern as `deploy-5-2`). Existing merged fixtures (`networkErrorMonitor`, `log`) are for E2E tests only.
+
+---
+
+## Mock Requirements
+
+None — integration tests perform static file analysis, no external services involved.
+
+---
+
+## Required data-testid Attributes
+
+None — no UI elements are being tested at the E2E level.
+
+---
+
+## Implementation Checklist
+
+### Test: 5.4-INT-001 + 5.4-INT-002 — Perspective deprecation fix
+
+**File:** `astro-app/src/lib/sanity.ts`
+
+**Tasks to make these tests pass:**
+
+- [ ] Change `"previewDrafts"` to `"drafts"` on the perspective assignment line (~line 29)
+- [ ] Verify the full line reads: `const perspective = visualEditingEnabled ? "drafts" : "published";`
+- [ ] Run test: `npx playwright test --config=playwright.integration.config.ts tests/integration/preview-publish-5-4/ --grep "INT-001|INT-002"`
+- [ ] Verify no deprecation warnings in build output
+- [ ] Tests pass (green phase)
+
+---
+
+### Test: 5.4-INT-004 + 5.4-INT-005 — SSR cache invalidation
+
+**File:** `astro-app/src/lib/sanity.ts`
+
+**Tasks to make these tests pass:**
+
+- [ ] Change `if (_siteSettingsCache) return _siteSettingsCache;` to `if (!visualEditingEnabled && _siteSettingsCache) return _siteSettingsCache;` (~line 69)
+- [ ] This ensures SSR preview always fetches fresh data while static builds retain memoization
+- [ ] Run test: `npx playwright test --config=playwright.integration.config.ts tests/integration/preview-publish-5-4/ --grep "INT-004|INT-005"`
+- [ ] Tests pass (green phase)
+
+---
+
+### Infrastructure Tasks (not code-testable)
+
+- [ ] **AC1-AC4:** Configure Cloudflare Pages deploy hook and Sanity webhook (see story Tasks 1-2)
+- [ ] **AC8:** Manual end-to-end verification: edit → preview → publish → webhook → rebuild → production updated
+- [ ] **AC9:** Run `npm run build --workspace=astro-app` for both static and SSR configs
+
+---
+
+## Running Tests
+
+```bash
+# Run all failing tests for this story
+npx playwright test --config=playwright.integration.config.ts tests/integration/preview-publish-5-4/
+
+# Run specific RED tests only (AC5 + AC7 — the ones that need code changes)
+npx playwright test --config=playwright.integration.config.ts tests/integration/preview-publish-5-4/ --grep "INT-001|INT-002|INT-004|INT-005"
+
+# Run all verification tests (should already pass)
+npx playwright test --config=playwright.integration.config.ts tests/integration/preview-publish-5-4/ --grep "INT-003|INT-006|INT-007|INT-008|INT-009|INT-010|INT-011|INT-012|INT-013|INT-014|INT-015|INT-016"
+
+# Run in verbose mode
+npx playwright test --config=playwright.integration.config.ts tests/integration/preview-publish-5-4/ --reporter=list
+```
+
+---
+
+## Red-Green-Refactor Workflow
+
+### RED Phase (Current)
+
+**TEA Agent Responsibilities:**
+
+- All 16 tests written
+- 4 tests failing (RED) — AC5 cache bypass + AC7 perspective rename
+- 12 tests passing (GREEN) — verification of existing CSP, Visual Editing, and security guards
+- Implementation checklist created mapping failing tests to code tasks
+
+**Verification:**
+
+- 4 tests fail due to missing code changes (not test bugs)
+- Failure messages clearly indicate what's wrong:
+  - INT-001: `Expected string not to contain "previewDrafts"` → code still has deprecated perspective
+  - INT-002: `Expected string to match pattern` → perspective doesn't match `"drafts"`
+  - INT-004: `Expected string to match pattern` → cache check lacks `!visualEditingEnabled` guard
+  - INT-005: `Expected string not to match pattern` → unconditional cache return still present
+
+---
+
+### GREEN Phase (DEV Team - Next Steps)
+
+**DEV Agent Responsibilities:**
+
+1. Open `astro-app/src/lib/sanity.ts`
+2. **Fix 1 (AC7):** Change `"previewDrafts"` → `"drafts"` on line 29
+3. Run INT-001 + INT-002 → verify PASS
+4. **Fix 2 (AC5):** Add `!visualEditingEnabled &&` guard to cache check on line 69
+5. Run INT-004 + INT-005 → verify PASS
+6. Run full suite → all 16 tests pass
+7. Configure webhook + deploy hook (infrastructure tasks)
+8. Manual E2E verification (AC8)
+
+**Key Principles:**
+
+- Two surgical code changes — total diff is ~10 characters
+- Both changes are in the same file (`sanity.ts`)
+- No new dependencies, no new files, no schema changes
+
+---
+
+### REFACTOR Phase (DEV Team - After All Tests Pass)
+
+No refactoring needed — the changes are minimal (2 line edits in 1 file). Code quality is already good.
+
+---
+
+## Next Steps
+
+1. **Run failing tests** to confirm RED phase: `npx playwright test --config=playwright.integration.config.ts tests/integration/preview-publish-5-4/ --grep "INT-001|INT-002|INT-004|INT-005"`
+2. **Implement the 2 code fixes** in `astro-app/src/lib/sanity.ts`
+3. **Run full suite** to verify all 16 tests pass
+4. **Configure infrastructure** (Cloudflare deploy hook + Sanity webhook)
+5. **Manual E2E verification** (edit → preview → publish → rebuild)
+6. **When complete**, update story status to 'done' in sprint-status.yaml
+
+---
+
+## Knowledge Base References Applied
+
+This ATDD workflow consulted the following knowledge fragments:
+
+- **test-quality.md** — Deterministic assertions, no hard waits, unique data, parallel-safe
+- **test-healing-patterns.md** — Failure pattern catalog for future debugging
+- **selector-resilience.md** — Selector hierarchy (not applicable — no E2E tests)
+- **timing-debugging.md** — Network-first patterns (not applicable — file-read tests)
+- **test-levels-framework.md** — Integration level selection for file/config validation
+- **fixtures-composition.md** — mergeTests pattern (existing fixtures preserved)
+- **playwright-cli.md** — CLI automation (not needed — no browser verification required)
+
+See `tea-index.csv` for complete knowledge fragment mapping.
+
+---
+
+## Test Execution Evidence
+
+### Initial Test Run (RED Phase Verification)
+
+**Command:** `npx playwright test --config=playwright.integration.config.ts tests/integration/preview-publish-5-4/`
+
+**Expected Results:**
+
+```
+  ✓ [P0] 5.4-INT-003 — perspective includes "published" for production
+  ✗ [P0] 5.4-INT-001 — loadQuery uses "drafts" perspective, not deprecated "previewDrafts"
+  ✗ [P0] 5.4-INT-002 — perspective is conditional on visualEditingEnabled
+  ✗ [P0] 5.4-INT-004 — getSiteSettings bypasses cache when visualEditingEnabled is true
+  ✗ [P0] 5.4-INT-005 — getSiteSettings does NOT unconditionally return cache
+  ✓ [P0] 5.4-INT-006 — module-level _siteSettingsCache variable exists
+  ✓ [P0] 5.4-INT-007 — CSP connect-src includes wss://*.sanity.io for WebSocket
+  ✓ [P0] 5.4-INT-008 — CSP connect-src includes https://*.sanity.io
+  ✓ [P0] 5.4-INT-009 — Layout renders VisualEditing component
+  ✓ [P0] 5.4-INT-010 — Layout imports VisualEditing from @sanity/astro
+  ✓ [P0] 5.4-INT-011 — _headers file exists
+  ✓ [P0] 5.4-INT-012 — _headers sets frame-ancestors for Sanity Studio embedding
+  ✓ [P1] 5.4-INT-013 — loadQuery uses token only when visualEditingEnabled
+  ✓ [P1] 5.4-INT-014 — loadQuery enables stega only when visualEditingEnabled
+  ✓ [P1] 5.4-INT-015 — visualEditingEnabled reads from PUBLIC_SANITY_VISUAL_EDITING_ENABLED
+  ✓ [P1] 5.4-INT-016 — loadQuery throws if token missing during visual editing
+```
+
+**Summary:**
+
+- Total tests: 16
+- Passing: 12 (verification — already implemented)
+- Failing: 4 (RED — code changes needed for AC5 + AC7)
+- Status: RED phase verified
+
+---
+
+## Notes
+
+- This story is primarily infrastructure configuration (webhook + deploy hook) with 2 surgical code fixes
+- The 4 RED tests target exactly the 2 lines that need changing in `sanity.ts`
+- AC1-AC4 (webhook/deploy hook) are configured in Sanity/Cloudflare dashboards — not testable in code
+- AC8 (end-to-end loop) requires live infrastructure — manual verification only
+- AC9 (build succeeds) is covered by existing CI pipeline and Playwright webServer config
+- The 12 GREEN verification tests serve as regression guards for existing Visual Editing setup
+
+---
+
+**Generated by BMad TEA Agent** - 2026-02-09

--- a/astro-app/src/lib/sanity.ts
+++ b/astro-app/src/lib/sanity.ts
@@ -26,7 +26,7 @@ export async function loadQuery<T>({
     );
   }
 
-  const perspective = visualEditingEnabled ? "previewDrafts" : "published";
+  const perspective = visualEditingEnabled ? "drafts" : "published";
 
   const { result } = await sanityClient.fetch<T>(query, params ?? {}, {
     filterResponse: false,
@@ -66,7 +66,7 @@ export const siteSettingsQuery = groq`*[_type == "siteSettings"][0]{
 let _siteSettingsCache: SiteSettings | null = null;
 
 export async function getSiteSettings(): Promise<SiteSettings> {
-  if (_siteSettingsCache) return _siteSettingsCache;
+  if (!visualEditingEnabled && _siteSettingsCache) return _siteSettingsCache;
 
   const result = await loadQuery<SiteSettings | null>({
     query: siteSettingsQuery,

--- a/docs/team/how-preview-and-publish-works.md
+++ b/docs/team/how-preview-and-publish-works.md
@@ -1,0 +1,426 @@
+---
+title: "How Preview & Publish Works"
+description: "A beginner-friendly guide to the dual-deployment architecture, Visual Editing, and the content publishing loop."
+lastUpdated: 2026-02-09
+---
+
+# How Preview & Publish Works
+
+This guide explains how content gets from Sanity Studio to the live website. It covers the two deployment branches, how Visual Editing works, what problems were solved along the way, and what Story 5.4 adds to complete the publishing loop.
+
+## Table of Contents
+
+- [The Big Picture](#the-big-picture)
+- [Two Branches, Two Deployments](#two-branches-two-deployments)
+- [How a Page Gets Built](#how-a-page-gets-built)
+- [How Visual Editing Works](#how-visual-editing-works)
+- [The CI/CD Pipeline](#the-cicd-pipeline)
+- [Security Headers and CSP](#security-headers-and-csp)
+- [SSR Bugs That Were Fixed (PR #3)](#ssr-bugs-that-were-fixed-pr-3)
+- [The Missing Piece: Story 5.4](#the-missing-piece-story-54)
+- [Two Bugs Story 5.4 Fixes in Code](#two-bugs-story-54-fixes-in-code)
+- [Glossary](#glossary)
+
+## The Big Picture
+
+The site has **two separate deployments** from the same codebase, each serving a different purpose:
+
+```mermaid
+flowchart LR
+    subgraph GitHub["GitHub Repository"]
+        Main["main branch"]
+        Preview["preview branch"]
+    end
+
+    subgraph CF["Cloudflare Pages"]
+        Prod["ywcc-capstone.pages.dev\n(Production)"]
+        Prev["preview.ywcc-capstone.pages.dev\n(Preview)"]
+    end
+
+    subgraph Sanity["Sanity"]
+        Studio["Sanity Studio\n(Presentation Tool)"]
+        CL["Content Lake\n(all your content)"]
+    end
+
+    Main -->|push| Prod
+    Preview -->|push| Prev
+    Studio -->|iframe| Prev
+    CL -->|published data| Prod
+    CL -->|draft data| Prev
+```
+
+- **Production** (`main` branch) serves the public website. Pages are pre-built as static HTML files. Fast, cacheable, and free of any editing overhead.
+- **Preview** (`preview` branch) serves the editors. A Cloudflare Worker renders pages on-demand so they always show the latest draft content from Sanity.
+
+## Two Branches, Two Deployments
+
+The behavior of the entire site changes based on a single environment variable: `PUBLIC_SANITY_VISUAL_EDITING_ENABLED`.
+
+| Aspect | Production (`main`) | Preview (`preview`) |
+|---|---|---|
+| URL | `ywcc-capstone.pages.dev` | `preview.ywcc-capstone.pages.dev` |
+| Astro output mode | `static` (pre-rendered HTML) | `server` (rendered per request) |
+| Content freshness | Frozen at build time | Live from Sanity on every request |
+| Sanity perspective | `published` | `drafts` (includes unpublished changes) |
+| Visual Editing overlays | Off | On (click-to-edit in Presentation tool) |
+| Stega encoding | Off | On (invisible metadata in strings) |
+| GA4 analytics | Active | Active |
+| Who uses it | The public | Content editors via Sanity Studio |
+
+### How the branch controls output mode
+
+In `astro.config.mjs`, one line controls everything:
+
+```javascript
+output: isVisualEditing ? "server" : "static",
+```
+
+When `PUBLIC_SANITY_VISUAL_EDITING_ENABLED` is `"true"`, Astro builds the site as a **server** application (a Cloudflare Worker that renders HTML on every request). When it is not set, Astro builds the site as **static** HTML files (generated once at build time).
+
+The CI/CD pipeline sets this variable automatically based on which branch is being built. You never set it manually in CI.
+
+## How a Page Gets Built
+
+### Static mode (production)
+
+```mermaid
+sequenceDiagram
+    participant Build as Astro Build (CI)
+    participant Sanity as Sanity Content Lake
+    participant CDN as Cloudflare CDN
+
+    Build->>Sanity: Fetch all published content (GROQ queries)
+    Sanity-->>Build: JSON data (published perspective)
+    Build->>Build: Render every page to .html files
+    Build->>CDN: Upload dist/ folder
+    CDN-->>CDN: Serve static files to visitors
+```
+
+Each page is an `.html` file sitting on Cloudflare's CDN. When a visitor requests `/about/`, Cloudflare serves the pre-built `about/index.html` directly. No server-side code runs.
+
+**Trade-off:** Fast and cheap, but content changes require a new build to appear.
+
+### Server mode (preview)
+
+```mermaid
+sequenceDiagram
+    participant Editor as Editor's Browser
+    participant Worker as Cloudflare Worker
+    participant Sanity as Sanity Content Lake
+
+    Editor->>Worker: GET /about/
+    Worker->>Sanity: Fetch draft content (GROQ + token)
+    Sanity-->>Worker: JSON data (drafts perspective)
+    Worker->>Worker: Render page to HTML
+    Worker-->>Editor: HTML response with stega encoding
+```
+
+When an editor (or Sanity Studio's Presentation tool) requests a page, a Cloudflare Worker runs Astro's rendering code on-the-fly. It fetches **draft** content from Sanity using an API token, so unpublished changes are visible immediately.
+
+**Trade-off:** Always shows the latest content, but every request hits Sanity's API.
+
+## How Visual Editing Works
+
+Visual Editing is the feature that lets editors click on content in the preview site and jump directly to the corresponding field in Sanity Studio. It involves three pieces working together.
+
+### 1. Stega encoding
+
+When the preview site fetches content from Sanity, the Sanity client embeds invisible Unicode characters into every string value. These characters encode:
+
+- The document ID (which document this text belongs to)
+- The field path (which field within that document)
+- The Studio URL (where to open the editor)
+
+You cannot see these characters, but they are there. This is why string comparisons break in preview mode — the string `"center"` actually contains hidden characters like `"c​e​n​t​e​r"`.
+
+### 2. The `stegaClean()` function
+
+Because stega encoding breaks direct string comparisons, every place in the code that compares a Sanity string value uses `stegaClean()` to strip the hidden characters first:
+
+```javascript
+// Without stegaClean — BREAKS in preview mode:
+if (block.alignment === "center") { ... }
+
+// With stegaClean — works in both modes:
+if (stegaClean(block.alignment) === "center") { ... }
+```
+
+`stegaClean()` is a no-op when stega encoding is disabled (production), so it is safe to use everywhere.
+
+### 3. The `<VisualEditing />` component
+
+`Layout.astro` renders a React component called `<VisualEditing>` on every page:
+
+```astro
+<VisualEditing enabled={visualEditingEnabled} />
+```
+
+When `enabled` is `true`, this component:
+
+- Reads the stega-encoded strings in the rendered HTML
+- Draws translucent blue overlay rectangles on each piece of editable content
+- Listens for clicks on those overlays
+- Sends a `postMessage` back to the parent window (Sanity Studio) saying "the user clicked on field X of document Y"
+- Studio then navigates to that field in the editor panel
+
+When `enabled` is `false` (production), the component renders nothing.
+
+### The Presentation tool flow
+
+```mermaid
+sequenceDiagram
+    participant Editor as Content Editor
+    participant Studio as Sanity Studio
+    participant Preview as Preview Site (iframe)
+
+    Editor->>Studio: Open Presentation tool
+    Studio->>Preview: Load preview site in iframe
+    Preview-->>Studio: Page renders with stega + overlays
+    Editor->>Preview: Click on a heading
+    Preview->>Studio: postMessage("open document X, field title")
+    Studio->>Studio: Navigate to document X, highlight title field
+    Editor->>Studio: Edit the title
+    Studio->>Studio: Save draft to Content Lake
+    Editor->>Preview: Refresh iframe
+    Preview-->>Editor: Page re-renders with updated draft content
+```
+
+## The CI/CD Pipeline
+
+A single GitHub Actions workflow file (`.github/workflows/deploy.yml`) handles both branches. The workflow triggers on every push to `main` or `preview`.
+
+```mermaid
+flowchart TD
+    Push["git push"] --> Which{"Which branch?"}
+
+    Which -->|main| BuildStatic["Build static site\n(output: static)"]
+    Which -->|preview| BuildSSR["Build SSR site\n(output: server)"]
+
+    BuildStatic --> DeployProd["wrangler pages deploy dist/\n(production)"]
+    BuildSSR --> DeployPreview["wrangler pages deploy dist/\n--branch=preview"]
+
+    DeployProd --> ProdURL["ywcc-capstone.pages.dev"]
+    DeployPreview --> PreviewURL["preview.ywcc-capstone.pages.dev"]
+```
+
+### Key details
+
+- **Node.js 22** is used for the build.
+- **`npm ci`** installs dependencies from the lockfile (deterministic, fast).
+- A `.env` file is **written dynamically** before the build step. This is critical because Vite reads environment variables from `.env` files, not from `process.env`. Without this step, variables like `SANITY_API_READ_TOKEN` are `undefined` in the built Worker bundle.
+- The `--branch=preview` flag on `wrangler pages deploy` tells Cloudflare to associate this deployment with the preview branch URL. No extra Cloudflare dashboard configuration is needed.
+
+### Secrets and variables
+
+| Name | Type | Purpose |
+|---|---|---|
+| `CLOUDFLARE_API_TOKEN` | Secret | Authenticates `wrangler` with Cloudflare API |
+| `CLOUDFLARE_ACCOUNT_ID` | Secret | Identifies the Cloudflare account |
+| `SANITY_API_READ_TOKEN` | Secret | Allows the SSR Worker to read draft content |
+| `PUBLIC_SANITY_STUDIO_PROJECT_ID` | Variable | Sanity project ID (`49nk9b0w`) |
+| `PUBLIC_SANITY_STUDIO_DATASET` | Variable | Sanity dataset name (`production`) |
+| `PUBLIC_GA_MEASUREMENT_ID` | Variable | Google Analytics 4 measurement ID |
+| `PUBLIC_SITE_URL` | Variable | Production URL for canonical links |
+
+## Security Headers and CSP
+
+The site uses a **two-layer security approach**:
+
+### Layer 1: CSP meta tag (in HTML)
+
+A `<meta http-equiv="Content-Security-Policy">` tag in `Layout.astro` tells the browser which external resources the page is allowed to load:
+
+| Directive | What it allows | Why |
+|---|---|---|
+| `script-src` | `'self'`, `googletagmanager.com`, `google-analytics.com` | GA4 loads scripts from both Google domains |
+| `img-src` | `'self'`, `cdn.sanity.io`, `data:` | Sanity CDN serves CMS images; `data:` allows base64 placeholder images |
+| `style-src` | `'self'`, `'unsafe-inline'` | Tailwind CSS and Astro's scoped styles use inline `<style>` tags |
+| `connect-src` | `'self'`, `google-analytics.com`, `*.sanity.io`, `wss://*.sanity.io` | GA4 beacons, Sanity API calls, and WebSocket connections for live Visual Editing |
+| `frame-src` | `'self'` | No third-party iframes allowed |
+
+### Layer 2: `_headers` file (HTTP response headers)
+
+A `public/_headers` file tells Cloudflare Pages to add response headers that browsers enforce:
+
+| Header | Value | What it does |
+|---|---|---|
+| `X-Content-Type-Options` | `nosniff` | Prevents browsers from guessing file types (stops certain attacks) |
+| `Referrer-Policy` | `strict-origin-when-cross-origin` | Controls how much URL information is shared with other sites |
+| `Permissions-Policy` | `camera=(), microphone=(), geolocation=()` | Disables access to camera, mic, and GPS (the site does not need them) |
+| `Content-Security-Policy: frame-ancestors` | `'self' https://*.sanity.studio https://*.sanity.io` | Allows only Sanity Studio to embed the site in an iframe (needed for Presentation tool) |
+
+The two layers complement each other. The meta tag provides CSP even during local development (where `_headers` does not apply). The `_headers` file provides non-CSP headers that cannot be set via meta tags.
+
+## SSR Bugs That Were Fixed ([PR #3][pr3])
+
+When the SSR preview was first deployed, three distinct issues prevented it from working. Each had a different root cause.
+
+[pr3]: https://github.com/gsinghjay/astro-shadcn-sanity/pull/3
+
+### Bug 1: Icons crash the Worker (`95e38e6`)
+
+**What happened:** Any SSR page that rendered an icon crashed with an error about `fs` (filesystem) not existing.
+
+**Why:** The `astro-icon` package calls `fs.readFileSync()` at render time to read SVG data from icon packages on disk. Cloudflare Workers have no filesystem — they run in a sandboxed V8 isolate, not Node.js.
+
+**Fix:** Replaced `astro-icon` with a custom wrapper using `@iconify/utils`. The new wrapper reads icon data from JSON imports (bundled into the Worker at build time) instead of reading files from disk at runtime.
+
+### Bug 2: API token missing from Worker bundle (`1f8e2f3`)
+
+**What happened:** All SSR pages returned HTTP 500: `"The SANITY_API_READ_TOKEN environment variable is required during Visual Editing."`
+
+**Why:** Vite (Astro's build tool) only reads `import.meta.env.*` values from `.env` files. The CI workflow passed the token as a process environment variable (`env:` block in the YAML), but no `.env` file existed in CI. Vite never saw the token and left it as `undefined` in the built Worker.
+
+**Fix:** Added a workflow step that writes a `.env` file before the build. Vite reads the file, finds the token, and inlines it into the Worker bundle.
+
+### Bug 3: `[object Object]` instead of HTML (`3f6202f`)
+
+**What happened:** SSR pages returned HTTP 200 with the literal text `[object Object]` as the body. Pre-rendered pages worked fine. Local testing with `wrangler dev` also worked fine.
+
+**Why:** The `nodejs_compat` flag in `wrangler.jsonc` causes Cloudflare to polyfill the Node.js `process` global. Astro's runtime detection checks for `process` to decide if it is running in Node.js. When it thinks it is in Node.js, Astro returns the response body as an `AsyncIterable` instead of a `ReadableStream`. Cloudflare Workers cannot consume `AsyncIterable`, so JavaScript's default `.toString()` produces `[object Object]`.
+
+**Fix:** Added `disable_nodejs_process_v2` to `compatibility_flags` in `wrangler.jsonc`. This prevents the `process` polyfill from being injected while keeping `nodejs_compat` available for other Node.js APIs the Sanity client needs.
+
+```jsonc
+// wrangler.jsonc — the two flags work together
+{
+  "compatibility_flags": ["nodejs_compat", "disable_nodejs_process_v2"]
+}
+```
+
+## The Missing Piece: Story 5.4
+
+After Story 5.2 and PR #3, the deployment architecture works end-to-end for **previewing** content. But there is a gap in the **publishing** loop:
+
+```mermaid
+flowchart TD
+    subgraph Current["Preview Loop (working)"]
+        Edit["Editor edits in Studio"] --> DraftSave["Draft saved to Content Lake"]
+        DraftSave --> PreviewShows["Preview site shows draft"]
+    end
+
+    subgraph Broken["Publish Loop (before Story 5.4)"]
+        Publish["Editor publishes content"] --> Nothing["Nothing happens"]
+        Nothing --> Stale["Production shows stale content"]
+        Stale --> AskDev["Editor asks developer to redeploy"]
+    end
+
+    subgraph Target["Publish Loop (after Story 5.4)"]
+        Publish2["Editor publishes content"] --> Webhook["Sanity webhook fires"]
+        Webhook --> Hook["POST to Cloudflare deploy hook"]
+        Hook --> Rebuild["Cloudflare rebuilds production"]
+        Rebuild --> Live["New content is live"]
+    end
+```
+
+### What Story 5.4 adds
+
+**1. Cloudflare deploy hook** — A secret URL in Cloudflare Pages that triggers a production build when called via HTTP POST. Created in the Cloudflare dashboard under Settings > Builds & deployments > Deploy hooks.
+
+**2. Sanity webhook** — A GROQ-powered webhook configured at `sanity.io/manage` that fires when a document is published (created, updated, or deleted). It sends an HTTP POST to the Cloudflare deploy hook URL.
+
+The webhook has a **filter** that only fires for content types that affect the public site:
+
+```groq
+_type in ["page", "siteSettings", "sponsor", "project", "team", "event"]
+```
+
+Draft saves do **not** trigger the webhook. Only the explicit "Publish" action in Studio does. This prevents the build system from being overwhelmed by every keystroke.
+
+**3. Two code fixes** (see next section).
+
+**4. End-to-end verification** — Testing the complete loop: edit in Studio, preview the draft, publish, webhook fires, Cloudflare rebuilds, production site shows new content.
+
+### The complete loop after Story 5.4
+
+```mermaid
+sequenceDiagram
+    participant Editor as Content Editor
+    participant Studio as Sanity Studio
+    participant CL as Content Lake
+    participant Webhook as Sanity Webhook
+    participant CF as Cloudflare Pages
+    participant Prod as Production Site
+
+    Editor->>Studio: Edit content
+    Studio->>CL: Save draft
+    Note over Editor,CL: Editor previews via Presentation tool (already working)
+
+    Editor->>Studio: Click "Publish"
+    Studio->>CL: Publish document
+    CL->>Webhook: Document published event
+    Webhook->>CF: POST deploy hook URL
+    CF->>CF: Rebuild static site from main branch
+    CF->>Prod: Deploy new HTML files
+    Note over Prod: New content is live
+```
+
+## Two Bugs Story 5.4 Fixes in Code
+
+Both bugs are in `astro-app/src/lib/sanity.ts`. Each is a one-line change.
+
+### Bug 1: Stale site settings in preview (line 69)
+
+**The problem:** The `getSiteSettings()` function caches site settings in a module-level variable:
+
+```javascript
+let _siteSettingsCache = null;
+
+export async function getSiteSettings() {
+  if (_siteSettingsCache) return _siteSettingsCache; // returns stale data!
+  // ... fetch from Sanity ...
+}
+```
+
+In **static** mode, this is fine. The cache only lives for the duration of the build process. Every `npm run build` starts fresh.
+
+In **server** mode (preview), this is a **bug**. The Cloudflare Worker loads the module once and keeps it in memory across requests. If an editor changes the site name or navigation in Sanity, the cache serves the old data until the Worker cold-starts again (which happens unpredictably).
+
+**The fix:**
+
+```javascript
+if (!visualEditingEnabled && _siteSettingsCache) return _siteSettingsCache;
+```
+
+When Visual Editing is enabled (preview/SSR), skip the cache and always fetch fresh data. When Visual Editing is off (production/static build), keep the cache for build performance.
+
+### Bug 2: Deprecated API perspective name (line 29)
+
+**The problem:** The `loadQuery` function uses a perspective name that Sanity has deprecated:
+
+```javascript
+const perspective = visualEditingEnabled ? "previewDrafts" : "published";
+```
+
+Sanity's API returns a deprecation warning: *"The previewDrafts perspective has been renamed to drafts."*
+
+**The fix:**
+
+```javascript
+const perspective = visualEditingEnabled ? "drafts" : "published";
+```
+
+A simple rename. The behavior is identical — `"drafts"` is the new name for the same thing.
+
+## Glossary
+
+| Term | Definition |
+|---|---|
+| **Astro** | The web framework used to build this site. Supports both static site generation and server-side rendering. |
+| **Cloudflare Pages** | The hosting platform. Serves static files from a CDN and runs server-side code via Cloudflare Workers. |
+| **Cloudflare Worker** | A serverless function that runs on Cloudflare's edge network. Executes the SSR rendering code for the preview site. |
+| **Content Lake** | Sanity's hosted database where all content (documents, images, settings) is stored. |
+| **CSP (Content Security Policy)** | A browser security feature that restricts which external resources a page can load (scripts, images, etc.). |
+| **Deploy hook** | A secret URL that triggers a build when called via HTTP POST. No authentication beyond knowing the URL. |
+| **Draft** | An unpublished version of a document in Sanity. Only visible through authenticated API calls with the `drafts` perspective. |
+| **GROQ** | Sanity's query language (Graph-Relational Object Queries). Similar to SQL but designed for JSON documents. |
+| **Perspective** | The "lens" through which you query Sanity content. `"published"` returns only published documents. `"drafts"` returns drafts, falling back to published versions. |
+| **Prerender** | Generating a page's HTML at build time instead of at request time. Astro pages export `prerender = true` to opt in. |
+| **Presentation tool** | A panel in Sanity Studio that shows the preview site in an iframe with click-to-edit overlays. |
+| **SSR (Server-Side Rendering)** | Rendering HTML on the server for each request, rather than pre-building it. Allows dynamic, always-fresh content. |
+| **Stega encoding** | Invisible Unicode characters embedded in strings by the Sanity client. They carry metadata (document ID, field path) that the Visual Editing overlay reads. |
+| **`stegaClean()`** | A function that strips stega encoding from a string. Required before comparing Sanity string values in code. |
+| **Visual Editing** | Sanity's feature that lets editors click on content in the preview site and jump to the corresponding field in Studio. |
+| **Vite** | The build tool Astro uses internally. Handles bundling, environment variable inlining, and development server. |
+| **Webhook** | An HTTP callback. Sanity sends a POST request to a URL you configure whenever content changes. |
+| **Wrangler** | Cloudflare's CLI tool for building, testing, and deploying Workers and Pages projects. |

--- a/tests/integration/preview-publish-5-4/preview-publish.spec.ts
+++ b/tests/integration/preview-publish-5-4/preview-publish.spec.ts
@@ -1,0 +1,137 @@
+import { test, expect } from '@playwright/test'
+import { readFileSync, existsSync } from 'fs'
+import path from 'path'
+import { fileURLToPath } from 'url'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+const ASTRO_APP = path.resolve(__dirname, '../../../astro-app')
+
+test.describe('Story 5-4: Preview & Publish Architecture', () => {
+  test.describe('AC7: Perspective deprecation fix', () => {
+    const sanityPath = path.resolve(ASTRO_APP, 'src/lib/sanity.ts')
+    let sanityContent: string
+
+    test.beforeAll(() => {
+      sanityContent = readFileSync(sanityPath, 'utf-8')
+    })
+
+    test('[P0] 5.4-INT-001 — loadQuery uses "drafts" perspective, not deprecated "previewDrafts"', () => {
+      // AC7: The perspective should be "drafts" (renamed from deprecated "previewDrafts")
+      expect(sanityContent).not.toContain('"previewDrafts"')
+    })
+
+    test('[P0] 5.4-INT-002 — perspective is conditional on visualEditingEnabled', () => {
+      // AC7: Should use "drafts" when visual editing is enabled, "published" otherwise
+      expect(sanityContent).toMatch(/visualEditingEnabled\s*\?\s*["']drafts["']/)
+    })
+
+    test('[P0] 5.4-INT-003 — perspective includes "published" for production', () => {
+      // AC7: Production (non-preview) should use "published" perspective
+      expect(sanityContent).toContain('"published"')
+    })
+  })
+
+  test.describe('AC5: SSR cache invalidation', () => {
+    const sanityPath = path.resolve(ASTRO_APP, 'src/lib/sanity.ts')
+    let sanityContent: string
+
+    test.beforeAll(() => {
+      sanityContent = readFileSync(sanityPath, 'utf-8')
+    })
+
+    test('[P0] 5.4-INT-004 — getSiteSettings bypasses cache when visualEditingEnabled is true', () => {
+      // AC5: In SSR mode (visualEditingEnabled), cache must be bypassed so editors see fresh data.
+      // The cache check must guard on !visualEditingEnabled before returning cached value.
+      expect(sanityContent).toMatch(/!visualEditingEnabled\s*&&\s*_siteSettingsCache/)
+    })
+
+    test('[P0] 5.4-INT-005 — getSiteSettings does NOT unconditionally return cache', () => {
+      // AC5: The old pattern "if (_siteSettingsCache) return _siteSettingsCache" without
+      // the visualEditingEnabled guard is a bug in SSR mode. It must not be present.
+      expect(sanityContent).not.toMatch(
+        /if\s*\(\s*_siteSettingsCache\s*\)\s*return\s+_siteSettingsCache/
+      )
+    })
+
+    test('[P0] 5.4-INT-006 — module-level _siteSettingsCache variable exists', () => {
+      // AC5: The cache variable itself should still exist (it's used for static builds)
+      expect(sanityContent).toContain('let _siteSettingsCache')
+    })
+  })
+
+  test.describe('AC6: Preview CSP for Visual Editing', () => {
+    const layoutPath = path.resolve(ASTRO_APP, 'src/layouts/Layout.astro')
+    let layoutContent: string
+
+    test.beforeAll(() => {
+      layoutContent = readFileSync(layoutPath, 'utf-8')
+    })
+
+    test('[P0] 5.4-INT-007 — CSP connect-src includes wss://*.sanity.io for WebSocket', () => {
+      // AC6: Visual Editing uses WebSocket for real-time content updates
+      expect(layoutContent).toContain('wss://*.sanity.io')
+    })
+
+    test('[P0] 5.4-INT-008 — CSP connect-src includes https://*.sanity.io', () => {
+      // AC6: Visual Editing needs HTTPS access to Sanity API
+      expect(layoutContent).toContain('https://*.sanity.io')
+    })
+
+    test('[P0] 5.4-INT-009 — Layout renders VisualEditing component', () => {
+      // AC6: The VisualEditing component must be present for overlays and click-to-edit
+      expect(layoutContent).toContain('<VisualEditing')
+      expect(layoutContent).toContain('enabled={visualEditingEnabled}')
+    })
+
+    test('[P0] 5.4-INT-010 — Layout imports VisualEditing from @sanity/astro', () => {
+      // AC6: Correct import path for the Astro Visual Editing integration
+      expect(layoutContent).toContain('from "@sanity/astro/visual-editing"')
+    })
+  })
+
+  test.describe('AC6: Cloudflare _headers for iframe embedding', () => {
+    const headersPath = path.resolve(ASTRO_APP, 'public/_headers')
+
+    test('[P0] 5.4-INT-011 — _headers file exists', () => {
+      expect(existsSync(headersPath)).toBe(true)
+    })
+
+    test('[P0] 5.4-INT-012 — _headers sets frame-ancestors for Sanity Studio embedding', () => {
+      // AC6: Sanity Presentation tool loads the preview site in an iframe.
+      // frame-ancestors must allow sanity.studio and sanity.io origins.
+      const content = readFileSync(headersPath, 'utf-8')
+      expect(content).toContain("frame-ancestors 'self' https://*.sanity.studio https://*.sanity.io")
+    })
+  })
+
+  test.describe('Sanity client configuration guards', () => {
+    const sanityPath = path.resolve(ASTRO_APP, 'src/lib/sanity.ts')
+    let sanityContent: string
+
+    test.beforeAll(() => {
+      sanityContent = readFileSync(sanityPath, 'utf-8')
+    })
+
+    test('[P1] 5.4-INT-013 — loadQuery uses token only when visualEditingEnabled', () => {
+      // Security: API read token should only be sent during preview, not in production builds
+      expect(sanityContent).toMatch(/visualEditingEnabled\s*\?\s*\{\s*token\s*\}/)
+    })
+
+    test('[P1] 5.4-INT-014 — loadQuery enables stega only when visualEditingEnabled', () => {
+      // Stega encoding (invisible characters for click-to-edit) must only be active in preview
+      expect(sanityContent).toMatch(/stega:\s*visualEditingEnabled/)
+    })
+
+    test('[P1] 5.4-INT-015 — visualEditingEnabled reads from PUBLIC_SANITY_VISUAL_EDITING_ENABLED', () => {
+      // The env var controls the preview/production split
+      expect(sanityContent).toContain('PUBLIC_SANITY_VISUAL_EDITING_ENABLED')
+    })
+
+    test('[P1] 5.4-INT-016 — loadQuery throws if token missing during visual editing', () => {
+      // Safety: Should error loudly rather than silently fail with unauthorized requests
+      expect(sanityContent).toContain('SANITY_API_READ_TOKEN')
+      expect(sanityContent).toMatch(/throw new Error/)
+    })
+  })
+})


### PR DESCRIPTION
## What This PR Does (The Big Picture)

Right now, our project has **two deployments**:

| Deployment | URL | Purpose |
|---|---|---|
| **Production** (static) | `ywcc-capstone.pages.dev` | What visitors see — fast, pre-built HTML |
| **Preview** (SSR) | `preview.ywcc-capstone.pages.dev` | What editors see — live draft content in Sanity Studio's Presentation tool |

This PR fixes **two bugs** in the preview deployment that affect content editors:

### Bug 1: Stale Site Settings in Preview (AC5)

**The problem:** When an editor updates site settings (navigation links, footer text, etc.) in Sanity Studio and refreshes the preview, they still see the **old** settings. This is because `getSiteSettings()` caches the result in a module-level variable (`_siteSettingsCache`). In SSR mode (preview), the module stays loaded across requests, so the cache never refreshes until the Cloudflare Worker cold-starts again (could be minutes or hours).

**The fix:** One line — add a `!visualEditingEnabled` guard to the cache check:

```diff
- if (_siteSettingsCache) return _siteSettingsCache;
+ if (!visualEditingEnabled && _siteSettingsCache) return _siteSettingsCache;
```

Now:
- **Preview (SSR):** Always fetches fresh data — editors see their changes immediately
- **Production (static build):** Still uses the cache — it only lives for the duration of `npm run build` anyway, so there's no staleness risk

### Bug 2: Deprecated API Perspective Name (AC7)

**The problem:** Sanity renamed the `"previewDrafts"` perspective to `"drafts"`. Our code still uses the old name, which triggers a deprecation warning in the API response.

**The fix:** One line — rename the string:

```diff
- const perspective = visualEditingEnabled ? "previewDrafts" : "published";
+ const perspective = visualEditingEnabled ? "drafts" : "published";
```

## What's a "Perspective"?

When you fetch content from Sanity, you choose a **perspective** — think of it as a "lens" for viewing content:

- `"published"` — Only see published content (what visitors see on the production site)
- `"drafts"` — See draft content overlaid on published content (what editors see in the Presentation tool preview)

Our code switches perspective based on the `PUBLIC_SANITY_VISUAL_EDITING_ENABLED` environment variable.

## Files Changed

| File | What Changed | Why |
|---|---|---|
| `astro-app/src/lib/sanity.ts` | 2 line edits (cache guard + perspective rename) | The actual bug fixes |
| `tests/integration/preview-publish-5-4/preview-publish.spec.ts` | 16 integration tests (new) | Validates both fixes + existing CSP/security config |
| `_bmad-output/implementation-artifacts/5-4-preview-publish-architecture.md` | Story file (new) | Implementation tracking |
| `_bmad-output/implementation-artifacts/sprint-status.yaml` | Status update | Sprint tracking |
| `_bmad-output/test-artifacts/atdd-checklist-5-4.md` | ATDD checklist (new) | Test-first development tracking |
| `docs/team/how-preview-and-publish-works.md` | Team documentation (new) | Explains the preview/publish architecture |

## How the Tests Work

The 16 integration tests in `preview-publish.spec.ts` use **static file analysis** — they read the source files and check for specific patterns using string matching and regex. No browser or server needed. This approach is appropriate because the changes are configuration-level (string values and conditional guards), not behavioral.

```bash
# Run all 16 tests
npx playwright test --config=playwright.integration.config.ts tests/integration/preview-publish-5-4/

# Run just the tests for the two bug fixes
npx playwright test --config=playwright.integration.config.ts tests/integration/preview-publish-5-4/ --grep "INT-001|INT-002|INT-004|INT-005"
```

**Test results:** 16/16 passing. Zero regressions in the full 248-test suite (12 pre-existing failures in other stories unchanged).

## What's NOT in This PR (But Is Planned)

This PR only covers the **code fixes**. The full Story 5.4 also includes infrastructure tasks that are done separately in web dashboards:

1. **Cloudflare Pages deploy hook** — A secret URL that triggers a production rebuild when called via POST
2. **Sanity webhook** — Fires when content is published and calls the deploy hook URL
3. **End-to-end verification** — Manual testing of the full loop: edit → preview → publish → webhook → rebuild

These are tracked in the story file under Tasks 1, 2, and 6.

## How to Review

1. Open `astro-app/src/lib/sanity.ts` — the entire meaningful diff is 2 lines
2. Check that the logic makes sense:
   - Line 29: `"drafts"` instead of `"previewDrafts"` (simple rename)
   - Line 69: Cache only used when `!visualEditingEnabled` (SSR bypass)
3. Run the tests: `npx playwright test --config=playwright.integration.config.ts tests/integration/preview-publish-5-4/`

## Test Plan

- [x] 16/16 integration tests pass
- [x] Full regression suite (248 tests) — no new failures
- [x] Local static build (`npm run build --workspace=astro-app`) succeeds
- [ ] Manual: Verify preview site shows fresh site settings after edit (requires deployment)
- [ ] Manual: Verify no `"previewDrafts"` deprecation warnings in server logs (requires deployment)
- [ ] Manual: Configure webhook + deploy hook and test full publishing loop (infrastructure tasks)