### PR TITLE
docs: onboarding docs refresh, git workflow guide, and team README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,18 @@
 # YWCC Capstone Sponsors
 
+![Astro](https://img.shields.io/badge/Astro-5.x-FF5D01?logo=astro&logoColor=white)
+![Sanity](https://img.shields.io/badge/Sanity-5-F03E2F?logo=sanity&logoColor=white)
+![Tailwind CSS](https://img.shields.io/badge/Tailwind_CSS-4-06B6D4?logo=tailwindcss&logoColor=white)
+![TypeScript](https://img.shields.io/badge/TypeScript-5.9-3178C6?logo=typescript&logoColor=white)
+![Vite](https://img.shields.io/badge/Vite-7-646CFF?logo=vite&logoColor=white)
+![Cloudflare Pages](https://img.shields.io/badge/Cloudflare_Pages-F38020?logo=cloudflarepages&logoColor=white)
+![Storybook](https://img.shields.io/badge/Storybook-10-FF4785?logo=storybook&logoColor=white)
+![Vitest](https://img.shields.io/badge/Vitest-6CB33E?logo=vitest&logoColor=white)
+![Playwright](https://img.shields.io/badge/Playwright-2EAD33?logo=playwright&logoColor=white)
+![semantic-release](https://img.shields.io/badge/semantic--release-494949?logo=semanticrelease&logoColor=white)
+![Node.js](https://img.shields.io/badge/Node.js-24+-5FA04E?logo=nodedotjs&logoColor=white)
+![npm workspaces](https://img.shields.io/badge/npm_workspaces-monorepo-CB3837?logo=npm&logoColor=white)
+
 A CMS-driven static website for NJIT's Ying Wu College of Computing Industry Capstone program. Content editors compose pages by stacking reusable UI blocks in Sanity Studio — zero code required.
 
 ```mermaid
@@ -20,12 +33,15 @@ flowchart LR
 - [Prerequisites](#prerequisites)
 - [Getting Started](#getting-started)
 - [Development](#development)
+- [Git Workflow](#git-workflow)
 - [Block Library](#block-library)
 - [Content Model](#content-model)
 - [Adding a New Block](#adding-a-new-block)
+- [Testing](#testing)
 - [Deployment](#deployment)
 - [Performance Targets](#performance-targets)
 - [Contributing](#contributing)
+- [Team](#team)
 - [Resources](#resources)
 - [License](#license)
 
@@ -48,16 +64,22 @@ The platform connects industry sponsors with capstone teams by showcasing sponso
 | Layer | Technology |
 |---|---|
 | Frontend | [Astro 5.x](https://astro.build/) (SSG, `output: 'static'`) |
-| CMS | [Sanity.io](https://www.sanity.io/) (headless) |
+| CMS | [Sanity 5](https://www.sanity.io/) (headless, Visual Editing) |
 | UI Components | [fulldev/ui](https://ui.full.dev) — vanilla `.astro` components via shadcn CLI |
 | Styling | [Tailwind CSS v4](https://tailwindcss.com/) (`@tailwindcss/vite`, CSS-first config) |
+| Icons | [@iconify/utils](https://iconify.design/) + Lucide (`@iconify-json/lucide`, `@iconify-json/simple-icons`) |
 | Interactivity | Vanilla JS (< 5KB total) |
-| Hosting (initial) | [GitHub Pages](https://pages.github.com/) |
-| Hosting (future) | [Cloudflare Pages](https://pages.cloudflare.com/) (when forms are added) |
+| Hosting | [Cloudflare Pages](https://pages.cloudflare.com/) (production: static, preview: SSR) |
+| Storybook | [GitHub Pages](https://pages.github.com/) (component library only) |
 | Form Proxy | [Cloudflare Worker](https://workers.cloudflare.com/) (deferred) |
 | Analytics | GA4 + Monsido |
+| Unit Tests | [Vitest](https://vitest.dev/) (jsdom) |
+| E2E Tests | [Playwright](https://playwright.dev/) (5 browser projects + axe-core a11y) |
+| CI/CD | [GitHub Actions](https://github.com/features/actions) (CI, release, Storybook deploy) |
+| Releases | [semantic-release](https://semantic-release.gitbook.io/) (automated versioning + changelog) |
+| Component Dev | [Storybook 10](https://storybook.js.org/) (via `storybook-astro` renderer) |
 
-The build bakes all content into static HTML — zero runtime API calls.
+Production builds bake all content into static HTML — zero runtime API calls. The `preview` branch uses SSR for live Visual Editing with draft content.
 
 ## Project Structure
 
@@ -84,8 +106,12 @@ astro-shadcn-sanity/
 │           ├── documents/    # Document schemas (page, sponsor, etc.)
 │           ├── objects/      # Shared objects (SEO, button, portable text)
 │           └── helpers/      # defineBlock helper
+├── .github/workflows/        # CI, release, Storybook deploy, branch enforcement
+├── docs/team/                # Developer guides and onboarding
+├── tests/                    # Playwright tests
 ├── package.json              # Root workspace config
-└── README.md
+├── .releaserc.json           # semantic-release configuration
+└── CHANGELOG.md              # Auto-generated (do not edit manually)
 ```
 
 This is an **npm workspaces** monorepo with two packages: `astro-app` and `studio`.
@@ -95,15 +121,15 @@ This is an **npm workspaces** monorepo with two packages: `astro-app` and `studi
 - [Node.js](https://nodejs.org/) v24 or later
 - npm v10 or later
 - A [Sanity.io](https://www.sanity.io/) account (free tier)
-- A [GitHub](https://github.com/) account (for GitHub Pages deployment)
-- A [Cloudflare](https://www.cloudflare.com/) account (free tier, for future forms deployment)
+- A [GitHub](https://github.com/) account
+- A [Cloudflare](https://www.cloudflare.com/) account (free tier, for deployment)
 
 ## Getting Started
 
 ### 1. Clone the repository
 
 ```bash
-git clone <repository-url>
+git clone git@github.com:gsinghjay/astro-shadcn-sanity.git
 cd astro-shadcn-sanity
 ```
 
@@ -141,31 +167,54 @@ Open <http://localhost:3333> and sign in with the same service (Google, GitHub, 
 
 ## Development
 
-### Run Astro app only
+| Command | What it does |
+|---|---|
+| `npm run dev` | Start Astro + Studio dev servers |
+| `npm run dev:storybook` | Start Astro + Studio + Storybook (all three) |
+| `npm run storybook` | Start Storybook alone (port 6006) |
+| `npm run build --workspace=astro-app` | Build Astro for production |
+| `npm run test:unit` | Run Vitest unit tests |
+| `npm run test:unit:watch` | Unit tests in watch mode |
+| `npm run test` | Run Playwright E2E tests (builds first) |
+| `npm run test:integration` | Run integration tests (fast, no browser) |
+| `npm run test:ui` | Run Playwright in UI mode |
 
-```bash
-npm run dev --workspace=astro-app
+## Git Workflow
+
+We use [Conventional Commits](https://www.conventionalcommits.org/) + [semantic-release](https://semantic-release.gitbook.io/) for automated versioning and changelog generation.
+
+```mermaid
+flowchart TD
+    A[feature/* branch] -->|PR, CI must pass| B[preview branch]
+    B -->|PR, code owner approval| C[main branch]
+    C -->|automatic| D[semantic-release]
+    D --> E[Version bump + CHANGELOG + GitHub Release]
+    E --> F[Sync preview with main]
+    F --> G[Discord notification]
 ```
 
-### Run Sanity Studio only
+### Branch rules
 
-```bash
-npm run dev --workspace=studio
+| Branch | Purpose | Protection |
+|---|---|---|
+| `main` | Production releases | PRs only from `preview`, code owner approval required |
+| `preview` | Staging/integration | PRs only, CI must pass (unit tests + Lighthouse) |
+| `feature/*` | Your working branches | No restrictions |
+
+### Commit format
+
+```
+<type>: <description>
 ```
 
-### Build for production
+| Prefix | Release? | Version bump |
+|---|---|---|
+| `feat:` | Yes | Minor (0.1.0 → 0.2.0) |
+| `fix:` | Yes | Patch (0.1.0 → 0.1.1) |
+| `feat!:` | Yes | Major (0.1.0 → 1.0.0) |
+| `chore:`, `docs:`, `ci:`, `test:`, `refactor:` | No | — |
 
-```bash
-npm run build --workspace=astro-app
-```
-
-This command performs TypeScript checking and generates static HTML.
-
-### Preview production build
-
-```bash
-npm run preview --workspace=astro-app
-```
+See [docs/team/git-workflow-guide.md](docs/team/git-workflow-guide.md) for the full guide with examples and troubleshooting.
 
 ## Block Library
 
@@ -297,19 +346,18 @@ Compose from fulldev/ui primitives in `src/components/ui/`:
 
 ```astro
 ---
-// astro-app/src/components/blocks/YourBlock.astro
-import type { YourBlockBlock } from '../../lib/sanity'
-import { Button } from '../ui/button'
+// astro-app/src/components/blocks/custom/YourBlock.astro
+import type { YourBlockBlock } from '@/lib/types'
+import { Button } from '@/components/ui/button'
 
 interface Props {
   block: YourBlockBlock
 }
 
 const { block } = Astro.props
-const { backgroundVariant = 'white', spacing = 'default', maxWidth = 'default' } = block
 ---
 
-<section class:list={['block-wrapper', `bg-${backgroundVariant}`, `spacing-${spacing}`, `max-w-${maxWidth}`]}>
+<section>
   <h2>{block.heading}</h2>
   <!-- Compose from ui/ primitives + Tailwind utilities -->
 </section>
@@ -317,7 +365,7 @@ const { backgroundVariant = 'white', spacing = 'default', maxWidth = 'default' }
 
 ### 5. Register in BlockRenderer
 
-Add the import and conditional in `BlockRenderer.astro`.
+Add the import and case in `BlockRenderer.astro`.
 
 ### 6. Add GROQ projection
 
@@ -325,31 +373,48 @@ Add the type-specific projection in `src/lib/sanity.ts`.
 
 Build and verify Lighthouse scores hold at 90+.
 
+## Testing
+
+| Layer | Tool | Command | What it tests |
+|---|---|---|---|
+| Unit | Vitest | `npm run test:unit` | Utilities, GROQ queries, mock data, DOM scripts |
+| Integration | Playwright | `npm run test:integration` | Schema validation, module imports |
+| E2E | Playwright | `npm run test` | Full browser tests across 5 device configs |
+| Accessibility | axe-core | Included in E2E | WCAG 2.1 AA compliance |
+| Performance | Lighthouse CI | CI only (preview PRs) | Core Web Vitals, performance budgets |
+
 ## Deployment
 
-### Deploy Sanity Studio
+### Astro site → Cloudflare Pages
+
+Deployed automatically via Cloudflare Pages git integration:
+
+- **Push to `main`** → Production (static, Visual Editing OFF)
+- **Push to any branch** → Preview URL (SSR, Visual Editing ON)
+
+Environment variables are configured in the [Cloudflare Pages dashboard](https://dash.cloudflare.com/). See [docs/team/cloudflare-setup-guide.md](docs/team/cloudflare-setup-guide.md).
+
+### Sanity Studio
 
 ```bash
-cd studio/
-npx sanity deploy
+npx sanity deploy --workspace=studio
 ```
 
-### Deploy Astro app to Cloudflare Pages
+### Storybook → GitHub Pages
 
-1. Connect your GitHub repository to [Cloudflare Pages](https://pages.cloudflare.com/)
-2. Set the build configuration:
-   - **Root directory:** `astro-app`
-   - **Build command:** `npm run build`
-   - **Build output directory:** `dist`
-3. Add environment variables (`PUBLIC_SANITY_PROJECT_ID`, `PUBLIC_SANITY_DATASET`)
+Deployed automatically via `.github/workflows/deploy-storybook.yml` on pushes to `main` that touch component files. Can also be triggered manually from the Actions tab.
 
-### Deploy Cloudflare Worker (form proxy)
+### Releases
 
-Deploy a Cloudflare Worker to proxy contact form submissions to Sanity. The worker keeps the write token server-side.
+Fully automated via [semantic-release](https://semantic-release.gitbook.io/). When `preview` merges into `main`:
 
-### Invite collaborators
+1. Commits are analyzed for version bump (based on conventional commit prefixes)
+2. `CHANGELOG.md` and `package.json` are updated
+3. A git tag and GitHub Release are created
+4. `preview` is auto-synced with `main`
+5. Discord notification confirms the sync
 
-Open [Sanity Manage](https://www.sanity.io/manage), select your project, and click "Invite project members."
+See the [CHANGELOG](CHANGELOG.md) and [GitHub Releases](https://github.com/gsinghjay/astro-shadcn-sanity/releases) for version history.
 
 ## Performance Targets
 
@@ -365,23 +430,48 @@ Optimize for fast First Contentful Paint and Largest Contentful Paint on 4G conn
 
 ## Contributing
 
-1. Fork the repository
-2. Create a feature branch (`git checkout -b feature/your-feature`)
+> **Read the [Git Workflow Guide](docs/team/git-workflow-guide.md) before your first contribution.** It covers branch strategy, commit conventions, and the full release pipeline.
+
+1. Pull the latest `preview` branch: `git checkout preview && git pull`
+2. Create a feature branch: `git checkout -b feat/your-feature`
 3. Follow the [block checklist](#adding-a-new-block) for new blocks
-4. Verify Lighthouse scores hold at 90+ across all categories
-5. Commit your changes (`git commit -m 'Add your feature'`)
-6. Push to the branch (`git push origin feature/your-feature`)
-7. Open a Pull Request
+4. Write [conventional commits](#commit-format): `git commit -m "feat: add your feature"`
+5. Push and open a PR to `preview`: `gh pr create --base preview`
+6. After CI passes and merge, open a PR from `preview` → `main`
+7. Code owner reviews and merges → release happens automatically
 
 ### Code conventions
 
 - **Sanity schemas:** TypeScript with `defineBlock` helper (blocks) or `defineType`/`defineField` (documents)
 - **UI primitives:** fulldev/ui components in `src/components/ui/` — install via `npx shadcn@latest add @fulldev/{name}`
-- **Block components:** `.astro` files in `src/components/blocks/` composing from `ui/` primitives
+- **Block components:** `.astro` files in `src/components/blocks/custom/` composing from `ui/` primitives
 - **Styling:** Tailwind v4 utility classes, CSS-first config in `global.css`, no `tailwind.config.mjs`
 - **Interactivity:** Vanilla JS with data-attribute driven event delegation, each handler under 50 lines
 - **Block architecture:** Flat array only — no nested blocks
-- **No React/JSX** in `astro-app/` — fulldev/ui components are pure `.astro`
+- **No React/JSX for page UI** — React is only for Sanity Visual Editing (Presentation tool)
+
+### Team documentation
+
+| Document | When to read it |
+|---|---|
+| [Git Workflow Guide](docs/team/git-workflow-guide.md) | Before your first commit |
+| [Onboarding Guide](docs/team/onboarding-guide.md) | First day setup |
+| [Cloudflare Setup Guide](docs/team/cloudflare-setup-guide.md) | Deployment and environment variables |
+| [How Preview & Publish Works](docs/team/how-preview-and-publish-works.md) | Visual Editing and draft content |
+
+## Team
+
+| Name | GitHub | Role |
+|---|---|---|
+| Jay Singh | [@gsinghjay](https://github.com/gsinghjay) | Project Lead |
+| | | |
+| | | |
+| | | |
+| | | |
+| | | |
+| | | |
+
+> **Team members:** Add your name, GitHub link, and role by editing this table on a feature branch and opening a PR to `preview`.
 
 ## Resources
 
@@ -390,7 +480,9 @@ Optimize for fast First Contentful Paint and Largest Contentful Paint on 4G conn
 - [fulldev/ui documentation](https://ui.full.dev/docs)
 - [Tailwind CSS v4 documentation](https://tailwindcss.com/docs)
 - [Cloudflare Pages documentation](https://developers.cloudflare.com/pages/)
-- [Sanity Community Slack](https://slack.sanity.io)
+- [Conventional Commits](https://www.conventionalcommits.org/)
+- [semantic-release documentation](https://semantic-release.gitbook.io/)
+- [Keep a Changelog](https://keepachangelog.com/)
 
 ## License
 

--- a/docs/team/git-workflow-guide.md
+++ b/docs/team/git-workflow-guide.md
@@ -1,0 +1,595 @@
+---
+title: Git Workflow & Release Guide
+description: How to commit, branch, and release code using our automated pipeline — from first commit to production release.
+---
+
+# Git Workflow & Release Guide
+
+This guide explains how code moves from your local machine to production. We use **Conventional Commits**, **branch protection**, and **semantic-release** to automate versioning and changelogs. If you follow this guide, you'll never need to manually bump a version number or write a changelog entry.
+
+## Table of Contents
+
+- [The Big Picture](#the-big-picture)
+- [Branch Strategy](#branch-strategy)
+- [Setting Up Your Local Environment](#setting-up-your-local-environment)
+- [Conventional Commits](#conventional-commits)
+- [Step-by-Step: Making Changes](#step-by-step-making-changes)
+- [Pull Request Workflow](#pull-request-workflow)
+- [What Happens When You Merge to Main](#what-happens-when-you-merge-to-main)
+- [Semantic Versioning](#semantic-versioning)
+- [The Changelog](#the-changelog)
+- [Branch Protection Rules](#branch-protection-rules)
+- [Discord Notifications](#discord-notifications)
+- [Common Scenarios](#common-scenarios)
+- [Troubleshooting](#troubleshooting)
+- [Quick Reference](#quick-reference)
+
+---
+
+## The Big Picture
+
+Every code change follows this path:
+
+```
+Your feature branch → preview (staging) → main (production)
+```
+
+```mermaid
+flowchart TD
+    A[Create feature branch] -->|write code, commit| B[Push branch]
+    B -->|open PR to preview| C[CI runs: unit tests + Lighthouse]
+    C -->|tests pass, merge| D[preview branch]
+    D -->|open PR to main| E[Branch check: source must be preview]
+    E -->|code owner approves, merge| F[main branch]
+    F -->|automatic| G[semantic-release]
+    G -->|analyzes commits| H{Releasable commits?}
+    H -->|feat: or fix:| I[Version bump + CHANGELOG + GitHub Release]
+    H -->|chore: or docs: only| J[No release created]
+    I --> K[Sync preview with main]
+    J --> K
+    K --> L[Discord notification: safe to pull]
+```
+
+**Key principle:** You never push directly to `main` or `preview`. Everything goes through pull requests.
+
+---
+
+## Branch Strategy
+
+| Branch | Purpose | Who pushes here | Protected? |
+|---|---|---|---|
+| `main` | Production-ready code | Only merged from `preview` via PR | Yes — requires code owner approval |
+| `preview` | Staging/integration branch | Only merged from feature branches via PR | Yes — CI must pass |
+| `feature/*`, `fix/*`, `chore/*` | Your working branches | You! | No |
+
+### Rules
+
+- **Only `preview` can merge into `main`** — enforced by CI. PRs from any other branch are automatically blocked.
+- **`main` cannot merge into `preview`** — enforced by CI. The sync happens automatically after releases.
+- **Feature branches always target `preview`** — never open a PR directly to `main`.
+
+---
+
+## Setting Up Your Local Environment
+
+### First-time setup
+
+```bash
+# Clone the repo
+git clone git@github.com:gsinghjay/astro-shadcn-sanity.git
+cd astro-shadcn-sanity
+
+# Install dependencies
+npm install
+
+# Make sure you're on preview (the default working branch)
+git checkout preview
+git pull origin preview
+```
+
+### Before starting any new work
+
+Always start from the latest `preview`:
+
+```bash
+git checkout preview
+git pull origin preview
+```
+
+---
+
+## Conventional Commits
+
+We use [Conventional Commits](https://www.conventionalcommits.org/) — a standardized format for commit messages. This isn't just a style preference; our entire release system depends on it.
+
+### Format
+
+```
+<type>: <description>
+
+[optional body]
+
+[optional footer]
+```
+
+### Commit Types
+
+| Type | What it means | Triggers release? | Version bump |
+|---|---|---|---|
+| `feat:` | A new feature or capability | Yes | Minor (0.1.0 → 0.2.0) |
+| `fix:` | A bug fix | Yes | Patch (0.1.0 → 0.1.1) |
+| `docs:` | Documentation only | No | — |
+| `chore:` | Maintenance, dependencies | No | — |
+| `ci:` | CI/CD changes | No | — |
+| `test:` | Adding or fixing tests | No | — |
+| `refactor:` | Code change that neither fixes nor adds | No | — |
+| `perf:` | Performance improvement | Yes | Patch |
+| `feat!:` | Breaking change (note the `!`) | Yes | Major (0.1.0 → 1.0.0) |
+
+### Examples
+
+```bash
+# Good — clear, specific, starts with type
+git commit -m "feat: add dark mode toggle to header"
+git commit -m "fix: resolve hero image not loading on mobile Safari"
+git commit -m "docs: add API endpoint documentation"
+git commit -m "chore: update dependencies to latest versions"
+git commit -m "test: add unit tests for contact form validation"
+
+# Bad — no type prefix, vague, or wrong type
+git commit -m "updated stuff"           # No type, vague
+git commit -m "fix: add new button"     # That's a feat, not a fix
+git commit -m "feat: Fix typo in readme" # That's docs or chore, not feat
+```
+
+### Multi-line commits (for significant changes)
+
+```bash
+git commit -m "$(cat <<'EOF'
+feat: add sponsor card filtering by tier
+
+Sponsors can now be filtered by Gold, Silver, and Bronze tiers
+on the sponsors page. Filter state persists in URL params.
+
+Closes #42
+EOF
+)"
+```
+
+### Breaking changes
+
+Use `!` after the type or add `BREAKING CHANGE:` in the footer:
+
+```bash
+# Option 1: exclamation mark
+git commit -m "feat!: redesign sponsor API response format"
+
+# Option 2: footer
+git commit -m "$(cat <<'EOF'
+feat: redesign sponsor API response format
+
+BREAKING CHANGE: The sponsors endpoint now returns a flat array
+instead of a nested object. All API consumers must update.
+EOF
+)"
+```
+
+**Warning:** Breaking changes bump the **major** version (e.g., 1.2.3 → 2.0.0). Only use them when you're genuinely breaking backwards compatibility.
+
+---
+
+## Step-by-Step: Making Changes
+
+### 1. Create a branch
+
+Branch names should be descriptive and use a prefix:
+
+```bash
+git checkout preview
+git pull origin preview
+git checkout -b feat/add-sponsor-filtering
+```
+
+Common prefixes:
+
+| Prefix | When to use |
+|---|---|
+| `feat/` | New features |
+| `fix/` | Bug fixes |
+| `chore/` | Maintenance, cleanup |
+| `docs/` | Documentation changes |
+| `refactor/` | Code restructuring |
+| `test/` | Test additions/fixes |
+
+### 2. Make your changes
+
+Write code, save files. Business as usual.
+
+### 3. Stage and commit
+
+```bash
+# Stage specific files (preferred)
+git add src/components/SponsorFilter.astro src/lib/types.ts
+
+# Or stage all changes (be careful — check what you're staging first)
+git status        # Review what changed
+git add -A        # Stage everything
+```
+
+Then commit with a conventional message:
+
+```bash
+git commit -m "feat: add sponsor card filtering by tier"
+```
+
+### 4. Push your branch
+
+```bash
+git push -u origin feat/add-sponsor-filtering
+```
+
+The `-u` flag sets the upstream tracking branch. You only need it on the first push. After that, just `git push`.
+
+### 5. Open a pull request
+
+```bash
+# Using GitHub CLI (recommended)
+gh pr create --base preview --title "feat: add sponsor filtering" --body "Description here"
+
+# Or go to GitHub and click "Compare & pull request"
+```
+
+**Important:** The PR must target `preview`, not `main`.
+
+---
+
+## Pull Request Workflow
+
+### PR to preview (feature branch → preview)
+
+When you open a PR targeting `preview`, CI automatically runs:
+
+- **Unit tests** — Must pass
+- **Lighthouse CI** — Performance audit (currently `continue-on-error`)
+
+Wait for checks to pass, then merge. You can merge your own PRs to `preview`.
+
+### PR to main (preview → main)
+
+After your changes are on `preview` and you're ready for production:
+
+1. Open a PR from `preview` → `main`
+2. The **enforce-preview-branch** check runs (verifies source is `preview`)
+3. **Code owner review required** — only @gsinghjay can approve
+4. Once approved and merged, the release pipeline kicks off automatically
+
+**You cannot:**
+- Open a PR from a feature branch directly to `main` (blocked by CI)
+- Open a PR from `main` to `preview` (blocked by CI)
+- Merge to `main` without code owner approval
+
+---
+
+## What Happens When You Merge to Main
+
+This is fully automated — you don't need to do anything after merging.
+
+```mermaid
+sequenceDiagram
+    participant Dev as Developer
+    participant GH as GitHub
+    participant SR as semantic-release
+    participant Sync as sync-preview
+    participant DC as Discord
+
+    Dev->>GH: Merge PR (preview → main)
+    GH->>SR: Push event triggers Release workflow
+    SR->>SR: Analyze all commits since last tag
+    SR->>SR: Determine version bump (major/minor/patch)
+
+    alt Has releasable commits (feat:/fix:)
+        SR->>GH: Update CHANGELOG.md
+        SR->>GH: Bump version in package.json
+        SR->>GH: Create git tag (v1.2.0)
+        SR->>GH: Create GitHub Release with notes
+    else No releasable commits (chore:/docs:)
+        SR->>SR: Skip — no release needed
+    end
+
+    SR-->>GH: Release workflow completes
+    GH->>Sync: workflow_run trigger
+    Sync->>GH: Merge main into preview
+    Sync->>DC: "Preview branch synced ✓"
+```
+
+### What gets created automatically
+
+1. **`CHANGELOG.md`** — Updated with grouped entries (Features, Bug Fixes, etc.)
+2. **`package.json`** — Version field bumped
+3. **Git tag** — e.g., `v1.2.0`
+4. **GitHub Release** — With release notes on the [Releases page](https://github.com/gsinghjay/astro-shadcn-sanity/releases)
+5. **Preview sync** — `main` merged back into `preview` so branches stay aligned
+6. **Discord notification** — Tells the team it's safe to pull
+
+---
+
+## Semantic Versioning
+
+We follow [Semantic Versioning](https://semver.org/) (semver): `MAJOR.MINOR.PATCH`
+
+| Component | When it increments | Example |
+|---|---|---|
+| **MAJOR** | Breaking changes (`feat!:` or `BREAKING CHANGE`) | 1.2.3 → **2**.0.0 |
+| **MINOR** | New features (`feat:`) | 1.2.3 → 1.**3**.0 |
+| **PATCH** | Bug fixes (`fix:`, `perf:`) | 1.2.3 → 1.2.**4** |
+
+### How it's determined
+
+semantic-release reads **every commit** since the last release tag and picks the **highest** bump:
+
+- If any commit is a breaking change → major
+- Else if any commit is a `feat:` → minor
+- Else if any commit is a `fix:` or `perf:` → patch
+- If only `chore:`, `docs:`, `ci:`, `test:`, `refactor:` → no release
+
+**This is why conventional commits matter.** A `feat:` that should have been a `chore:` will incorrectly trigger a version bump.
+
+---
+
+## The Changelog
+
+The `CHANGELOG.md` file is auto-generated and follows the [Keep a Changelog](https://keepachangelog.com/) format. Entries are grouped by type:
+
+```markdown
+# [1.1.0](https://github.com/.../compare/v1.0.0...v1.1.0) (2026-02-10)
+
+### Features
+
+* add Discord notifications for preview branch sync status ([c207c5c](https://github.com/.../commit/c207c5c))
+* add sponsor card filtering by tier ([a1b2c3d](https://github.com/.../commit/a1b2c3d))
+
+### Bug Fixes
+
+* resolve hero image not loading on mobile Safari ([e4f5g6h](https://github.com/.../commit/e4f5g6h))
+```
+
+**Never edit `CHANGELOG.md` manually.** It's overwritten on every release.
+
+---
+
+## Branch Protection Rules
+
+These are enforced by GitHub and cannot be bypassed (except by the release bot):
+
+### `main` branch
+
+| Rule | Details |
+|---|---|
+| Require PR | No direct pushes |
+| Required reviews | 1 approval from code owner (@gsinghjay) |
+| Source branch | Must be `preview` (enforced by CI check) |
+| Dismiss stale reviews | Re-approval needed after new commits |
+
+### `preview` branch
+
+| Rule | Details |
+|---|---|
+| Require PR | No direct pushes |
+| CI checks | Unit tests + Lighthouse must pass |
+| Source branch | Must NOT be `main` (enforced by CI check) |
+
+### Who can bypass?
+
+- **Release bot (PAT)** — Pushes version commits and tags to `main`, syncs `preview`
+- **Repository admins** — Can bypass in emergencies (shows as "bypassed" in git log)
+
+---
+
+## Discord Notifications
+
+After every release cycle, the team gets a Discord notification:
+
+| Status | Message | What to do |
+|---|---|---|
+| **Success** (green) | "Preview branch synced at `abc1234`" | Safe to `git pull` on preview and create new branches |
+| **Failure** (red) | "Preview sync failed" with link to Actions run | Do NOT branch from preview — alert the team lead |
+
+**Wait for the green notification before starting new work.** If you branch from preview before the sync completes, you'll have merge conflicts later.
+
+---
+
+## Common Scenarios
+
+### "I need to fix something urgent"
+
+Same workflow, just move faster:
+
+```bash
+git checkout preview && git pull origin preview
+git checkout -b fix/critical-homepage-crash
+# make the fix
+git add . && git commit -m "fix: resolve null pointer crash on homepage"
+git push -u origin fix/critical-homepage-crash
+gh pr create --base preview --title "fix: resolve homepage crash"
+# merge to preview, then create PR from preview to main
+```
+
+### "I committed with the wrong message"
+
+If you haven't pushed yet:
+
+```bash
+git commit --amend -m "feat: correct commit message here"
+```
+
+If you already pushed, it's better to just make a new commit. The release system looks at all commits, so one bad message won't break anything — it just might categorize that change incorrectly.
+
+### "I accidentally committed to preview directly"
+
+This shouldn't be possible (branch protection blocks it), but if it somehow happens:
+
+```bash
+# Don't panic — check what happened
+git log --oneline -5
+```
+
+Alert the team lead. Direct pushes show as "Bypassed rule violations" in the git log.
+
+### "I need to work on multiple things at once"
+
+Use separate branches:
+
+```bash
+# Start feature A
+git checkout preview && git pull
+git checkout -b feat/sponsor-filtering
+# work on it, commit, push, open PR
+
+# Switch to feature B (without merging A)
+git checkout preview && git pull
+git checkout -b fix/mobile-nav-bug
+# work on it, commit, push, open PR
+```
+
+### "My PR has merge conflicts"
+
+```bash
+# Update your branch with latest preview
+git checkout feat/my-feature
+git pull origin preview
+# Resolve conflicts in your editor
+git add .
+git commit -m "chore: resolve merge conflicts with preview"
+git push
+```
+
+### "I want to see what version we're on"
+
+```bash
+# Check package.json
+node -p "require('./package.json').version"
+
+# Or check GitHub Releases
+gh release list --limit 5
+
+# Or check git tags
+git tag --sort=-version:refname | head -5
+```
+
+---
+
+## Troubleshooting
+
+### CI is failing on my PR
+
+```bash
+# Check which job failed
+gh pr checks
+
+# View the failed run logs
+gh run view --log-failed
+```
+
+Common causes:
+- **Unit test failure** — Run `npm run test:unit` locally to reproduce
+- **Lighthouse failure** — Currently set to `continue-on-error`, so this shouldn't block merges
+
+### "Permission denied" when pushing
+
+You're probably trying to push to a protected branch:
+
+```bash
+# Wrong — can't push directly to preview or main
+git push origin preview  # ❌
+
+# Right — push to your feature branch
+git push origin feat/my-feature  # ✓
+```
+
+### Release didn't trigger after merging to main
+
+Check the Actions tab:
+
+```bash
+gh run list --workflow release.yml --limit 3
+```
+
+Common causes:
+- All commits were `chore:`/`docs:` — no releasable content (this is correct behavior)
+- PAT expired — check `RELEASE_TOKEN` secret in repo settings
+
+### Preview and main are out of sync
+
+This should auto-resolve via the sync workflow. If it doesn't:
+
+```bash
+# Check if sync workflow ran
+gh run list --workflow sync-preview.yml --limit 3
+```
+
+If the sync failed, check Discord for the red notification and view the linked Actions run.
+
+---
+
+## Quick Reference
+
+### Commit message cheat sheet
+
+```bash
+feat: add new feature              # → minor version bump
+fix: fix a bug                     # → patch version bump
+feat!: breaking change             # → major version bump
+docs: update readme                # → no release
+chore: update dependencies         # → no release
+ci: update workflow                # → no release
+test: add unit tests               # → no release
+refactor: restructure code         # → no release
+perf: improve load time            # → patch version bump
+```
+
+### Daily workflow cheat sheet
+
+```bash
+# 1. Start fresh
+git checkout preview && git pull origin preview
+
+# 2. Create branch
+git checkout -b feat/my-feature
+
+# 3. Work, stage, commit
+git add src/components/MyComponent.astro
+git commit -m "feat: add my new component"
+
+# 4. Push and PR
+git push -u origin feat/my-feature
+gh pr create --base preview --title "feat: add my new component"
+
+# 5. After merge to preview, PR to main
+gh pr create --base main --head preview --title "feat: my new component"
+
+# 6. Wait for approval, merge, wait for Discord notification
+# 7. Done! 🎉
+```
+
+### Useful commands
+
+```bash
+gh pr list                          # See open PRs
+gh pr checks                       # Check CI status on current PR
+gh pr view 13                      # View PR details
+gh run list --limit 5              # Recent workflow runs
+gh run view --log-failed           # Debug a failed run
+gh release list --limit 5          # Recent releases
+git log --oneline -10              # Recent commits
+git log --oneline main..preview    # What's on preview but not main
+```
+
+---
+
+## Further Reading
+
+- [Conventional Commits Specification](https://www.conventionalcommits.org/)
+- [Semantic Versioning](https://semver.org/)
+- [Keep a Changelog](https://keepachangelog.com/)
+- [semantic-release Documentation](https://semantic-release.gitbook.io/)
+- [GitHub CLI Manual](https://cli.github.com/manual/)


### PR DESCRIPTION
## Summary

Major documentation refresh to onboard the full team. Updates outdated references, adds a comprehensive git workflow guide, and prepares the README for team introductions.

## What changed

### New: Git Workflow Guide
**`docs/team/git-workflow-guide.md`**

A beginner-friendly, end-to-end guide covering:
- Branch strategy (`feature/* → preview → main`) with Mermaid diagrams
- Conventional Commits format with good/bad examples
- Step-by-step workflow from creating a branch to production release
- How semantic-release automates versioning and changelogs
- Branch protection rules and what they enforce
- Discord notifications for sync status
- Common scenarios (hotfixes, wrong commit messages, merge conflicts, parallel work)
- Troubleshooting guide
- Quick reference cheat sheets

### Updated: Onboarding Guide
**`docs/team/onboarding-guide.md`** — 11 fixes for outdated information:

| What | Old | New |
|---|---|---|
| Hosting | GitHub Pages | Cloudflare Pages |
| CMS version | Sanity 4 | Sanity 5 |
| Icons | astro-icon | @iconify/utils |
| Testing | Playwright only | Vitest + Playwright |
| React in frontend | "No React" | React for Visual Editing only |
| Runtime API calls | "Zero" | Zero in production, SSR on preview |
| Storybook stub note | astro-icon reference | Removed (astro-icon replaced) |
| Deployment section | GitHub Pages | Cloudflare Pages (GitHub Pages for Storybook only) |
| Key docs links | Broken paths | Fixed relative paths |
| Rule count | 78 | 95 |
| Key docs table | Missing git guide | Added git workflow guide reference |

### Updated: README
**`README.md`**

- **Replaced dynamic badges** with static shields.io tech stack badges (dynamic ones don't render on private repos)
- Added badges for: Astro, Sanity, Tailwind CSS, TypeScript, Vite, Cloudflare Pages, Storybook, Vitest, Playwright, semantic-release, Node.js, npm workspaces
- **New Git Workflow section** with branch rules, commit format, and Mermaid diagram
- **New Testing section** in table format
- **New Team section** with 7 rows — Jay's info filled in, 6 empty slots for teammates
- Updated tech stack table (Sanity 5, @iconify/utils, Vitest, Cloudflare Pages, semantic-release)
- Updated deployment section (Cloudflare Pages for site, GitHub Pages for Storybook only)
- Updated contributing section to reference the git workflow guide
- Added team documentation table

---

## Action Required: All Team Members

### Step 1: Review the docs (on this PR)

Please read through these documents and leave comments if anything is unclear:

- [ ] **@teammate1** — Read `docs/team/git-workflow-guide.md` and `docs/team/onboarding-guide.md`
- [ ] **@teammate2** — Read `docs/team/git-workflow-guide.md` and `docs/team/onboarding-guide.md`
- [ ] **@teammate3** — Read `docs/team/git-workflow-guide.md` and `docs/team/onboarding-guide.md`
- [ ] **@teammate4** — Read `docs/team/git-workflow-guide.md` and `docs/team/onboarding-guide.md`
- [ ] **@teammate5** — Read `docs/team/git-workflow-guide.md` and `docs/team/onboarding-guide.md`
- [ ] **@teammate6** — Read `docs/team/git-workflow-guide.md` and `docs/team/onboarding-guide.md`

### Step 2: Add yourself to the README (in your own PR)

After this PR merges, each team member should practice the git workflow by adding their info:

1. Pull the latest `preview`: `git checkout preview && git pull`
2. Create your branch: `git checkout -b docs/add-<your-name>`
3. Edit `README.md` — fill in your row in the **Team** table
4. Commit: `git commit -m "docs: add <your-name> to team section"`
5. Push and open a PR to `preview`: `gh pr create --base preview`

This serves as your first hands-on practice with the branch workflow, conventional commits, and PR process described in the git workflow guide.

---

## Test plan

- [ ] Verify all Mermaid diagrams render correctly on GitHub
- [ ] Verify shields.io badges render on the private repo
- [ ] Verify all relative links in docs resolve correctly
- [ ] Confirm no broken references to deleted files (astro-icon, GitHub Pages hosting, etc.)