### PR TITLE
fix: code review fixes for Stories 2.11, 2.12, 4.3, 4.4

### DIFF
--- a/astro-app/src/components/blocks/custom/EventList.stories.ts
+++ b/astro-app/src/components/blocks/custom/EventList.stories.ts
@@ -1,4 +1,5 @@
 import EventList from './EventList.astro'
+import { eventsData } from '../../__tests__/__fixtures__/events'
 
 export default {
   title: 'Blocks/EventList',
@@ -6,68 +7,8 @@ export default {
   tags: ['autodocs'],
 }
 
-const upcomingEvents = [
-  {
-    _id: 'event-1',
-    title: 'Spring Showcase 2026',
-    slug: 'spring-showcase-2026',
-    date: '2026-04-15T14:00:00Z',
-    endDate: '2026-04-15T18:00:00Z',
-    location: 'NJIT Campus Center Ballroom',
-    description: 'Join us for our Spring 2026 Capstone Showcase where student teams present their projects to industry sponsors and faculty.',
-    eventType: 'showcase',
-    status: 'upcoming',
-  },
-  {
-    _id: 'event-2',
-    title: 'Sponsor Networking Mixer',
-    slug: 'sponsor-networking-mixer',
-    date: '2026-03-20T17:30:00Z',
-    endDate: '2026-03-20T19:30:00Z',
-    location: 'Ying Wu College of Computing',
-    description: 'An evening networking event connecting industry sponsors with student development teams.',
-    eventType: 'networking',
-    status: 'upcoming',
-  },
-  {
-    _id: 'event-5',
-    title: 'Agile Methods Workshop',
-    slug: 'agile-methods-workshop',
-    date: '2026-02-28T13:00:00Z',
-    endDate: null,
-    location: 'Virtual (Zoom)',
-    description: 'Learn agile development methodologies including Scrum and Kanban. Perfect for teams starting their capstone projects.',
-    eventType: 'workshop',
-    status: 'upcoming',
-  },
-]
-
-const pastEvents = [
-  {
-    _id: 'event-3',
-    title: 'Git & CI/CD Workshop',
-    slug: 'git-cicd-workshop',
-    date: '2025-11-10T10:00:00Z',
-    endDate: '2025-11-10T12:00:00Z',
-    location: 'GITC Room 3700',
-    description: 'Hands-on workshop covering Git branching strategies, pull request workflows, and CI/CD pipeline setup.',
-    eventType: 'workshop',
-    status: 'past',
-  },
-  {
-    _id: 'event-4',
-    title: 'Fall 2025 Showcase',
-    slug: 'fall-2025-showcase',
-    date: '2025-12-05T14:00:00Z',
-    endDate: null,
-    location: null,
-    description: null,
-    eventType: 'showcase',
-    status: 'past',
-  },
-]
-
-const allEvents = [...upcomingEvents, ...pastEvents]
+const upcomingEvents = eventsData.filter(e => e.status === 'upcoming')
+const pastEvents = eventsData.filter(e => e.status === 'past')
 
 export const Default = {
   args: {
@@ -87,7 +28,7 @@ export const AllEvents = {
     heading: 'All Events',
     filterBy: 'all',
     limit: 10,
-    events: allEvents,
+    events: eventsData,
   },
 }
 

--- a/astro-app/src/components/blocks/custom/Testimonials.astro
+++ b/astro-app/src/components/blocks/custom/Testimonials.astro
@@ -56,11 +56,15 @@ if (isByProject) {
     </SectionContent>
   ) : (
     <SectionContent>
-      <div class="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
-        {testimonials.map((t) => (
-          <TestimonialCard testimonial={t} />
-        ))}
-      </div>
+      {testimonials.length > 0 ? (
+        <div class="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+          {testimonials.map((t) => (
+            <TestimonialCard testimonial={t} />
+          ))}
+        </div>
+      ) : (
+        <p class="text-muted-foreground text-center py-8">No testimonials to display.</p>
+      )}
     </SectionContent>
   )}
 </Section>

--- a/astro-app/src/components/blocks/custom/Testimonials.stories.ts
+++ b/astro-app/src/components/blocks/custom/Testimonials.stories.ts
@@ -1,4 +1,5 @@
 import Testimonials from './Testimonials.astro'
+import { testimonialsData } from '../../__tests__/__fixtures__/testimonials'
 
 export default {
   title: 'Blocks/Testimonials',
@@ -6,52 +7,8 @@ export default {
   tags: ['autodocs'],
 }
 
-const industryTestimonials = [
-  {
-    _id: 't1',
-    name: 'Jane Smith',
-    quote: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore.',
-    role: 'CTO',
-    organization: 'Acme Corp',
-    type: 'industry',
-    photo: {
-      asset: { _id: 'image-Tb9Ew8CXIwaY6R1kjMvI0uRR-200x200-png', url: 'https://cdn.sanity.io/images/test/test/Tb9Ew8CXIwaY6R1kjMvI0uRR-200x200.png', metadata: null },
-      alt: 'Jane Smith photo',
-      hotspot: null,
-      crop: null,
-    },
-    project: { _id: 'p1', title: 'AI Dashboard', slug: 'ai-dashboard' },
-  },
-  {
-    _id: 't2',
-    name: 'Maria Garcia',
-    quote: 'Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo.',
-    role: 'VP of Engineering',
-    organization: 'Beta Inc',
-    type: 'industry',
-  },
-]
-
-const studentTestimonials = [
-  {
-    _id: 't3',
-    name: 'John Doe',
-    quote: 'Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.',
-    role: 'Student',
-    organization: 'NJIT',
-    type: 'student',
-    project: { _id: 'p1', title: 'AI Dashboard', slug: 'ai-dashboard' },
-  },
-  {
-    _id: 't4',
-    name: 'Alex Chen',
-    quote: 'Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim.',
-    type: 'student',
-    project: { _id: 'p2', title: 'Mobile App', slug: 'mobile-app' },
-  },
-]
-
-const allTestimonials = [...industryTestimonials, ...studentTestimonials]
+const industryTestimonials = testimonialsData.filter(t => t.type === 'industry')
+const studentTestimonials = testimonialsData.filter(t => t.type === 'student')
 
 export const Default = {
   args: {
@@ -59,7 +16,7 @@ export const Default = {
     _key: 'story-tm-1',
     heading: 'What People Say',
     displayMode: 'all',
-    testimonials: allTestimonials,
+    testimonials: testimonialsData,
   },
 }
 
@@ -89,7 +46,7 @@ export const ByProject = {
     _key: 'story-tm-4',
     heading: 'Impact Case Studies',
     displayMode: 'byProject',
-    testimonials: allTestimonials.filter(t => t.project),
+    testimonials: testimonialsData.filter(t => t.project != null),
   },
 }
 
@@ -99,7 +56,7 @@ export const Manual = {
     _key: 'story-tm-5',
     heading: 'Featured Testimonials',
     displayMode: 'manual',
-    testimonials: [allTestimonials[0]],
+    testimonials: [testimonialsData[0]],
   },
 }
 

--- a/astro-app/src/lib/sanity.ts
+++ b/astro-app/src/lib/sanity.ts
@@ -287,8 +287,8 @@ export function resolveBlockTestimonials(
 ): Testimonial[] {
   const mode = stegaClean(block.displayMode) ?? 'all';
   if (mode === 'all') return allTestimonials;
-  if (mode === 'industry') return allTestimonials.filter(t => t.type === 'industry');
-  if (mode === 'student') return allTestimonials.filter(t => t.type === 'student');
+  if (mode === 'industry') return allTestimonials.filter(t => stegaClean(t.type) === 'industry');
+  if (mode === 'student') return allTestimonials.filter(t => stegaClean(t.type) === 'student');
   if (mode === 'byProject') return allTestimonials.filter(t => t.project != null);
   // manual
   const manualIds = new Set(block.testimonials?.map(t => t._id) ?? []);

--- a/astro-app/src/pages/projects/[slug].astro
+++ b/astro-app/src/pages/projects/[slug].astro
@@ -1,0 +1,188 @@
+---
+import type { GetStaticPaths } from 'astro';
+import Layout from '@/layouts/Layout.astro';
+import Breadcrumb from '@/components/Breadcrumb.astro';
+import TestimonialCard from '@/components/TestimonialCard.astro';
+import type { Testimonial } from '@/lib/sanity';
+import { sanityClient, ALL_PROJECT_SLUGS_QUERY, getProjectBySlug } from '@/lib/sanity';
+import { urlFor } from '@/lib/image';
+import { stegaClean } from '@sanity/client/stega';
+import { Badge } from '@/components/ui/badge';
+import { Section, SectionContent } from '@/components/ui/section';
+import { PortableText } from 'astro-portabletext';
+
+export const getStaticPaths: GetStaticPaths = async () => {
+  const projects = await sanityClient.fetch<Array<{ slug: string }>>(ALL_PROJECT_SLUGS_QUERY);
+  return projects.map((p) => ({ params: { slug: p.slug } }));
+};
+
+const { slug } = Astro.params;
+const project = await getProjectBySlug(slug as string);
+if (!project) return Astro.redirect('/404');
+
+const statusStyles: Record<string, string> = {
+  active: 'bg-green-100 text-green-800 border-green-300',
+  completed: 'bg-blue-100 text-blue-800 border-blue-300',
+  archived: 'bg-muted text-muted-foreground border-border',
+};
+
+const tierStyles: Record<string, { badge: string }> = {
+  platinum: { badge: 'bg-foreground text-background border-foreground' },
+  gold: { badge: 'bg-njit-gold text-foreground border-njit-gold' },
+  silver: { badge: 'bg-muted-foreground text-background border-muted-foreground' },
+  bronze: { badge: 'bg-amber-700 text-background border-amber-700' },
+};
+
+const cleanStatus = stegaClean(project.status) || 'active';
+const sponsor = project.sponsor;
+const cleanTier = stegaClean(sponsor?.tier) || 'silver';
+const sponsorSlug = sponsor ? stegaClean(sponsor.slug) : null;
+
+function sponsorLogoUrl(logo: NonNullable<typeof sponsor>['logo']) {
+  return logo ? urlFor(logo as unknown as Parameters<typeof urlFor>[0]).width(200).height(200).url() : null;
+}
+
+const logoUrl = sponsor?.logo ? sponsorLogoUrl(sponsor.logo) : null;
+const team = project.team ?? [];
+const techs = project.technologyTags ?? [];
+const testimonials = (project.testimonials ?? []) as unknown as Testimonial[];
+---
+
+<Layout title={project.title ?? 'Project'}>
+  <!-- Header with breadcrumb, title, status, semester -->
+  <Section>
+    <SectionContent>
+      <Breadcrumb items={[
+        { label: 'Home', href: '/' },
+        { label: 'Projects', href: '/projects' },
+        { label: project.title ?? 'Project' },
+      ]} />
+
+      <div class="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+        <div class="flex items-center gap-4">
+          <h1 class="text-4xl md:text-5xl font-bold tracking-[-0.03em] leading-[1.05]">
+            {project.title}
+          </h1>
+          <Badge class={statusStyles[cleanStatus] || statusStyles.active}>{cleanStatus}</Badge>
+        </div>
+        {project.semester && (
+          <p class="text-muted-foreground text-sm">{project.semester}</p>
+        )}
+      </div>
+    </SectionContent>
+  </Section>
+
+  <!-- Detail content — single section with tighter spacing -->
+  <Section size="sm">
+    <SectionContent class="gap-y-10">
+      <!-- Sponsor -->
+      {sponsor && (
+        <div>
+          <h2 class="text-2xl font-bold mb-4">Sponsor</h2>
+          <div class="flex flex-col md:flex-row gap-6 items-start">
+            {logoUrl && (
+              <div class="w-[200px] h-[200px] bg-muted flex items-center justify-center flex-shrink-0 border border-border overflow-hidden">
+                <img
+                  src={logoUrl}
+                  alt={sponsor.logo?.alt || `${sponsor.name} logo`}
+                  class="w-full h-full object-cover"
+                  width="200"
+                  height="200"
+                  loading="lazy"
+                />
+              </div>
+            )}
+            <div class="flex flex-col gap-2">
+              <div class="flex items-center gap-3">
+                <a
+                  href={`/sponsors/${sponsorSlug}`}
+                  class="text-xl font-semibold text-primary hover:text-primary/80"
+                >
+                  {sponsor.name}
+                </a>
+                {sponsor.tier && (
+                  <Badge class={tierStyles[cleanTier]?.badge || tierStyles.silver.badge}>{sponsor.tier}</Badge>
+                )}
+              </div>
+              {sponsor.industry && (
+                <p class="text-sm text-muted-foreground">{sponsor.industry}</p>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+
+      <!-- Problem & Approach -->
+      {project.content && (
+        <div>
+          <h2 class="text-2xl font-bold mb-4">Problem & Approach</h2>
+          <div class="prose max-w-none">
+            <PortableText value={project.content} />
+          </div>
+        </div>
+      )}
+
+      <!-- Technology Stack -->
+      {techs.length > 0 && (
+        <div>
+          <h2 class="text-2xl font-bold mb-4">Technology Stack</h2>
+          <div class="flex flex-wrap gap-2">
+            {techs.map((tag) => (
+              <Badge variant="outline">{tag}</Badge>
+            ))}
+          </div>
+        </div>
+      )}
+
+      <!-- Team -->
+      {team.length > 0 && (
+        <div>
+          <h2 class="text-2xl font-bold mb-4">Team</h2>
+          <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {team.map((member) => (
+              <div class="flex flex-col gap-1 rounded-lg border border-border bg-card p-4">
+                <span class="font-semibold">{member.name}</span>
+                {member.role && (
+                  <span class="text-sm text-muted-foreground">{member.role}</span>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      <!-- Mentor -->
+      {project.mentor && (
+        <div>
+          <h2 class="text-2xl font-bold mb-4">Mentor</h2>
+          <p class="text-lg">{project.mentor}</p>
+        </div>
+      )}
+
+      <!-- Outcome & Impact -->
+      {project.outcome && (
+        <div>
+          <h2 class="text-2xl font-bold mb-4">Outcome & Impact</h2>
+          <p class="text-lg leading-relaxed">{project.outcome}</p>
+        </div>
+      )}
+
+      <!-- Testimonials -->
+      {testimonials.length > 0 && (
+        <div>
+          <h2 class="text-2xl font-bold mb-4">Testimonials</h2>
+          <div class="grid gap-6 md:grid-cols-2">
+            {testimonials.map((t) => (
+              <TestimonialCard testimonial={t} />
+            ))}
+          </div>
+        </div>
+      )}
+
+      <!-- Back to Projects -->
+      <a href="/projects" class="inline-flex items-center gap-2 text-muted-foreground hover:text-foreground text-sm">
+        &larr; Back to Projects
+      </a>
+    </SectionContent>
+  </Section>
+</Layout>

--- a/astro-app/src/pages/sponsors/[slug].astro
+++ b/astro-app/src/pages/sponsors/[slug].astro
@@ -36,6 +36,7 @@ const projects = sponsor.projects ?? [];
 ---
 
 <Layout title={sponsor.name ?? 'Sponsor'}>
+  <!-- Header with breadcrumb + sponsor info -->
   <Section>
     <SectionContent>
       <Breadcrumb items={[
@@ -92,28 +93,27 @@ const projects = sponsor.projects ?? [];
     </SectionContent>
   </Section>
 
-  {projects.length > 0 && (
-    <Section>
-      <SectionContent>
-        <h2 class="text-2xl font-bold mb-6">Associated Projects</h2>
-        <ul class="space-y-3">
-          {projects.map((p) => (
-            <li>
-              <a
-                href={`/projects/${stegaClean(p.slug)}`}
-                class="text-primary hover:text-primary/80 underline"
-              >
-                {p.title}
-              </a>
-            </li>
-          ))}
-        </ul>
-      </SectionContent>
-    </Section>
-  )}
+  <!-- Detail content — single section -->
+  <Section size="sm">
+    <SectionContent class="gap-y-10">
+      {projects.length > 0 && (
+        <div>
+          <h2 class="text-2xl font-bold mb-4">Associated Projects</h2>
+          <ul class="space-y-3">
+            {projects.map((p) => (
+              <li>
+                <a
+                  href={`/projects/${stegaClean(p.slug)}`}
+                  class="text-primary hover:text-primary/80 underline"
+                >
+                  {p.title}
+                </a>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
 
-  <Section>
-    <SectionContent>
       <a href="/sponsors" class="inline-flex items-center gap-2 text-muted-foreground hover:text-foreground text-sm">
         &larr; Back to Sponsors
       </a>

--- a/studio/src/schemaTypes/blocks/event-list.ts
+++ b/studio/src/schemaTypes/blocks/event-list.ts
@@ -18,7 +18,11 @@ export const eventList = defineBlock({
       title: 'Filter By',
       type: 'string',
       options: {
-        list: ['all', 'upcoming', 'past'],
+        list: [
+          {title: 'All', value: 'all'},
+          {title: 'Upcoming', value: 'upcoming'},
+          {title: 'Past', value: 'past'},
+        ],
       },
       initialValue: 'upcoming',
     }),

--- a/studio/src/schemaTypes/blocks/testimonials.ts
+++ b/studio/src/schemaTypes/blocks/testimonials.ts
@@ -18,7 +18,13 @@ export const testimonials = defineBlock({
       title: 'Display Mode',
       type: 'string',
       options: {
-        list: ['all', 'industry', 'student', 'byProject', 'manual'],
+        list: [
+          {title: 'All', value: 'all'},
+          {title: 'Industry', value: 'industry'},
+          {title: 'Student', value: 'student'},
+          {title: 'By Project', value: 'byProject'},
+          {title: 'Manual', value: 'manual'},
+        ],
       },
       initialValue: 'all',
     }),

--- a/studio/src/schemaTypes/documents/event.ts
+++ b/studio/src/schemaTypes/documents/event.ts
@@ -64,7 +64,11 @@ export const event = defineType({
       title: 'Event Type',
       type: 'string',
       options: {
-        list: ['showcase', 'networking', 'workshop'],
+        list: [
+          {title: 'Showcase', value: 'showcase'},
+          {title: 'Networking', value: 'networking'},
+          {title: 'Workshop', value: 'workshop'},
+        ],
         layout: 'radio',
       },
     }),
@@ -73,7 +77,10 @@ export const event = defineType({
       title: 'Status',
       type: 'string',
       options: {
-        list: ['upcoming', 'past'],
+        list: [
+          {title: 'Upcoming', value: 'upcoming'},
+          {title: 'Past', value: 'past'},
+        ],
         layout: 'radio',
       },
       initialValue: 'upcoming',

--- a/studio/src/schemaTypes/documents/testimonial.ts
+++ b/studio/src/schemaTypes/documents/testimonial.ts
@@ -37,7 +37,10 @@ export const testimonial = defineType({
       title: 'Type',
       type: 'string',
       options: {
-        list: ['industry', 'student'],
+        list: [
+          {title: 'Industry', value: 'industry'},
+          {title: 'Student', value: 'student'},
+        ],
       },
     }),
     defineField({


### PR DESCRIPTION
## What This PR Does

This PR fixes issues found during a code review of the recent story implementations (2.11 Testimonials, 2.12 Events, 4.3 Project Listing, 4.4 Project Detail). Think of it as a cleanup pass — no new features, just making the existing code more correct and consistent.

## Changes Explained

### 1. Visual Editing bug fix (`sanity.ts`)

**What was wrong:** When Sanity's Visual Editing mode is active, all text values from the CMS get wrapped in invisible "stega" characters (used for click-to-edit tracking). Our testimonial filter was comparing these wrapped strings directly — e.g. `t.type === 'industry'` — which silently fails because the actual string contains hidden characters around `industry`.

**The fix:** Wrap the comparison in `stegaClean()` so the hidden characters are stripped before comparing:
```diff
- if (mode === 'industry') return allTestimonials.filter(t => t.type === 'industry');
+ if (mode === 'industry') return allTestimonials.filter(t => stegaClean(t.type) === 'industry');
```

### 2. Empty state for Testimonials block (`Testimonials.astro`)

**What was wrong:** When a Testimonials block had zero testimonials, it rendered a heading with a completely blank area below it. The EventList block already handled this gracefully with a "No events to display." message.

**The fix:** Added the same pattern — a centered gray message saying "No testimonials to display." when the array is empty.

### 3. Schema string list labels (`event.ts`, `testimonial.ts`, `event-list.ts`, `testimonials.ts`)

**What was wrong:** Some schemas used bare strings for dropdown options (e.g. `list: ['upcoming', 'past']`) while others used the title/value format (`list: [{title: 'Active', value: 'active'}]`). Bare strings work fine, but editors see the raw value (`byProject`) instead of a friendly label (`By Project`).

**The fix:** Normalized all 4 schema files to use `{title, value}` objects so editors see clean labels in Sanity Studio.

### 4. DRY Storybook stories (`EventList.stories.ts`, `Testimonials.stories.ts`)

**What was wrong:** Both Storybook files copy-pasted ~60 lines of fixture data that already existed in the `__fixtures__/` test directory. Two copies of the same data means two places to update if the shape changes.

**The fix:** Import the shared fixture data instead of duplicating it:
```diff
+ import { eventsData } from '../../__tests__/__fixtures__/events'
- const upcomingEvents = [ { _id: 'event-1', ... }, ... ]
+ const upcomingEvents = eventsData.filter(e => e.status === 'upcoming')
```

### 5. Sponsor detail page layout (`sponsors/[slug].astro`)

**What was wrong:** The "Associated Projects" list and "Back to Sponsors" link were each wrapped in their own `<Section>` component. Each `<Section>` adds 48–64px of vertical padding, creating excessive whitespace between what should be tightly-spaced content.

**The fix:** Consolidated into a single `<Section size="sm">` with `gap-y-10` — same pattern already used on the project detail page.

### 6. Project detail page (`projects/[slug].astro`)

**What:** New file for Story 4.4. Renders individual project pages with sponsor info, Portable Text content, tech stack badges, team grid, mentor, outcome, and linked testimonials.

## Test Plan

- [x] `npm run typegen` — 11 queries, 43 schema types (regenerated after schema changes)
- [x] `npm run test:unit` — 442 tests pass, 0 failures, 42 test files
- [x] No new test files needed (existing tests cover all changed logic)