### PR TITLE
feat(sanity): stegaClean BlockWrapper & Studio UX polish

### DIFF
--- a/astro-app/src/components/BlockRenderer.astro
+++ b/astro-app/src/components/BlockRenderer.astro
@@ -1,6 +1,7 @@
 ---
 import type { PageBlock } from '@/lib/types';
 import { customBlocks, uiBlocks } from './block-registry';
+import BlockWrapper from './blocks/BlockWrapper.astro';
 
 interface Props {
   blocks: PageBlock[];
@@ -15,13 +16,13 @@ const { blocks } = Astro.props;
   // Custom blocks (block prop pattern)
   const CustomComponent = customBlocks[type];
   if (CustomComponent) {
-    return <CustomComponent block={block} />;
+    return <BlockWrapper backgroundVariant={(block as any).backgroundVariant} spacing={(block as any).spacing} maxWidth={(block as any).maxWidth}><CustomComponent block={block} /></BlockWrapper>;
   }
 
   // fulldotdev/ui blocks (spread props pattern)
   const UiComponent = uiBlocks[type];
   if (UiComponent) {
-    return <UiComponent {...(block as any)} />;
+    return <BlockWrapper backgroundVariant={(block as any).backgroundVariant} spacing={(block as any).spacing} maxWidth={(block as any).maxWidth}><UiComponent {...(block as any)} /></BlockWrapper>;
   }
 
   return null;

--- a/astro-app/src/components/__tests__/BlockWrapper.test.ts
+++ b/astro-app/src/components/__tests__/BlockWrapper.test.ts
@@ -1,0 +1,120 @@
+import { experimental_AstroContainer as AstroContainer } from 'astro/container';
+import { describe, test, expect } from 'vitest';
+import BlockWrapper from '../blocks/BlockWrapper.astro';
+
+describe('BlockWrapper', () => {
+  test('renders slot content', async () => {
+    const container = await AstroContainer.create();
+    const html = await container.renderToString(BlockWrapper, {
+      props: { backgroundVariant: 'white', spacing: 'default', maxWidth: 'default' },
+      slots: { default: '<p>Hello</p>' },
+    });
+    expect(html).toContain('<p>Hello</p>');
+  });
+
+  test('maps backgroundVariant "dark" to bg-foreground', async () => {
+    const container = await AstroContainer.create();
+    const html = await container.renderToString(BlockWrapper, {
+      props: { backgroundVariant: 'dark' },
+      slots: { default: '<p>content</p>' },
+    });
+    expect(html).toContain('bg-foreground');
+    expect(html).toContain('text-background');
+  });
+
+  test('maps backgroundVariant "primary" to bg-primary', async () => {
+    const container = await AstroContainer.create();
+    const html = await container.renderToString(BlockWrapper, {
+      props: { backgroundVariant: 'primary' },
+      slots: { default: '<p>content</p>' },
+    });
+    expect(html).toContain('bg-primary');
+    expect(html).toContain('text-primary-foreground');
+  });
+
+  test('maps backgroundVariant "light" to bg-muted', async () => {
+    const container = await AstroContainer.create();
+    const html = await container.renderToString(BlockWrapper, {
+      props: { backgroundVariant: 'light' },
+      slots: { default: '<p>content</p>' },
+    });
+    expect(html).toContain('bg-muted');
+  });
+
+  test('backgroundVariant "white" adds no bg class', async () => {
+    const container = await AstroContainer.create();
+    const html = await container.renderToString(BlockWrapper, {
+      props: { backgroundVariant: 'white' },
+      slots: { default: '<p>content</p>' },
+    });
+    expect(html).not.toContain('bg-');
+  });
+
+  test('null backgroundVariant defaults to "white" (no bg class)', async () => {
+    const container = await AstroContainer.create();
+    const html = await container.renderToString(BlockWrapper, {
+      props: { backgroundVariant: null },
+      slots: { default: '<p>content</p>' },
+    });
+    expect(html).not.toContain('bg-');
+  });
+
+  test('maps spacing "large" to py-8', async () => {
+    const container = await AstroContainer.create();
+    const html = await container.renderToString(BlockWrapper, {
+      props: { spacing: 'large' },
+      slots: { default: '<p>content</p>' },
+    });
+    expect(html).toContain('py-8');
+  });
+
+  test('maps spacing "small" to py-4', async () => {
+    const container = await AstroContainer.create();
+    const html = await container.renderToString(BlockWrapper, {
+      props: { spacing: 'small' },
+      slots: { default: '<p>content</p>' },
+    });
+    expect(html).toContain('py-4');
+  });
+
+  test('maps spacing "none" to py-0', async () => {
+    const container = await AstroContainer.create();
+    const html = await container.renderToString(BlockWrapper, {
+      props: { spacing: 'none' },
+      slots: { default: '<p>content</p>' },
+    });
+    expect(html).toContain('py-0');
+  });
+
+  test('maps maxWidth "narrow" to max-w-4xl', async () => {
+    const container = await AstroContainer.create();
+    const html = await container.renderToString(BlockWrapper, {
+      props: { maxWidth: 'narrow' },
+      slots: { default: '<p>content</p>' },
+    });
+    expect(html).toContain('max-w-4xl');
+    expect(html).toContain('mx-auto');
+  });
+
+  test('maps maxWidth "full" to max-w-full', async () => {
+    const container = await AstroContainer.create();
+    const html = await container.renderToString(BlockWrapper, {
+      props: { maxWidth: 'full' },
+      slots: { default: '<p>content</p>' },
+    });
+    expect(html).toContain('max-w-full');
+  });
+
+  test('all props null defaults gracefully', async () => {
+    const container = await AstroContainer.create();
+    const html = await container.renderToString(BlockWrapper, {
+      props: { backgroundVariant: null, spacing: null, maxWidth: null },
+      slots: { default: '<p>content</p>' },
+    });
+    expect(html).toContain('<p>content</p>');
+    // defaults: white (no bg), default spacing (no extra padding), default maxWidth (no constraint)
+    expect(html).not.toContain('bg-');
+    expect(html).not.toContain('py-');
+    expect(html).not.toContain('max-w-');
+  });
+});

--- a/astro-app/src/components/blocks/BlockWrapper.astro
+++ b/astro-app/src/components/blocks/BlockWrapper.astro
@@ -1,0 +1,39 @@
+---
+import { stegaClean } from '@sanity/client/stega';
+
+interface Props {
+  backgroundVariant?: string | null;
+  spacing?: string | null;
+  maxWidth?: string | null;
+}
+
+const { backgroundVariant, spacing, maxWidth } = Astro.props;
+
+const bg = stegaClean(backgroundVariant) ?? 'white';
+const sp = stegaClean(spacing) ?? 'default';
+const mw = stegaClean(maxWidth) ?? 'default';
+
+const bgClasses: Record<string, string> = {
+  white: '',
+  light: 'bg-muted',
+  dark: 'bg-foreground text-background',
+  primary: 'bg-primary text-primary-foreground',
+};
+
+const spacingClasses: Record<string, string> = {
+  none: 'py-0',
+  small: 'py-4',
+  default: '',
+  large: 'py-8',
+};
+
+const maxWidthClasses: Record<string, string> = {
+  narrow: 'max-w-4xl mx-auto',
+  default: '',
+  full: 'max-w-full',
+};
+---
+
+<div class:list={[bgClasses[bg], spacingClasses[sp], maxWidthClasses[mw]]}>
+  <slot />
+</div>

--- a/studio/sanity.cli.ts
+++ b/studio/sanity.cli.ts
@@ -15,7 +15,7 @@ export default defineCliConfig({
     projectId,
     dataset,
   },
-  studioHost: process.env.SANITY_STUDIO_STUDIO_HOST || '', // Visit https://www.sanity.io/docs/environment-variables to leanr more about using environment variables for local & production.
+  studioHost: process.env.SANITY_STUDIO_STUDIO_HOST || '', // Visit https://www.sanity.io/docs/environment-variables to learn more about using environment variables for local & production.
   deployment: {
     appId: 'zi1cig2o607y1js5cfoyird6',
     autoUpdates: true,

--- a/studio/sanity.config.ts
+++ b/studio/sanity.config.ts
@@ -7,7 +7,7 @@ import {schemaTypes} from './src/schemaTypes'
 import {resolve} from './src/presentation/resolve'
 
 // Environment variables for project configuration
-const projectId = process.env.SANITY_STUDIO_PROJECT_ID || 'your-projectID'
+const projectId = process.env.SANITY_STUDIO_PROJECT_ID || '<your project ID>'
 const dataset = process.env.SANITY_STUDIO_DATASET || 'production'
 
 // Singleton document types — only one instance allowed

--- a/studio/src/schemaTypes/documents/site-settings.ts
+++ b/studio/src/schemaTypes/documents/site-settings.ts
@@ -83,6 +83,7 @@ export const siteSettings = defineType({
       of: [
         defineArrayMember({
           type: 'object',
+          preview: {select: {title: 'label'}},
           fields: [
             defineField({
               name: 'label',
@@ -110,6 +111,7 @@ export const siteSettings = defineType({
               of: [
                 defineArrayMember({
                   type: 'object',
+                  preview: {select: {title: 'label'}},
                   fields: [
                     defineField({
                       name: 'label',
@@ -162,6 +164,7 @@ export const siteSettings = defineType({
       of: [
         defineArrayMember({
           type: 'object',
+          preview: {select: {title: 'platform'}},
           fields: [
             defineField({
               name: 'platform',
@@ -211,6 +214,7 @@ export const siteSettings = defineType({
       of: [
         defineArrayMember({
           type: 'object',
+          preview: {select: {title: 'label'}},
           fields: [
             defineField({
               name: 'label',
@@ -236,6 +240,7 @@ export const siteSettings = defineType({
       of: [
         defineArrayMember({
           type: 'object',
+          preview: {select: {title: 'label'}},
           fields: [
             defineField({
               name: 'label',
@@ -267,6 +272,7 @@ export const siteSettings = defineType({
       of: [
         defineArrayMember({
           type: 'object',
+          preview: {select: {title: 'label'}},
           fields: [
             defineField({
               name: 'label',

--- a/studio/src/schemaTypes/helpers/defineBlock.ts
+++ b/studio/src/schemaTypes/helpers/defineBlock.ts
@@ -6,6 +6,7 @@ interface DefineBlockConfig {
   name: string
   title: string
   fields: ReturnType<typeof defineField>[]
+  fieldsets?: Array<{name: string; title: string; options?: Record<string, unknown>}>
   preview?: {select: Record<string, string>}
   icon?: ComponentType
 }
@@ -15,6 +16,10 @@ export function defineBlock(config: DefineBlockConfig) {
     name: config.name,
     title: config.title,
     type: 'object',
+    fieldsets: [
+      {name: 'layout', title: 'Layout Options', options: {collapsible: true, collapsed: true}},
+      ...(config.fieldsets ?? []),
+    ],
     fields: [...blockBaseFields, ...config.fields],
     preview: config.preview,
     icon: config.icon,

--- a/studio/src/schemaTypes/objects/block-base.ts
+++ b/studio/src/schemaTypes/objects/block-base.ts
@@ -5,6 +5,7 @@ export const blockBaseFields = [
     name: 'backgroundVariant',
     title: 'Background Variant',
     type: 'string',
+    fieldset: 'layout',
     options: {
       list: ['white', 'light', 'dark', 'primary'],
       layout: 'radio',
@@ -15,6 +16,7 @@ export const blockBaseFields = [
     name: 'spacing',
     title: 'Spacing',
     type: 'string',
+    fieldset: 'layout',
     options: {
       list: ['none', 'small', 'default', 'large'],
       layout: 'radio',
@@ -25,6 +27,7 @@ export const blockBaseFields = [
     name: 'maxWidth',
     title: 'Max Width',
     type: 'string',
+    fieldset: 'layout',
     options: {
       list: ['narrow', 'default', 'full'],
       layout: 'radio',

--- a/studio/src/schemaTypes/objects/portable-text.ts
+++ b/studio/src/schemaTypes/objects/portable-text.ts
@@ -22,7 +22,7 @@ export const portableText = defineType({
           {title: 'Underline', value: 'underline'},
         ],
         annotations: [
-          {
+          defineArrayMember({
             name: 'link',
             type: 'object',
             title: 'External Link',
@@ -35,8 +35,8 @@ export const portableText = defineType({
                   Rule.uri({scheme: ['http', 'https', 'mailto', 'tel']}),
               }),
             ],
-          },
-          {
+          }),
+          defineArrayMember({
             name: 'internalLink',
             type: 'object',
             title: 'Internal Link',
@@ -48,7 +48,7 @@ export const portableText = defineType({
                 to: [{type: 'page'}],
               }),
             ],
-          },
+          }),
         ],
       },
       lists: [


### PR DESCRIPTION
## What is this PR about?

This PR fixes a subtle but important bug related to **Visual Editing** in Sanity, and makes the Sanity Studio nicer to use for content editors.

### The Problem: Invisible Characters Breaking Styles

When Visual Editing is enabled in Sanity, the system injects **invisible characters** (called "stega" characters) into text field values. These characters help Sanity know which field the editor clicked on — but they cause a sneaky bug:

```
// What you expect:
backgroundVariant = "dark"   →  bgClasses["dark"]  →  "bg-foreground text-background"  ✅

// What actually happens with Visual Editing enabled:
backgroundVariant = "dark\u200B\u200C..."   →  bgClasses["dark\u200B\u200C..."]  →  undefined! ❌
```

The invisible characters mean the CSS class lookup **silently fails** — the block gets no background color, no spacing, no max-width. The page looks broken but there's no error message to explain why.

### The Fix: BlockWrapper

We created a new `BlockWrapper` component that sits between the `BlockRenderer` and every block component. It does one critical thing: **cleans the invisible characters** from layout fields (`backgroundVariant`, `spacing`, `maxWidth`) using Sanity's `stegaClean()` function before mapping them to CSS classes.

```
BlockRenderer → BlockWrapper (stegaClean here) → HeroBanner / CtaBanner / etc.
```

This means the cleaning happens in **one place** instead of needing every block to do it individually.

### Studio UX Improvements

We also made the Sanity Studio friendlier for editors:

- **Collapsible layout options** — The `backgroundVariant`, `spacing`, and `maxWidth` fields on every block are now grouped in a "Layout Options" fieldset that starts collapsed. This declutters the editing area so editors see the important content fields first.

- **Array item previews** — Navigation items, footer links, resource links, program links, and social links in Site Settings now show their label/platform name when collapsed instead of "Untitled". Much easier to find what you're looking for!

- **Portable text annotations wrapped properly** — The `link` and `internalLink` annotations now use `defineArrayMember()` for better TypeScript type safety.

- **Minor cleanup** — Fixed a "leanr" → "learn" typo and standardized env variable fallback values across config files.

## Summary

- Create `BlockWrapper.astro` — centralized stegaClean + CSS class mapping for block base fields
- Update `BlockRenderer.astro` — wrap all blocks in BlockWrapper
- Add collapsible "Layout Options" fieldset to all block schemas
- Add preview labels to 6 siteSettings array members
- Wrap portable-text annotations in `defineArrayMember`
- Fix typo and standardize env var fallbacks

## Test plan

- [x] `npm run build -w astro-app` — 0 errors, 0 warnings (526 files)
- [x] Sanity Studio builds without errors
- [x] `npm run typegen` — 3 queries, 32 schema types, no regression
- [x] Integration tests — 18 suites, 235 tests pass
- [ ] Visual verification: open Studio, confirm layout fieldset is collapsed
- [ ] Visual verification: open siteSettings, confirm array items show labels