### PR TITLE
refactor(blocks): unify block dispatch to single spread-props pattern

### DIFF
--- a/astro-app/src/components/BlockRenderer.astro
+++ b/astro-app/src/components/BlockRenderer.astro
@@ -1,6 +1,6 @@
 ---
 import type { PageBlock } from '@/lib/types';
-import { customBlocks, uiBlocks } from './block-registry';
+import { allBlocks } from './block-registry';
 import BlockWrapper from './blocks/BlockWrapper.astro';
 
 interface Props {
@@ -11,19 +11,7 @@ const { blocks } = Astro.props;
 ---
 
 {blocks.map((block) => {
-  const type = (block as any)._type;
-
-  // Custom blocks (block prop pattern)
-  const CustomComponent = customBlocks[type];
-  if (CustomComponent) {
-    return <BlockWrapper backgroundVariant={(block as any).backgroundVariant} spacing={(block as any).spacing} maxWidth={(block as any).maxWidth}><CustomComponent block={block} /></BlockWrapper>;
-  }
-
-  // fulldotdev/ui blocks (spread props pattern)
-  const UiComponent = uiBlocks[type];
-  if (UiComponent) {
-    return <BlockWrapper backgroundVariant={(block as any).backgroundVariant} spacing={(block as any).spacing} maxWidth={(block as any).maxWidth}><UiComponent {...(block as any)} /></BlockWrapper>;
-  }
-
-  return null;
+  const Component = allBlocks[(block as any)._type];
+  if (!Component) return null;
+  return <BlockWrapper backgroundVariant={(block as any).backgroundVariant} spacing={(block as any).spacing} maxWidth={(block as any).maxWidth}><Component {...(block as any)} /></BlockWrapper>;
 })}

--- a/astro-app/src/components/__tests__/ContactForm.test.ts
+++ b/astro-app/src/components/__tests__/ContactForm.test.ts
@@ -7,7 +7,7 @@ describe('ContactForm', () => {
   test('renders heading and description', async () => {
     const container = await AstroContainer.create();
     const html = await container.renderToString(ContactForm, {
-      props: { block: contactFormFull },
+      props: contactFormFull,
     });
 
     expect(html).toContain('Get In Touch');
@@ -17,7 +17,7 @@ describe('ContactForm', () => {
   test('renders form fields', async () => {
     const container = await AstroContainer.create();
     const html = await container.renderToString(ContactForm, {
-      props: { block: contactFormFull },
+      props: contactFormFull,
     });
 
     expect(html).toContain('Full Name');
@@ -29,7 +29,7 @@ describe('ContactForm', () => {
   test('renders custom success message', async () => {
     const container = await AstroContainer.create();
     const html = await container.renderToString(ContactForm, {
-      props: { block: contactFormFull },
+      props: contactFormFull,
     });
 
     expect(html).toContain('Thanks! We will be in touch soon.');
@@ -38,7 +38,7 @@ describe('ContactForm', () => {
   test('renders default success message when none provided', async () => {
     const container = await AstroContainer.create();
     const html = await container.renderToString(ContactForm, {
-      props: { block: contactFormMinimal },
+      props: contactFormMinimal,
     });
 
     expect(html).toContain('Thank you for your inquiry');
@@ -47,7 +47,7 @@ describe('ContactForm', () => {
   test('handles minimal data without crashing', async () => {
     const container = await AstroContainer.create();
     const html = await container.renderToString(ContactForm, {
-      props: { block: contactFormMinimal },
+      props: contactFormMinimal,
     });
 
     expect(html).toContain('data-contact-form');

--- a/astro-app/src/components/__tests__/CtaBanner.test.ts
+++ b/astro-app/src/components/__tests__/CtaBanner.test.ts
@@ -7,7 +7,7 @@ describe('CtaBanner', () => {
   test('renders heading, description, and CTA buttons', async () => {
     const container = await AstroContainer.create();
     const html = await container.renderToString(CtaBanner, {
-      props: { block: ctaFull },
+      props: ctaFull,
     });
 
     expect(html).toContain('Ready to Get Started?');
@@ -19,7 +19,7 @@ describe('CtaBanner', () => {
   test('handles minimal data without crashing', async () => {
     const container = await AstroContainer.create();
     const html = await container.renderToString(CtaBanner, {
-      props: { block: ctaMinimal },
+      props: ctaMinimal,
     });
 
     expect(html).toContain('Simple CTA');
@@ -28,7 +28,7 @@ describe('CtaBanner', () => {
   test('omits description when null', async () => {
     const container = await AstroContainer.create();
     const html = await container.renderToString(CtaBanner, {
-      props: { block: ctaMinimal },
+      props: ctaMinimal,
     });
 
     expect(html).not.toContain('opacity-80');

--- a/astro-app/src/components/__tests__/FaqSection.test.ts
+++ b/astro-app/src/components/__tests__/FaqSection.test.ts
@@ -7,7 +7,7 @@ describe('FaqSection', () => {
   test('renders heading and FAQ items', async () => {
     const container = await AstroContainer.create();
     const html = await container.renderToString(FaqSection, {
-      props: { block: faqFull },
+      props: faqFull,
     });
 
     expect(html).toContain('Frequently Asked Questions');
@@ -19,7 +19,7 @@ describe('FaqSection', () => {
   test('renders numbered items', async () => {
     const container = await AstroContainer.create();
     const html = await container.renderToString(FaqSection, {
-      props: { block: faqFull },
+      props: faqFull,
     });
 
     expect(html).toContain('01');
@@ -29,7 +29,7 @@ describe('FaqSection', () => {
   test('handles minimal data without crashing', async () => {
     const container = await AstroContainer.create();
     const html = await container.renderToString(FaqSection, {
-      props: { block: faqMinimal },
+      props: faqMinimal,
     });
     expect(html).toBeDefined();
   });

--- a/astro-app/src/components/__tests__/FeatureGrid.test.ts
+++ b/astro-app/src/components/__tests__/FeatureGrid.test.ts
@@ -7,7 +7,7 @@ describe('FeatureGrid', () => {
   test('renders heading and feature items', async () => {
     const container = await AstroContainer.create();
     const html = await container.renderToString(FeatureGrid, {
-      props: { block: featureGridFull },
+      props: featureGridFull,
     });
 
     expect(html).toContain('What We Offer');
@@ -19,7 +19,7 @@ describe('FeatureGrid', () => {
   test('renders numbered items', async () => {
     const container = await AstroContainer.create();
     const html = await container.renderToString(FeatureGrid, {
-      props: { block: featureGridFull },
+      props: featureGridFull,
     });
 
     expect(html).toContain('01');
@@ -29,7 +29,7 @@ describe('FeatureGrid', () => {
   test('handles minimal data without crashing', async () => {
     const container = await AstroContainer.create();
     const html = await container.renderToString(FeatureGrid, {
-      props: { block: featureGridMinimal },
+      props: featureGridMinimal,
     });
     expect(html).toBeDefined();
   });

--- a/astro-app/src/components/__tests__/HeroBanner.test.ts
+++ b/astro-app/src/components/__tests__/HeroBanner.test.ts
@@ -7,7 +7,7 @@ describe('HeroBanner', () => {
   test('renders heading and subheading', async () => {
     const container = await AstroContainer.create();
     const html = await container.renderToString(HeroBanner, {
-      props: { block: heroFull },
+      props: heroFull,
     });
 
     expect(html).toContain('Welcome to YWCC');
@@ -17,7 +17,7 @@ describe('HeroBanner', () => {
   test('renders CTA buttons with links', async () => {
     const container = await AstroContainer.create();
     const html = await container.renderToString(HeroBanner, {
-      props: { block: heroFull },
+      props: heroFull,
     });
 
     expect(html).toContain('Get Started');
@@ -29,7 +29,7 @@ describe('HeroBanner', () => {
   test('renders background images in carousel', async () => {
     const container = await AstroContainer.create();
     const html = await container.renderToString(HeroBanner, {
-      props: { block: heroFull },
+      props: heroFull,
     });
 
     expect(html).toContain('data-carousel');
@@ -39,7 +39,7 @@ describe('HeroBanner', () => {
   test('handles minimal data without crashing', async () => {
     const container = await AstroContainer.create();
     const html = await container.renderToString(HeroBanner, {
-      props: { block: heroMinimal },
+      props: heroMinimal,
     });
 
     expect(html).toContain('Minimal Hero');
@@ -49,7 +49,7 @@ describe('HeroBanner', () => {
   test('omits subheading when null', async () => {
     const container = await AstroContainer.create();
     const html = await container.renderToString(HeroBanner, {
-      props: { block: heroMinimal },
+      props: heroMinimal,
     });
 
     // Subheading paragraph should not render
@@ -59,7 +59,7 @@ describe('HeroBanner', () => {
   test('omits CTA section when no buttons', async () => {
     const container = await AstroContainer.create();
     const html = await container.renderToString(HeroBanner, {
-      props: { block: heroMinimal },
+      props: heroMinimal,
     });
 
     expect(html).not.toContain('Get Started');

--- a/astro-app/src/components/__tests__/LogoCloud.test.ts
+++ b/astro-app/src/components/__tests__/LogoCloud.test.ts
@@ -7,7 +7,7 @@ describe('LogoCloud', () => {
   test('renders heading and sponsor logos', async () => {
     const container = await AstroContainer.create();
     const html = await container.renderToString(LogoCloud, {
-      props: { block: logoCloudFull },
+      props: logoCloudFull,
     });
 
     expect(html).toContain('Trusted By');
@@ -17,7 +17,7 @@ describe('LogoCloud', () => {
   test('renders logo image with sponsor name as alt', async () => {
     const container = await AstroContainer.create();
     const html = await container.renderToString(LogoCloud, {
-      props: { block: logoCloudFull },
+      props: logoCloudFull,
     });
 
     // LogoCloud uses sponsor.name as alt text
@@ -27,7 +27,7 @@ describe('LogoCloud', () => {
   test('renders sponsor name as fallback when no logo', async () => {
     const container = await AstroContainer.create();
     const html = await container.renderToString(LogoCloud, {
-      props: { block: logoCloudFull },
+      props: logoCloudFull,
     });
 
     expect(html).toContain('DataLabs');
@@ -36,7 +36,7 @@ describe('LogoCloud', () => {
   test('wraps sponsor in link when website is present', async () => {
     const container = await AstroContainer.create();
     const html = await container.renderToString(LogoCloud, {
-      props: { block: logoCloudFull },
+      props: logoCloudFull,
     });
 
     expect(html).toContain('https://techcorp.example.com');
@@ -45,7 +45,7 @@ describe('LogoCloud', () => {
   test('handles minimal data without crashing', async () => {
     const container = await AstroContainer.create();
     const html = await container.renderToString(LogoCloud, {
-      props: { block: logoCloudMinimal },
+      props: logoCloudMinimal,
     });
     expect(html).toBeDefined();
   });

--- a/astro-app/src/components/__tests__/RichText.test.ts
+++ b/astro-app/src/components/__tests__/RichText.test.ts
@@ -7,7 +7,7 @@ describe('RichText', () => {
   test('renders h2 blocks', async () => {
     const container = await AstroContainer.create();
     const html = await container.renderToString(RichText, {
-      props: { block: richTextFull },
+      props: richTextFull,
     });
 
     // Astro adds data-astro-source-* attributes, so match content not exact tags
@@ -17,7 +17,7 @@ describe('RichText', () => {
   test('renders h3 blocks', async () => {
     const container = await AstroContainer.create();
     const html = await container.renderToString(RichText, {
-      props: { block: richTextFull },
+      props: richTextFull,
     });
 
     expect(html).toMatch(/<h3[^>]*>Our Values<\/h3>/);
@@ -26,7 +26,7 @@ describe('RichText', () => {
   test('renders normal paragraphs', async () => {
     const container = await AstroContainer.create();
     const html = await container.renderToString(RichText, {
-      props: { block: richTextFull },
+      props: richTextFull,
     });
 
     expect(html).toContain('We empower women in technology.');
@@ -35,7 +35,7 @@ describe('RichText', () => {
   test('handles null content without crashing', async () => {
     const container = await AstroContainer.create();
     const html = await container.renderToString(RichText, {
-      props: { block: richTextMinimal },
+      props: richTextMinimal,
     });
     expect(html).toBeDefined();
   });

--- a/astro-app/src/components/__tests__/SponsorCards.test.ts
+++ b/astro-app/src/components/__tests__/SponsorCards.test.ts
@@ -7,7 +7,7 @@ describe('SponsorCards', () => {
   test('renders heading and sponsor names', async () => {
     const container = await AstroContainer.create();
     const html = await container.renderToString(SponsorCards, {
-      props: { block: sponsorCardsFull },
+      props: sponsorCardsFull,
     });
 
     expect(html).toContain('Our Sponsors');
@@ -18,7 +18,7 @@ describe('SponsorCards', () => {
   test('renders tier badges', async () => {
     const container = await AstroContainer.create();
     const html = await container.renderToString(SponsorCards, {
-      props: { block: sponsorCardsFull },
+      props: sponsorCardsFull,
     });
 
     expect(html).toContain('gold');
@@ -28,7 +28,7 @@ describe('SponsorCards', () => {
   test('renders sponsor description and website link', async () => {
     const container = await AstroContainer.create();
     const html = await container.renderToString(SponsorCards, {
-      props: { block: sponsorCardsFull },
+      props: sponsorCardsFull,
     });
 
     expect(html).toContain('Leading technology partner');
@@ -39,7 +39,7 @@ describe('SponsorCards', () => {
   test('renders logo image when available', async () => {
     const container = await AstroContainer.create();
     const html = await container.renderToString(SponsorCards, {
-      props: { block: sponsorCardsFull },
+      props: sponsorCardsFull,
     });
 
     expect(html).toContain('Acme logo');
@@ -48,7 +48,7 @@ describe('SponsorCards', () => {
   test('renders initials fallback when no logo', async () => {
     const container = await AstroContainer.create();
     const html = await container.renderToString(SponsorCards, {
-      props: { block: sponsorCardsFull },
+      props: sponsorCardsFull,
     });
 
     // Beta Inc has no logo — should show initials "BI"
@@ -58,7 +58,7 @@ describe('SponsorCards', () => {
   test('handles minimal data without crashing', async () => {
     const container = await AstroContainer.create();
     const html = await container.renderToString(SponsorCards, {
-      props: { block: sponsorCardsMinimal },
+      props: sponsorCardsMinimal,
     });
     expect(html).toBeDefined();
   });

--- a/astro-app/src/components/__tests__/SponsorSteps.test.ts
+++ b/astro-app/src/components/__tests__/SponsorSteps.test.ts
@@ -7,7 +7,7 @@ describe('SponsorSteps', () => {
   test('renders heading and subheading', async () => {
     const container = await AstroContainer.create();
     const html = await container.renderToString(SponsorSteps, {
-      props: { block: sponsorStepsFull },
+      props: sponsorStepsFull,
     });
 
     expect(html).toContain('How to Become a Sponsor');
@@ -17,7 +17,7 @@ describe('SponsorSteps', () => {
   test('renders step items with titles and descriptions', async () => {
     const container = await AstroContainer.create();
     const html = await container.renderToString(SponsorSteps, {
-      props: { block: sponsorStepsFull },
+      props: sponsorStepsFull,
     });
 
     expect(html).toContain('Choose a Tier');
@@ -28,7 +28,7 @@ describe('SponsorSteps', () => {
   test('renders list items within steps', async () => {
     const container = await AstroContainer.create();
     const html = await container.renderToString(SponsorSteps, {
-      props: { block: sponsorStepsFull },
+      props: sponsorStepsFull,
     });
 
     expect(html).toContain('Platinum');
@@ -40,7 +40,7 @@ describe('SponsorSteps', () => {
   test('renders CTA buttons', async () => {
     const container = await AstroContainer.create();
     const html = await container.renderToString(SponsorSteps, {
-      props: { block: sponsorStepsFull },
+      props: sponsorStepsFull,
     });
 
     expect(html).toContain('Get Started');
@@ -50,7 +50,7 @@ describe('SponsorSteps', () => {
   test('handles minimal data without crashing', async () => {
     const container = await AstroContainer.create();
     const html = await container.renderToString(SponsorSteps, {
-      props: { block: sponsorStepsMinimal },
+      props: sponsorStepsMinimal,
     });
     expect(html).toBeDefined();
   });

--- a/astro-app/src/components/__tests__/StatsRow.test.ts
+++ b/astro-app/src/components/__tests__/StatsRow.test.ts
@@ -7,7 +7,7 @@ describe('StatsRow', () => {
   test('renders stats values and labels', async () => {
     const container = await AstroContainer.create();
     const html = await container.renderToString(StatsRow, {
-      props: { block: statsFull },
+      props: statsFull,
     });
 
     expect(html).toContain('500+');
@@ -21,7 +21,7 @@ describe('StatsRow', () => {
   test('renders heading when present', async () => {
     const container = await AstroContainer.create();
     const html = await container.renderToString(StatsRow, {
-      props: { block: statsFull },
+      props: statsFull,
     });
 
     expect(html).toContain('Our Impact');
@@ -30,7 +30,7 @@ describe('StatsRow', () => {
   test('handles minimal data without crashing', async () => {
     const container = await AstroContainer.create();
     const html = await container.renderToString(StatsRow, {
-      props: { block: statsMinimal },
+      props: statsMinimal,
     });
     expect(html).toBeDefined();
   });

--- a/astro-app/src/components/__tests__/TextWithImage.test.ts
+++ b/astro-app/src/components/__tests__/TextWithImage.test.ts
@@ -7,7 +7,7 @@ describe('TextWithImage', () => {
   test('renders heading and content', async () => {
     const container = await AstroContainer.create();
     const html = await container.renderToString(TextWithImage, {
-      props: { block: textWithImageFull },
+      props: textWithImageFull,
     });
 
     expect(html).toContain('Our Story');
@@ -16,7 +16,7 @@ describe('TextWithImage', () => {
   test('renders image with alt text', async () => {
     const container = await AstroContainer.create();
     const html = await container.renderToString(TextWithImage, {
-      props: { block: textWithImageFull },
+      props: textWithImageFull,
     });
 
     expect(html).toContain('Team photo');
@@ -26,7 +26,7 @@ describe('TextWithImage', () => {
   test('handles minimal data without crashing', async () => {
     const container = await AstroContainer.create();
     const html = await container.renderToString(TextWithImage, {
-      props: { block: textWithImageMinimal },
+      props: textWithImageMinimal,
     });
     expect(html).toBeDefined();
   });

--- a/astro-app/src/components/block-registry.ts
+++ b/astro-app/src/components/block-registry.ts
@@ -1,19 +1,19 @@
-// Custom blocks — auto-discovered from blocks/custom/
-// Filename convention: PascalCase (e.g. HeroBanner.astro) → camelCase _type (heroBanner)
+// All blocks — auto-discovered via import.meta.glob
+// Custom blocks: PascalCase filename → camelCase _type (e.g. HeroBanner.astro → heroBanner)
+// UI blocks: kebab-case filename used directly as _type (e.g. hero-1.astro → hero-1)
+const allBlocks: Record<string, any> = {};
+
 const customModules = import.meta.glob('./blocks/custom/*.astro', { eager: true });
-const customBlocks: Record<string, any> = {};
 for (const [path, mod] of Object.entries(customModules)) {
   const filename = path.split('/').pop()!.replace('.astro', '');
   const typeName = filename[0].toLowerCase() + filename.slice(1);
-  customBlocks[typeName] = (mod as any).default;
+  allBlocks[typeName] = (mod as any).default;
 }
 
-// fulldotdev/ui blocks — auto-discovered from blocks/
 const uiModules = import.meta.glob('./blocks/*.astro', { eager: true });
-const uiBlocks: Record<string, any> = {};
 for (const [path, mod] of Object.entries(uiModules)) {
   const name = path.split('/').pop()!.replace('.astro', '');
-  uiBlocks[name] = (mod as any).default;
+  allBlocks[name] = (mod as any).default;
 }
 
-export { customBlocks, uiBlocks };
+export { allBlocks };

--- a/astro-app/src/components/blocks/custom/ContactForm.astro
+++ b/astro-app/src/components/blocks/custom/ContactForm.astro
@@ -8,11 +8,12 @@ import { NativeSelect, NativeSelectOption } from '@/components/ui/native-select'
 import { Button } from '@/components/ui/button';
 import { Icon } from '@/components/ui/icon';
 
-interface Props {
-  block: ContactFormBlock;
+interface Props extends ContactFormBlock {
+  class?: string;
+  id?: string;
 }
 
-const { block } = Astro.props;
+const { heading, description, successMessage } = Astro.props;
 
 interface FormField {
   _key: string;
@@ -34,11 +35,11 @@ const formFields: FormField[] = [
 <Section data-animate>
   <SectionSplit>
     <SectionContent class="justify-center">
-      {block.heading && (
-        <h2 class="text-3xl md:text-4xl font-bold tracking-[-0.03em] leading-[1.1]">{block.heading}</h2>
+      {heading && (
+        <h2 class="text-3xl md:text-4xl font-bold tracking-[-0.03em] leading-[1.1]">{heading}</h2>
       )}
-      {block.description && (
-        <p class="text-muted-foreground leading-relaxed">{block.description}</p>
+      {description && (
+        <p class="text-muted-foreground leading-relaxed">{description}</p>
       )}
     </SectionContent>
 
@@ -97,7 +98,7 @@ const formFields: FormField[] = [
           <Icon name="lucide:check" class="w-8 h-8 text-primary-foreground" />
         </div>
         <h3 class="text-2xl font-bold mb-3">Inquiry Received</h3>
-        <p class="text-muted-foreground">{block.successMessage || 'Thank you for your inquiry. We will get back to you shortly.'}</p>
+        <p class="text-muted-foreground">{successMessage || 'Thank you for your inquiry. We will get back to you shortly.'}</p>
       </div>
     </form>
   </SectionSplit>

--- a/astro-app/src/components/blocks/custom/ContactForm.stories.ts
+++ b/astro-app/src/components/blocks/custom/ContactForm.stories.ts
@@ -8,23 +8,19 @@ export default {
 
 export const Default = {
   args: {
-    block: {
-      _type: 'contactForm',
-      _key: 'story-contact-1',
-      heading: 'Contact Us',
-      description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit sed do eiusmod tempor incididunt ut labore.',
-    },
+    _type: 'contactForm',
+    _key: 'story-contact-1',
+    heading: 'Contact Us',
+    description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit sed do eiusmod tempor incididunt ut labore.',
   },
 }
 
 export const WithSuccessMessage = {
   args: {
-    block: {
-      _type: 'contactForm',
-      _key: 'story-contact-2',
-      heading: 'Lorem Ipsum Inquiry',
-      description: 'Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
-      successMessage: 'Your inquiry has been submitted successfully. We will respond within 48 hours.',
-    },
+    _type: 'contactForm',
+    _key: 'story-contact-2',
+    heading: 'Lorem Ipsum Inquiry',
+    description: 'Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
+    successMessage: 'Your inquiry has been submitted successfully. We will respond within 48 hours.',
   },
 }

--- a/astro-app/src/components/blocks/custom/CtaBanner.astro
+++ b/astro-app/src/components/blocks/custom/CtaBanner.astro
@@ -4,11 +4,12 @@ import { Section, SectionContent, SectionActions } from '@/components/ui/section
 import { Button } from '@/components/ui/button';
 import { stegaClean } from '@sanity/client/stega';
 
-interface Props {
-  block: CtaBannerBlock;
+interface Props extends CtaBannerBlock {
+  class?: string;
+  id?: string;
 }
 
-const { block } = Astro.props;
+const { heading, description, ctaButtons, backgroundVariant } = Astro.props;
 
 const bgMap: Record<string, string> = {
   primary: 'bg-primary text-primary-foreground',
@@ -31,22 +32,22 @@ const secondaryBtnMap: Record<string, string> = {
   white: '',
 };
 
-const variant = stegaClean(block.backgroundVariant) || 'dark';
+const variant = stegaClean(backgroundVariant) || 'dark';
 ---
 
 <Section class={bgMap[variant]} data-animate>
   <SectionContent class="items-center text-center max-w-3xl mx-auto">
     <h2 class="text-4xl md:text-5xl font-bold tracking-[-0.03em] leading-[1.05]">
-      {block.heading}
+      {heading}
     </h2>
 
-    {block.description && (
-      <p class="text-lg leading-relaxed max-w-2xl opacity-80">{block.description}</p>
+    {description && (
+      <p class="text-lg leading-relaxed max-w-2xl opacity-80">{description}</p>
     )}
 
-    {block.ctaButtons && block.ctaButtons.length > 0 && (
+    {ctaButtons && ctaButtons.length > 0 && (
       <SectionActions class="justify-center">
-        {block.ctaButtons.map((btn, i) => (
+        {ctaButtons.map((btn, i) => (
           <Button
             href={btn.url}
             variant={i === 0 ? 'default' : (btn.variant || 'outline')}

--- a/astro-app/src/components/blocks/custom/CtaBanner.stories.ts
+++ b/astro-app/src/components/blocks/custom/CtaBanner.stories.ts
@@ -9,30 +9,26 @@ export default {
 
 export const Default = {
   args: {
-    block: {
-      _type: 'ctaBanner',
-      _key: 'story-cta-1',
-      heading: 'Lorem Ipsum Dolor Sit Amet?',
-      description: 'Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua ut enim ad minim veniam.',
-      backgroundVariant: 'dark',
-      ctaButtons: [
-        { _key: 'btn-1', text: 'Get Started', url: '/sponsors' },
-        { _key: 'btn-2', text: 'Learn More', url: '/about', variant: 'outline' },
-      ],
-    },
+    _type: 'ctaBanner',
+    _key: 'story-cta-1',
+    heading: 'Lorem Ipsum Dolor Sit Amet?',
+    description: 'Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua ut enim ad minim veniam.',
+    backgroundVariant: 'dark',
+    ctaButtons: [
+      { _key: 'btn-1', text: 'Get Started', url: '/sponsors' },
+      { _key: 'btn-2', text: 'Learn More', url: '/about', variant: 'outline' },
+    ],
   },
 }
 
 export const Minimal = {
   args: {
-    block: {
-      _type: 'ctaBanner',
-      _key: 'story-cta-2',
-      heading: 'Consectetur Adipiscing',
-      backgroundVariant: 'light',
-      ctaButtons: [
-        { _key: 'btn-1', text: 'Contact Us', url: '/contact' },
-      ],
-    },
+    _type: 'ctaBanner',
+    _key: 'story-cta-2',
+    heading: 'Consectetur Adipiscing',
+    backgroundVariant: 'light',
+    ctaButtons: [
+      { _key: 'btn-1', text: 'Contact Us', url: '/contact' },
+    ],
   },
 }

--- a/astro-app/src/components/blocks/custom/FaqSection.astro
+++ b/astro-app/src/components/blocks/custom/FaqSection.astro
@@ -3,23 +3,24 @@ import type { FaqSectionBlock } from '@/lib/types';
 import { Section, SectionSplit, SectionContent } from '@/components/ui/section';
 import { Accordion, AccordionItem, AccordionTrigger, AccordionContent } from '@/components/ui/accordion';
 
-interface Props {
-  block: FaqSectionBlock;
+interface Props extends FaqSectionBlock {
+  class?: string;
+  id?: string;
 }
 
-const { block } = Astro.props;
+const { heading, items } = Astro.props;
 ---
 
 <Section data-animate>
   <SectionSplit>
     <SectionContent>
-      {block.heading && (
-        <h2 class="text-4xl md:text-5xl font-bold tracking-[-0.03em] leading-[1.05] sticky top-24">{block.heading}</h2>
+      {heading && (
+        <h2 class="text-4xl md:text-5xl font-bold tracking-[-0.03em] leading-[1.05] sticky top-24">{heading}</h2>
       )}
     </SectionContent>
 
     <Accordion>
-      {(block.items ?? []).map((item, i) => (
+      {(items ?? []).map((item, i) => (
         <AccordionItem>
           <AccordionTrigger>
             <span class="flex items-start gap-4">

--- a/astro-app/src/components/blocks/custom/FaqSection.stories.ts
+++ b/astro-app/src/components/blocks/custom/FaqSection.stories.ts
@@ -8,59 +8,55 @@ export default {
 
 export const Default = {
   args: {
-    block: {
-      _type: 'faqSection',
-      _key: 'story-faq-1',
-      heading: 'Frequently Asked Questions',
-      items: [
-        {
-          _key: 'q1',
-          question: 'Lorem ipsum dolor sit amet consectetur?',
-          answer: 'Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam eaque ipsa quae.',
-        },
-        {
-          _key: 'q2',
-          question: 'Ut enim ad minim veniam quis nostrud?',
-          answer: 'Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt.',
-        },
-        {
-          _key: 'q3',
-          question: 'Duis aute irure dolor in reprehenderit?',
-          answer: 'At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum deleniti atque corrupti quos dolores.',
-        },
-        {
-          _key: 'q4',
-          question: 'Excepteur sint occaecat cupidatat non proident?',
-          answer: 'Quis autem vel eum iure reprehenderit qui in ea voluptate velit esse quam nihil molestiae consequatur vel illum qui dolorem.',
-        },
-        {
-          _key: 'q5',
-          question: 'Sed do eiusmod tempor incididunt ut labore?',
-          answer: 'Nam libero tempore, cum soluta nobis est eligendi optio cumque nihil impedit quo minus id quod maxime placeat facere possimus.',
-        },
-      ],
-    },
+    _type: 'faqSection',
+    _key: 'story-faq-1',
+    heading: 'Frequently Asked Questions',
+    items: [
+      {
+        _key: 'q1',
+        question: 'Lorem ipsum dolor sit amet consectetur?',
+        answer: 'Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam eaque ipsa quae.',
+      },
+      {
+        _key: 'q2',
+        question: 'Ut enim ad minim veniam quis nostrud?',
+        answer: 'Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt.',
+      },
+      {
+        _key: 'q3',
+        question: 'Duis aute irure dolor in reprehenderit?',
+        answer: 'At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum deleniti atque corrupti quos dolores.',
+      },
+      {
+        _key: 'q4',
+        question: 'Excepteur sint occaecat cupidatat non proident?',
+        answer: 'Quis autem vel eum iure reprehenderit qui in ea voluptate velit esse quam nihil molestiae consequatur vel illum qui dolorem.',
+      },
+      {
+        _key: 'q5',
+        question: 'Sed do eiusmod tempor incididunt ut labore?',
+        answer: 'Nam libero tempore, cum soluta nobis est eligendi optio cumque nihil impedit quo minus id quod maxime placeat facere possimus.',
+      },
+    ],
   },
 }
 
 export const Minimal = {
   args: {
-    block: {
-      _type: 'faqSection',
-      _key: 'story-faq-2',
-      heading: 'Questions',
-      items: [
-        {
-          _key: 'q1',
-          question: 'Lorem ipsum dolor sit amet?',
-          answer: 'Consectetur adipiscing elit sed do eiusmod tempor.',
-        },
-        {
-          _key: 'q2',
-          question: 'Ut enim ad minim veniam?',
-          answer: 'Quis nostrud exercitation ullamco laboris nisi ut aliquip.',
-        },
-      ],
-    },
+    _type: 'faqSection',
+    _key: 'story-faq-2',
+    heading: 'Questions',
+    items: [
+      {
+        _key: 'q1',
+        question: 'Lorem ipsum dolor sit amet?',
+        answer: 'Consectetur adipiscing elit sed do eiusmod tempor.',
+      },
+      {
+        _key: 'q2',
+        question: 'Ut enim ad minim veniam?',
+        answer: 'Quis nostrud exercitation ullamco laboris nisi ut aliquip.',
+      },
+    ],
   },
 }

--- a/astro-app/src/components/blocks/custom/FeatureGrid.astro
+++ b/astro-app/src/components/blocks/custom/FeatureGrid.astro
@@ -3,24 +3,25 @@ import type { FeatureGridBlock } from '@/lib/types';
 import { Section, SectionContent, SectionGrid } from '@/components/ui/section';
 import { Tile, TileContent, TileTitle, TileDescription } from '@/components/ui/tile';
 
-interface Props {
-  block: FeatureGridBlock;
+interface Props extends FeatureGridBlock {
+  class?: string;
+  id?: string;
 }
 
-const { block } = Astro.props;
-const cols = block.columns || 3;
+const { heading, columns, items } = Astro.props;
+const cols = columns || 3;
 const gridSize = cols === 2 ? 'lg' : cols === 4 ? 'sm' : 'default';
 ---
 
 <Section data-animate>
-  {block.heading && (
+  {heading && (
     <SectionContent class="max-w-3xl">
-      <h2 class="text-4xl md:text-5xl font-bold tracking-[-0.03em] leading-[1.05]">{block.heading}</h2>
+      <h2 class="text-4xl md:text-5xl font-bold tracking-[-0.03em] leading-[1.05]">{heading}</h2>
     </SectionContent>
   )}
 
   <SectionGrid size={gridSize}>
-    {(block.items ?? []).map((feature, i) => (
+    {(items ?? []).map((feature, i) => (
       <Tile variant="floating">
         <TileContent>
           <div class="flex items-center gap-3">

--- a/astro-app/src/components/blocks/custom/FeatureGrid.stories.ts
+++ b/astro-app/src/components/blocks/custom/FeatureGrid.stories.ts
@@ -8,48 +8,42 @@ export default {
 
 export const TwoColumn = {
   args: {
-    block: {
-      _type: 'featureGrid',
-      _key: 'story-features-2col',
-      heading: 'Lorem Ipsum Dolor Sit',
-      columns: 2,
-      items: [
-        { _key: 'f1', title: 'Consectetur Adipiscing', description: 'Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore.' },
-        { _key: 'f2', title: 'Elit Sed Do', description: 'Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi.' },
-      ],
-    },
+    _type: 'featureGrid',
+    _key: 'story-features-2col',
+    heading: 'Lorem Ipsum Dolor Sit',
+    columns: 2,
+    items: [
+      { _key: 'f1', title: 'Consectetur Adipiscing', description: 'Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore.' },
+      { _key: 'f2', title: 'Elit Sed Do', description: 'Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi.' },
+    ],
   },
 }
 
 export const ThreeColumn = {
   args: {
-    block: {
-      _type: 'featureGrid',
-      _key: 'story-features-3col',
-      heading: 'Lorem Ipsum Features',
-      columns: 3,
-      items: [
-        { _key: 'f1', title: 'Consectetur Adipiscing', description: 'Duis aute irure dolor in reprehenderit' },
-        { _key: 'f2', title: 'Elit Sed Do', description: 'Ut enim ad minim veniam quis nostrud' },
-        { _key: 'f3', title: 'Eiusmod Tempor', description: 'Excepteur sint occaecat cupidatat non' },
-      ],
-    },
+    _type: 'featureGrid',
+    _key: 'story-features-3col',
+    heading: 'Lorem Ipsum Features',
+    columns: 3,
+    items: [
+      { _key: 'f1', title: 'Consectetur Adipiscing', description: 'Duis aute irure dolor in reprehenderit' },
+      { _key: 'f2', title: 'Elit Sed Do', description: 'Ut enim ad minim veniam quis nostrud' },
+      { _key: 'f3', title: 'Eiusmod Tempor', description: 'Excepteur sint occaecat cupidatat non' },
+    ],
   },
 }
 
 export const FourColumn = {
   args: {
-    block: {
-      _type: 'featureGrid',
-      _key: 'story-features-4col',
-      heading: 'Lorem Highlights',
-      columns: 4,
-      items: [
-        { _key: 'f1', title: 'Lorem Ipsum', description: 'Sed do eiusmod tempor incididunt ut labore.' },
-        { _key: 'f2', title: 'Dolor Sit', description: 'Ut enim ad minim veniam quis nostrud exercitation.' },
-        { _key: 'f3', title: 'Amet Consectetur', description: 'Duis aute irure dolor in reprehenderit in voluptate.' },
-        { _key: 'f4', title: 'Adipiscing Elit', description: 'Excepteur sint occaecat cupidatat non proident sunt.' },
-      ],
-    },
+    _type: 'featureGrid',
+    _key: 'story-features-4col',
+    heading: 'Lorem Highlights',
+    columns: 4,
+    items: [
+      { _key: 'f1', title: 'Lorem Ipsum', description: 'Sed do eiusmod tempor incididunt ut labore.' },
+      { _key: 'f2', title: 'Dolor Sit', description: 'Ut enim ad minim veniam quis nostrud exercitation.' },
+      { _key: 'f3', title: 'Amet Consectetur', description: 'Duis aute irure dolor in reprehenderit in voluptate.' },
+      { _key: 'f4', title: 'Adipiscing Elit', description: 'Excepteur sint occaecat cupidatat non proident sunt.' },
+    ],
   },
 }

--- a/astro-app/src/components/blocks/custom/HeroBanner.astro
+++ b/astro-app/src/components/blocks/custom/HeroBanner.astro
@@ -4,19 +4,20 @@ import { Section, SectionContent, SectionActions } from '@/components/ui/section
 import { Button } from '@/components/ui/button';
 import { stegaClean } from '@sanity/client/stega';
 
-interface Props {
-  block: HeroBannerBlock;
+interface Props extends HeroBannerBlock {
+  class?: string;
+  id?: string;
 }
 
-const { block } = Astro.props;
-const isCentered = stegaClean(block.alignment) === 'center';
-const hasCarousel = block.backgroundImages && block.backgroundImages.length > 0;
+const { heading, subheading, ctaButtons, backgroundImages, alignment } = Astro.props;
+const isCentered = stegaClean(alignment) === 'center';
+const hasCarousel = backgroundImages && backgroundImages.length > 0;
 ---
 
 <Section size="lg" class="bg-foreground text-background overflow-hidden relative group" data-animate>
   {hasCarousel && (
     <div class="hero-carousel absolute inset-0" data-carousel>
-      {block.backgroundImages?.map((image, index) => (
+      {backgroundImages?.map((image, index) => (
         <div
           class="hero-carousel-slide absolute inset-0 transition-opacity duration-1000"
           data-slide={index}
@@ -31,7 +32,7 @@ const hasCarousel = block.backgroundImages && block.backgroundImages.length > 0;
         </div>
       ))}
       <div class="hero-carousel-nav absolute bottom-8 left-1/2 -translate-x-1/2 z-10 flex gap-2 opacity-0 group-hover:opacity-100 transition-opacity duration-300">
-        {block.backgroundImages?.map((_, index) => (
+        {backgroundImages?.map((_, index) => (
           <button
             class="hero-carousel-dot h-2 rounded-full transition-all duration-300"
             data-dot={index}
@@ -45,18 +46,18 @@ const hasCarousel = block.backgroundImages && block.backgroundImages.length > 0;
 
   <SectionContent class={`relative z-10 ${isCentered ? 'items-center text-center' : ''} bg-foreground/80 backdrop-blur-sm p-8 md:p-12 rounded-lg`}>
     <h1 class="text-5xl md:text-7xl lg:text-8xl font-bold leading-[0.95] tracking-[-0.04em]">
-      {block.heading}
+      {heading}
     </h1>
 
-    {block.subheading && (
+    {subheading && (
       <p class={`text-lg md:text-xl text-background/60 leading-relaxed ${isCentered ? 'max-w-2xl' : 'max-w-2xl'}`}>
-        {block.subheading}
+        {subheading}
       </p>
     )}
 
-    {block.ctaButtons && block.ctaButtons.length > 0 && (
+    {ctaButtons && ctaButtons.length > 0 && (
       <SectionActions class={isCentered ? 'justify-center' : ''}>
-        {block.ctaButtons.map((btn, i) => (
+        {ctaButtons.map((btn, i) => (
           <Button
             href={btn.url}
             variant={i === 0 ? 'default' : (btn.variant || 'outline')}

--- a/astro-app/src/components/blocks/custom/HeroBanner.stories.ts
+++ b/astro-app/src/components/blocks/custom/HeroBanner.stories.ts
@@ -9,46 +9,40 @@ export default {
 
 export const Default = {
   args: {
-    block: {
-      _type: 'heroBanner',
-      _key: 'story-hero-1',
-      heading: 'Lorem Ipsum Dolor Sit',
-      subheading: 'Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua',
-      alignment: 'center',
-      ctaButtons: [
-        { _key: 'btn-1', text: 'Learn More', url: '/about' },
-        { _key: 'btn-2', text: 'Contact Us', url: '/contact', variant: 'outline' },
-      ],
-    },
+    _type: 'heroBanner',
+    _key: 'story-hero-1',
+    heading: 'Lorem Ipsum Dolor Sit',
+    subheading: 'Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua',
+    alignment: 'center',
+    ctaButtons: [
+      { _key: 'btn-1', text: 'Learn More', url: '/about' },
+      { _key: 'btn-2', text: 'Contact Us', url: '/contact', variant: 'outline' },
+    ],
   },
 }
 
 export const WithBackgroundImages = {
   args: {
-    block: {
-      _type: 'heroBanner',
-      _key: 'story-hero-2',
-      heading: 'Consectetur Adipiscing Elit',
-      subheading: 'Ut enim ad minim veniam quis nostrud exercitation ullamco',
-      alignment: 'center',
-      ctaButtons: [
-        { _key: 'btn-1', text: 'Get Started', url: '/apply' },
-      ],
-      backgroundImages: [
-        { _key: 'img-1', asset: { url: 'https://placehold.co/1920x1080/1a1a2e/ffffff?text=Slide+1' }, alt: 'Placeholder slide 1' },
-        { _key: 'img-2', asset: { url: 'https://placehold.co/1920x1080/2a2a3e/ffffff?text=Slide+2' }, alt: 'Placeholder slide 2' },
-      ],
-    },
+    _type: 'heroBanner',
+    _key: 'story-hero-2',
+    heading: 'Consectetur Adipiscing Elit',
+    subheading: 'Ut enim ad minim veniam quis nostrud exercitation ullamco',
+    alignment: 'center',
+    ctaButtons: [
+      { _key: 'btn-1', text: 'Get Started', url: '/apply' },
+    ],
+    backgroundImages: [
+      { _key: 'img-1', asset: { url: 'https://placehold.co/1920x1080/1a1a2e/ffffff?text=Slide+1' }, alt: 'Placeholder slide 1' },
+      { _key: 'img-2', asset: { url: 'https://placehold.co/1920x1080/2a2a3e/ffffff?text=Slide+2' }, alt: 'Placeholder slide 2' },
+    ],
   },
 }
 
 export const Minimal = {
   args: {
-    block: {
-      _type: 'heroBanner',
-      _key: 'story-hero-3',
-      heading: 'Amet Consectetur',
-      alignment: 'full',
-    },
+    _type: 'heroBanner',
+    _key: 'story-hero-3',
+    heading: 'Amet Consectetur',
+    alignment: 'full',
   },
 }

--- a/astro-app/src/components/blocks/custom/LogoCloud.astro
+++ b/astro-app/src/components/blocks/custom/LogoCloud.astro
@@ -2,22 +2,23 @@
 import type { LogoCloudBlock } from '@/lib/types';
 import { Section } from '@/components/ui/section';
 
-interface Props {
-  block: LogoCloudBlock;
+interface Props extends LogoCloudBlock {
+  class?: string;
+  id?: string;
 }
 
-const { block } = Astro.props;
+const { heading, sponsors } = Astro.props;
 ---
 
 <Section size="sm" class="bg-muted border-y border-border" data-animate>
-  {block.heading && (
+  {heading && (
     <div class="text-center">
-      <span class="label-caps text-muted-foreground">{block.heading}</span>
+      <span class="label-caps text-muted-foreground">{heading}</span>
     </div>
   )}
 
   <div class="grid grid-cols-2 sm:grid-cols-4 lg:grid-cols-8 gap-px bg-border">
-    {block.sponsors?.map((sponsor) => {
+    {sponsors?.map((sponsor) => {
       const logoUrl = sponsor.logo?.asset?.url;
       const content = (
         <div class="bg-muted p-6 flex items-center justify-center h-24 hover:bg-background transition-colors duration-200">

--- a/astro-app/src/components/blocks/custom/LogoCloud.stories.ts
+++ b/astro-app/src/components/blocks/custom/LogoCloud.stories.ts
@@ -9,40 +9,36 @@ export default {
 
 export const WithLogos = {
   args: {
-    block: {
-      _type: 'logoCloud',
-      _key: 'story-logos-1',
-      heading: 'Trusted by Leading Organizations',
-      sponsors: [
-        { _id: 'l1', name: 'Acme Corp', logo: { asset: { url: 'https://placehold.co/120x40/e2e8f0/475569?text=Acme' }, alt: 'Acme Corp logo' }, website: 'https://example.com' },
-        { _id: 'l2', name: 'Ipsum Solutions', logo: { asset: { url: 'https://placehold.co/120x40/e2e8f0/475569?text=Ipsum' }, alt: 'Ipsum Solutions logo' }, website: 'https://example.com' },
-        { _id: 'l3', name: 'Dolor Tech', logo: { asset: { url: 'https://placehold.co/120x40/e2e8f0/475569?text=Dolor' }, alt: 'Dolor Tech logo' }, website: 'https://example.com' },
-        { _id: 'l4', name: 'Sit Amet Inc', logo: { asset: { url: 'https://placehold.co/120x40/e2e8f0/475569?text=Sit+Amet' }, alt: 'Sit Amet Inc logo' }, website: 'https://example.com' },
-        { _id: 'l5', name: 'Magna Global', logo: { asset: { url: 'https://placehold.co/120x40/e2e8f0/475569?text=Magna' }, alt: 'Magna Global logo' } },
-        { _id: 'l6', name: 'Aliqua Systems', logo: { asset: { url: 'https://placehold.co/120x40/e2e8f0/475569?text=Aliqua' }, alt: 'Aliqua Systems logo' } },
-        { _id: 'l7', name: 'Veniam Group', logo: { asset: { url: 'https://placehold.co/120x40/e2e8f0/475569?text=Veniam' }, alt: 'Veniam Group logo' } },
-        { _id: 'l8', name: 'Tempor Holdings', logo: { asset: { url: 'https://placehold.co/120x40/e2e8f0/475569?text=Tempor' }, alt: 'Tempor Holdings logo' } },
-      ],
-    },
+    _type: 'logoCloud',
+    _key: 'story-logos-1',
+    heading: 'Trusted by Leading Organizations',
+    sponsors: [
+      { _id: 'l1', name: 'Acme Corp', logo: { asset: { url: 'https://placehold.co/120x40/e2e8f0/475569?text=Acme' }, alt: 'Acme Corp logo' }, website: 'https://example.com' },
+      { _id: 'l2', name: 'Ipsum Solutions', logo: { asset: { url: 'https://placehold.co/120x40/e2e8f0/475569?text=Ipsum' }, alt: 'Ipsum Solutions logo' }, website: 'https://example.com' },
+      { _id: 'l3', name: 'Dolor Tech', logo: { asset: { url: 'https://placehold.co/120x40/e2e8f0/475569?text=Dolor' }, alt: 'Dolor Tech logo' }, website: 'https://example.com' },
+      { _id: 'l4', name: 'Sit Amet Inc', logo: { asset: { url: 'https://placehold.co/120x40/e2e8f0/475569?text=Sit+Amet' }, alt: 'Sit Amet Inc logo' }, website: 'https://example.com' },
+      { _id: 'l5', name: 'Magna Global', logo: { asset: { url: 'https://placehold.co/120x40/e2e8f0/475569?text=Magna' }, alt: 'Magna Global logo' } },
+      { _id: 'l6', name: 'Aliqua Systems', logo: { asset: { url: 'https://placehold.co/120x40/e2e8f0/475569?text=Aliqua' }, alt: 'Aliqua Systems logo' } },
+      { _id: 'l7', name: 'Veniam Group', logo: { asset: { url: 'https://placehold.co/120x40/e2e8f0/475569?text=Veniam' }, alt: 'Veniam Group logo' } },
+      { _id: 'l8', name: 'Tempor Holdings', logo: { asset: { url: 'https://placehold.co/120x40/e2e8f0/475569?text=Tempor' }, alt: 'Tempor Holdings logo' } },
+    ],
   },
 }
 
 export const TextOnly = {
   args: {
-    block: {
-      _type: 'logoCloud',
-      _key: 'story-logos-2',
-      heading: 'Our Partners',
-      sponsors: [
-        { _id: 'l1', name: 'Acme Corp', website: 'https://example.com' },
-        { _id: 'l2', name: 'Ipsum Solutions', website: 'https://example.com' },
-        { _id: 'l3', name: 'Dolor Tech' },
-        { _id: 'l4', name: 'Sit Amet Inc' },
-        { _id: 'l5', name: 'Magna Global' },
-        { _id: 'l6', name: 'Aliqua Systems' },
-        { _id: 'l7', name: 'Veniam Group' },
-        { _id: 'l8', name: 'Tempor Holdings' },
-      ],
-    },
+    _type: 'logoCloud',
+    _key: 'story-logos-2',
+    heading: 'Our Partners',
+    sponsors: [
+      { _id: 'l1', name: 'Acme Corp', website: 'https://example.com' },
+      { _id: 'l2', name: 'Ipsum Solutions', website: 'https://example.com' },
+      { _id: 'l3', name: 'Dolor Tech' },
+      { _id: 'l4', name: 'Sit Amet Inc' },
+      { _id: 'l5', name: 'Magna Global' },
+      { _id: 'l6', name: 'Aliqua Systems' },
+      { _id: 'l7', name: 'Veniam Group' },
+      { _id: 'l8', name: 'Tempor Holdings' },
+    ],
   },
 }

--- a/astro-app/src/components/blocks/custom/RichText.astro
+++ b/astro-app/src/components/blocks/custom/RichText.astro
@@ -2,16 +2,17 @@
 import type { RichTextBlock } from '@/lib/types';
 import { Section, SectionProse } from '@/components/ui/section';
 
-interface Props {
-  block: RichTextBlock;
+interface Props extends RichTextBlock {
+  class?: string;
+  id?: string;
 }
 
-const { block } = Astro.props;
+const { content } = Astro.props;
 ---
 
 <Section data-animate>
   <SectionProse>
-    {(block.content ?? []).map((b) => {
+    {(content ?? []).map((b) => {
       if (b._type !== 'block') return null;
       const text = (b.children ?? []).map((c) => c.text).join('');
       switch (b.style) {

--- a/astro-app/src/components/blocks/custom/RichText.stories.ts
+++ b/astro-app/src/components/blocks/custom/RichText.stories.ts
@@ -8,66 +8,62 @@ export default {
 
 export const Default = {
   args: {
-    block: {
-      _type: 'richText',
-      _key: 'story-rt-1',
-      content: [
-        {
-          _type: 'block',
-          _key: 'b1',
-          style: 'h2',
-          children: [{ _type: 'span', text: 'Lorem Ipsum Dolor Sit Amet' }],
-        },
-        {
-          _type: 'block',
-          _key: 'b2',
-          children: [{ _type: 'span', text: 'Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur.' }],
-        },
-        {
-          _type: 'block',
-          _key: 'b3',
-          style: 'h3',
-          children: [{ _type: 'span', text: 'Consectetur Adipiscing Elit' }],
-        },
-        {
-          _type: 'block',
-          _key: 'b4',
-          children: [{ _type: 'span', text: 'At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum deleniti atque corrupti quos dolores et quas molestias excepturi sint occaecati cupiditate.' }],
-        },
-        {
-          _type: 'block',
-          _key: 'b5',
-          style: 'h4',
-          children: [{ _type: 'span', text: 'Sed Do Eiusmod Tempor' }],
-        },
-        {
-          _type: 'block',
-          _key: 'b6',
-          children: [{ _type: 'span', text: 'Nam libero tempore, cum soluta nobis est eligendi optio cumque nihil impedit quo minus id quod maxime placeat facere possimus, omnis voluptas assumenda est omnis dolor repellendus.' }],
-        },
-      ],
-    },
+    _type: 'richText',
+    _key: 'story-rt-1',
+    content: [
+      {
+        _type: 'block',
+        _key: 'b1',
+        style: 'h2',
+        children: [{ _type: 'span', text: 'Lorem Ipsum Dolor Sit Amet' }],
+      },
+      {
+        _type: 'block',
+        _key: 'b2',
+        children: [{ _type: 'span', text: 'Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur.' }],
+      },
+      {
+        _type: 'block',
+        _key: 'b3',
+        style: 'h3',
+        children: [{ _type: 'span', text: 'Consectetur Adipiscing Elit' }],
+      },
+      {
+        _type: 'block',
+        _key: 'b4',
+        children: [{ _type: 'span', text: 'At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum deleniti atque corrupti quos dolores et quas molestias excepturi sint occaecati cupiditate.' }],
+      },
+      {
+        _type: 'block',
+        _key: 'b5',
+        style: 'h4',
+        children: [{ _type: 'span', text: 'Sed Do Eiusmod Tempor' }],
+      },
+      {
+        _type: 'block',
+        _key: 'b6',
+        children: [{ _type: 'span', text: 'Nam libero tempore, cum soluta nobis est eligendi optio cumque nihil impedit quo minus id quod maxime placeat facere possimus, omnis voluptas assumenda est omnis dolor repellendus.' }],
+      },
+    ],
   },
 }
 
 export const ShortContent = {
   args: {
-    block: {
-      _type: 'richText',
-      _key: 'story-rt-2',
-      content: [
-        {
-          _type: 'block',
-          _key: 'b1',
-          style: 'h2',
-          children: [{ _type: 'span', text: 'Lorem Ipsum Notice' }],
-        },
-        {
-          _type: 'block',
-          _key: 'b2',
-          children: [{ _type: 'span', text: 'Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.' }],
-        },
-      ],
-    },
+    _type: 'richText',
+    _key: 'story-rt-2',
+    content: [
+      {
+        _type: 'block',
+        _key: 'b1',
+        style: 'h2',
+        children: [{ _type: 'span', text: 'Lorem Ipsum Notice' }],
+      },
+      {
+        _type: 'block',
+        _key: 'b2',
+        children: [{ _type: 'span', text: 'Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.' }],
+      },
+    ],
   },
 }

--- a/astro-app/src/components/blocks/custom/SponsorCards.astro
+++ b/astro-app/src/components/blocks/custom/SponsorCards.astro
@@ -6,11 +6,12 @@ import { Badge } from '@/components/ui/badge';
 import { Icon } from '@/components/ui/icon';
 import { stegaClean } from '@sanity/client/stega';
 
-interface Props {
-  block: SponsorCardsBlock;
+interface Props extends SponsorCardsBlock {
+  class?: string;
+  id?: string;
 }
 
-const { block } = Astro.props;
+const { heading, sponsors } = Astro.props;
 
 const tierStyles: Record<string, { border: string; badge: string }> = {
   platinum: { border: 'border-foreground', badge: 'bg-foreground text-background border-foreground' },
@@ -21,14 +22,14 @@ const tierStyles: Record<string, { border: string; badge: string }> = {
 ---
 
 <Section data-animate>
-  {block.heading && (
+  {heading && (
     <SectionContent>
-      <h2 class="text-4xl md:text-5xl font-bold tracking-[-0.03em] leading-[1.05]">{block.heading}</h2>
+      <h2 class="text-4xl md:text-5xl font-bold tracking-[-0.03em] leading-[1.05]">{heading}</h2>
     </SectionContent>
   )}
 
   <SectionGrid size="lg">
-    {(block.sponsors ?? []).map((sponsor) => {
+    {(sponsors ?? []).map((sponsor) => {
       const tier = tierStyles[stegaClean(sponsor.tier) || 'silver'];
       const logoUrl = sponsor.logo?.asset?.url;
       return (

--- a/astro-app/src/components/blocks/custom/SponsorCards.stories.ts
+++ b/astro-app/src/components/blocks/custom/SponsorCards.stories.ts
@@ -8,62 +8,58 @@ export default {
 
 export const Default = {
   args: {
-    block: {
-      _type: 'sponsorCards',
-      _key: 'story-sponsors-1',
-      heading: 'Lorem Ipsum Partners',
-      sponsors: [
-        {
-          _id: 'sp1',
-          name: 'Acme Corp',
-          tier: 'platinum',
-          description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt.',
-          website: 'https://example.com',
-        },
-        {
-          _id: 'sp2',
-          name: 'Ipsum Solutions',
-          tier: 'gold',
-          description: 'Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip.',
-          website: 'https://example.com',
-        },
-        {
-          _id: 'sp3',
-          name: 'Dolor Tech',
-          tier: 'gold',
-          description: 'Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore.',
-        },
-        {
-          _id: 'sp4',
-          name: 'Sit Amet Inc',
-          tier: 'silver',
-          description: 'Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt.',
-        },
-      ],
-    },
+    _type: 'sponsorCards',
+    _key: 'story-sponsors-1',
+    heading: 'Lorem Ipsum Partners',
+    sponsors: [
+      {
+        _id: 'sp1',
+        name: 'Acme Corp',
+        tier: 'platinum',
+        description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt.',
+        website: 'https://example.com',
+      },
+      {
+        _id: 'sp2',
+        name: 'Ipsum Solutions',
+        tier: 'gold',
+        description: 'Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip.',
+        website: 'https://example.com',
+      },
+      {
+        _id: 'sp3',
+        name: 'Dolor Tech',
+        tier: 'gold',
+        description: 'Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore.',
+      },
+      {
+        _id: 'sp4',
+        name: 'Sit Amet Inc',
+        tier: 'silver',
+        description: 'Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt.',
+      },
+    ],
   },
 }
 
 export const Minimal = {
   args: {
-    block: {
-      _type: 'sponsorCards',
-      _key: 'story-sponsors-2',
-      heading: 'Our Partners',
-      sponsors: [
-        {
-          _id: 'sp1',
-          name: 'Magna Global',
-          tier: 'silver',
-          description: 'Lorem ipsum dolor sit amet consectetur.',
-        },
-        {
-          _id: 'sp2',
-          name: 'Veniam Group',
-          tier: 'silver',
-          description: 'Sed do eiusmod tempor incididunt.',
-        },
-      ],
-    },
+    _type: 'sponsorCards',
+    _key: 'story-sponsors-2',
+    heading: 'Our Partners',
+    sponsors: [
+      {
+        _id: 'sp1',
+        name: 'Magna Global',
+        tier: 'silver',
+        description: 'Lorem ipsum dolor sit amet consectetur.',
+      },
+      {
+        _id: 'sp2',
+        name: 'Veniam Group',
+        tier: 'silver',
+        description: 'Sed do eiusmod tempor incididunt.',
+      },
+    ],
   },
 }

--- a/astro-app/src/components/blocks/custom/SponsorSteps.astro
+++ b/astro-app/src/components/blocks/custom/SponsorSteps.astro
@@ -18,24 +18,25 @@ import {
   TileTitle,
 } from '@/components/ui/tile';
 
-interface Props {
-  block: SponsorStepsBlock;
+interface Props extends SponsorStepsBlock {
+  class?: string;
+  id?: string;
 }
 
-const { block } = Astro.props;
+const { heading, subheading, items, ctaButtons } = Astro.props;
 ---
 
 <Section>
   <SectionContent>
-    {(block.heading || block.subheading) && (
+    {(heading || subheading) && (
       <SectionProse>
-        {block.heading && <h2>{block.heading}</h2>}
-        {block.subheading && <p>{block.subheading}</p>}
+        {heading && <h2>{heading}</h2>}
+        {subheading && <p>{subheading}</p>}
       </SectionProse>
     )}
     <SectionActions>
       {
-        block.ctaButtons?.map((btn, i) => (
+        ctaButtons?.map((btn, i) => (
           <Button variant={i === 0 ? 'default' : 'outline'} href={btn.url}>
             {btn.text}
           </Button>
@@ -46,7 +47,7 @@ const { block } = Astro.props;
       class="before:bg-border relative gap-8 before:absolute before:left-5.5 before:h-full before:w-px before:@5xl:top-5.5 before:@5xl:h-px before:@5xl:w-full"
     >
       {
-        (block.items ?? []).map(({ title, description, list }, i) => (
+        (items ?? []).map(({ title, description, list }, i) => (
           <Tile class="items-start gap-8 gap-x-4 @max-5xl:flex-row">
             <TileMedia variant="icon">{i + 1}</TileMedia>
             <TileContent class="p-0">

--- a/astro-app/src/components/blocks/custom/SponsorSteps.stories.ts
+++ b/astro-app/src/components/blocks/custom/SponsorSteps.stories.ts
@@ -8,40 +8,38 @@ export default {
 
 export const Default = {
   args: {
-    block: {
-      _type: 'sponsorSteps',
-      _key: 'story-steps-1',
-      headline: 'How to Become a Sponsor',
-      subtitle: 'Follow these steps to begin your sponsorship journey.',
-      items: [
-        {
-          _key: 'ss1',
-          title: 'Initial Inquiry',
-          description: 'Submit your interest through our sponsorship form.',
-          list: [
-            'Provide company information',
-            'Indicate areas of interest',
-          ],
-        },
-        {
-          _key: 'ss2',
-          title: 'Consultation Meeting',
-          description: 'Schedule a meeting with our team to discuss goals.',
-          list: [
-            'Technical challenges and goals',
-            'Timeline and expectations',
-          ],
-        },
-        {
-          _key: 'ss3',
-          title: 'Agreement Signing',
-          description: 'Complete the sponsorship process.',
-          list: [
-            'Review sponsorship agreement',
-            'Finalize project scope',
-          ],
-        },
-      ],
-    },
+    _type: 'sponsorSteps',
+    _key: 'story-steps-1',
+    headline: 'How to Become a Sponsor',
+    subtitle: 'Follow these steps to begin your sponsorship journey.',
+    items: [
+      {
+        _key: 'ss1',
+        title: 'Initial Inquiry',
+        description: 'Submit your interest through our sponsorship form.',
+        list: [
+          'Provide company information',
+          'Indicate areas of interest',
+        ],
+      },
+      {
+        _key: 'ss2',
+        title: 'Consultation Meeting',
+        description: 'Schedule a meeting with our team to discuss goals.',
+        list: [
+          'Technical challenges and goals',
+          'Timeline and expectations',
+        ],
+      },
+      {
+        _key: 'ss3',
+        title: 'Agreement Signing',
+        description: 'Complete the sponsorship process.',
+        list: [
+          'Review sponsorship agreement',
+          'Finalize project scope',
+        ],
+      },
+    ],
   },
 }

--- a/astro-app/src/components/blocks/custom/StatsRow.astro
+++ b/astro-app/src/components/blocks/custom/StatsRow.astro
@@ -3,12 +3,13 @@ import type { StatsRowBlock } from '@/lib/types';
 import { Section } from '@/components/ui/section';
 import { stegaClean } from '@sanity/client/stega';
 
-interface Props {
-  block: StatsRowBlock;
+interface Props extends StatsRowBlock {
+  class?: string;
+  id?: string;
 }
 
-const { block } = Astro.props;
-const isDark = stegaClean(block.backgroundVariant) === 'dark';
+const { heading, stats, backgroundVariant } = Astro.props;
+const isDark = stegaClean(backgroundVariant) === 'dark';
 ---
 
 <Section
@@ -16,11 +17,11 @@ const isDark = stegaClean(block.backgroundVariant) === 'dark';
   class={`border-y-2 ${isDark ? 'bg-foreground text-background border-foreground' : 'bg-muted border-border'}`}
   data-animate
 >
-  {block.heading && (
-    <h2 class="text-2xl md:text-3xl font-bold tracking-[-0.03em] text-center mb-8">{block.heading}</h2>
+  {heading && (
+    <h2 class="text-2xl md:text-3xl font-bold tracking-[-0.03em] text-center mb-8">{heading}</h2>
   )}
   <div class="grid grid-cols-2 md:grid-cols-4 gap-8 md:gap-12">
-    {(block.stats ?? []).map((stat) => (
+    {(stats ?? []).map((stat) => (
       <div class="text-center">
         <div class="text-4xl md:text-6xl font-bold tracking-[-0.04em] leading-none mb-3">
           {stat.value}

--- a/astro-app/src/components/blocks/custom/StatsRow.stories.ts
+++ b/astro-app/src/components/blocks/custom/StatsRow.stories.ts
@@ -9,47 +9,41 @@ export default {
 
 export const Light = {
   args: {
-    block: {
-      _type: 'statsRow',
-      _key: 'story-stats-1',
-      heading: 'By the Numbers',
-      backgroundVariant: 'light',
-      stats: [
-        { _key: 's1', value: '100+', label: 'Lorem Ipsum' },
-        { _key: 's2', value: '200+', label: 'Dolor Sit' },
-        { _key: 's3', value: '50+', label: 'Amet Consectetur' },
-        { _key: 's4', value: '99%', label: 'Adipiscing Elit' },
-      ],
-    },
+    _type: 'statsRow',
+    _key: 'story-stats-1',
+    heading: 'By the Numbers',
+    backgroundVariant: 'light',
+    stats: [
+      { _key: 's1', value: '100+', label: 'Lorem Ipsum' },
+      { _key: 's2', value: '200+', label: 'Dolor Sit' },
+      { _key: 's3', value: '50+', label: 'Amet Consectetur' },
+      { _key: 's4', value: '99%', label: 'Adipiscing Elit' },
+    ],
   },
 }
 
 export const Dark = {
   args: {
-    block: {
-      _type: 'statsRow',
-      _key: 'story-stats-2',
-      backgroundVariant: 'dark',
-      stats: [
-        { _key: 's1', value: '100+', label: 'Lorem Ipsum' },
-        { _key: 's2', value: '200+', label: 'Dolor Sit' },
-        { _key: 's3', value: '50+', label: 'Amet Consectetur' },
-        { _key: 's4', value: '99%', label: 'Adipiscing Elit' },
-      ],
-    },
+    _type: 'statsRow',
+    _key: 'story-stats-2',
+    backgroundVariant: 'dark',
+    stats: [
+      { _key: 's1', value: '100+', label: 'Lorem Ipsum' },
+      { _key: 's2', value: '200+', label: 'Dolor Sit' },
+      { _key: 's3', value: '50+', label: 'Amet Consectetur' },
+      { _key: 's4', value: '99%', label: 'Adipiscing Elit' },
+    ],
   },
 }
 
 export const TwoStats = {
   args: {
-    block: {
-      _type: 'statsRow',
-      _key: 'story-stats-3',
-      backgroundVariant: 'light',
-      stats: [
-        { _key: 's1', value: '10', label: 'Lorem Ipsum' },
-        { _key: 's2', value: '15', label: 'Dolor Sit' },
-      ],
-    },
+    _type: 'statsRow',
+    _key: 'story-stats-3',
+    backgroundVariant: 'light',
+    stats: [
+      { _key: 's1', value: '10', label: 'Lorem Ipsum' },
+      { _key: 's2', value: '15', label: 'Dolor Sit' },
+    ],
   },
 }

--- a/astro-app/src/components/blocks/custom/TextWithImage.astro
+++ b/astro-app/src/components/blocks/custom/TextWithImage.astro
@@ -4,24 +4,25 @@ import { Section, SectionSplit, SectionContent, SectionMedia } from '@/component
 import { PortableText } from 'astro-portabletext';
 import { stegaClean } from '@sanity/client/stega';
 
-interface Props {
-  block: TextWithImageBlock;
+interface Props extends TextWithImageBlock {
+  class?: string;
+  id?: string;
 }
 
-const { block } = Astro.props;
-const isRight = stegaClean(block.imagePosition) !== 'left';
-const imgSrc = block.image?.asset?.url;
+const { heading, content, image, imagePosition } = Astro.props;
+const isRight = stegaClean(imagePosition) !== 'left';
+const imgSrc = image?.asset?.url;
 ---
 
 <Section data-animate>
   <SectionSplit>
     <SectionContent class="justify-center">
-      {block.heading && (
-        <h2 class="text-3xl md:text-4xl font-bold tracking-[-0.03em] leading-[1.1]">{block.heading}</h2>
+      {heading && (
+        <h2 class="text-3xl md:text-4xl font-bold tracking-[-0.03em] leading-[1.1]">{heading}</h2>
       )}
-      {block.content && (
+      {content && (
         <div class="text-muted-foreground leading-relaxed prose">
-          <PortableText value={block.content} />
+          <PortableText value={content} />
         </div>
       )}
     </SectionContent>
@@ -30,7 +31,7 @@ const imgSrc = block.image?.asset?.url;
       {imgSrc && (
         <img
           src={imgSrc}
-          alt={block.image?.alt || block.heading || ''}
+          alt={image?.alt || heading || ''}
           class="w-full h-full object-cover"
           loading="lazy"
         />

--- a/astro-app/src/components/blocks/custom/TextWithImage.stories.ts
+++ b/astro-app/src/components/blocks/custom/TextWithImage.stories.ts
@@ -8,44 +8,38 @@ export default {
 
 export const ImageRight = {
   args: {
-    block: {
-      _type: 'textWithImage',
-      _key: 'story-twi-1',
-      heading: 'Lorem Ipsum Dolor Sit Amet Elit',
-      content: [
-        { _type: 'block', _key: 'b1', style: 'normal', children: [{ _type: 'span', _key: 's1', text: 'Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis.' }] },
-      ],
-      image: { asset: { url: 'https://placehold.co/800x600/e2e8f0/475569?text=Placeholder' }, alt: 'Placeholder image' },
-      imagePosition: 'right',
-    },
+    _type: 'textWithImage',
+    _key: 'story-twi-1',
+    heading: 'Lorem Ipsum Dolor Sit Amet Elit',
+    content: [
+      { _type: 'block', _key: 'b1', style: 'normal', children: [{ _type: 'span', _key: 's1', text: 'Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis.' }] },
+    ],
+    image: { asset: { url: 'https://placehold.co/800x600/e2e8f0/475569?text=Placeholder' }, alt: 'Placeholder image' },
+    imagePosition: 'right',
   },
 }
 
 export const ImageLeft = {
   args: {
-    block: {
-      _type: 'textWithImage',
-      _key: 'story-twi-2',
-      heading: 'Consectetur Adipiscing Elit Sed Do',
-      content: [
-        { _type: 'block', _key: 'b1', style: 'normal', children: [{ _type: 'span', _key: 's1', text: 'Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt.' }] },
-      ],
-      image: { asset: { url: 'https://placehold.co/800x600/e2e8f0/475569?text=Placeholder' }, alt: 'Placeholder image' },
-      imagePosition: 'left',
-    },
+    _type: 'textWithImage',
+    _key: 'story-twi-2',
+    heading: 'Consectetur Adipiscing Elit Sed Do',
+    content: [
+      { _type: 'block', _key: 'b1', style: 'normal', children: [{ _type: 'span', _key: 's1', text: 'Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt.' }] },
+    ],
+    image: { asset: { url: 'https://placehold.co/800x600/e2e8f0/475569?text=Placeholder' }, alt: 'Placeholder image' },
+    imagePosition: 'left',
   },
 }
 
 export const Minimal = {
   args: {
-    block: {
-      _type: 'textWithImage',
-      _key: 'story-twi-3',
-      heading: 'Eiusmod Tempor Incididunt',
-      content: [
-        { _type: 'block', _key: 'b1', style: 'normal', children: [{ _type: 'span', _key: 's1', text: 'Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.' }] },
-      ],
-      image: { asset: { url: 'https://placehold.co/800x600/e2e8f0/475569?text=Placeholder' }, alt: 'Placeholder image' },
-    },
+    _type: 'textWithImage',
+    _key: 'story-twi-3',
+    heading: 'Eiusmod Tempor Incididunt',
+    content: [
+      { _type: 'block', _key: 'b1', style: 'normal', children: [{ _type: 'span', _key: 's1', text: 'Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.' }] },
+    ],
+    image: { asset: { url: 'https://placehold.co/800x600/e2e8f0/475569?text=Placeholder' }, alt: 'Placeholder image' },
   },
 }


### PR DESCRIPTION
## Summary

This PR is a **pure refactoring** — it changes *how* block components receive their data, but the actual website looks and behaves exactly the same before and after.

### What changed and why?

Our project has two kinds of blocks:
- **Custom blocks** (like HeroBanner, FaqSection, ContactForm) — blocks we wrote ourselves
- **fulldev/ui blocks** (like hero-1, features-3) — blocks from the fulldev/ui library

Before this PR, these two kinds of blocks received their data differently:

| | Custom blocks (before) | fulldev/ui blocks |
|---|---|---|
| **How they got data** | Wrapped in a `block` prop: `<HeroBanner block={data} />` | Spread as individual props: `<Hero1 heading="..." subheading="..." />` |
| **How they read data** | `block.heading`, `block.subheading` | `heading`, `subheading` (directly) |
| **Dispatch in BlockRenderer** | Separate `customBlocks` map | Separate `uiBlocks` map |

This meant BlockRenderer had **two code paths** — one for each style. That's unnecessary complexity.

**After this PR**, everything uses the same pattern:

```astro
<!-- Every block now receives spread props -->
<Component {...block} />
```

### What does "spread props" mean?

Think of it like unpacking a suitcase. Instead of passing the whole suitcase:

```js
// BEFORE: pass the whole object as one prop called "block"
<HeroBanner block={{ heading: "Hello", subheading: "World" }} />
// Component reads: block.heading, block.subheading
```

We unpack it and pass each item individually:

```js
// AFTER: spread each property as its own prop
<HeroBanner heading="Hello" subheading="World" />
// Component reads: heading, subheading (directly)
```

The `{...block}` syntax (the "spread operator") does this unpacking automatically.

### Files changed (35 total)

| Category | Files | What changed |
|---|---|---|
| **BlockRenderer** | `BlockRenderer.astro`, `block-registry.ts` | Merged two block maps into one; single dispatch path |
| **11 Components** | `blocks/custom/*.astro` | Props interface: `{ block: X }` → `extends X`; template: `block.heading` → `heading` |
| **11 Stories** | `blocks/custom/*.stories.ts` | Story args: `{ block: { ... } }` → `{ ... }` (flat) |
| **11 Tests** | `__tests__/*.test.ts` | Test props: `{ block: fixture }` → `fixture` (flat) |

### What did NOT change

- No Sanity schemas touched
- No GROQ queries changed
- No TypeScript type definitions changed (`types.ts` is identical)
- No visual changes — every page renders identically
- No new dependencies

## Test plan

- [x] All 356 Vitest tests pass (unit + component + integration)
- [x] `astro check` — 0 errors, 0 warnings
- [x] `astro build` — clean build
- [x] Storybook build passes (verified via integration test)
- [ ] Visual spot-check: homepage renders all blocks correctly
- [ ] Storybook: stories render with correct data