### PR TITLE
fix: align login pages with design system and fix security/a11y issues

### DIFF
--- a/astro-app/src/pages/auth/login.astro
+++ b/astro-app/src/pages/auth/login.astro
@@ -7,30 +7,67 @@
  */
 export const prerender = false;
 
-const redirect = Astro.url.searchParams.get('redirect') || '/student/';
+import "../../styles/global.css";
+
+function safeRedirect(url: string | null, fallback: string): string {
+  if (!url) return fallback;
+  if (url.startsWith('/') && !url.startsWith('//')) return url;
+  return fallback;
+}
+
+const redirect = safeRedirect(Astro.url.searchParams.get('redirect'), '/student/');
 ---
 
 <html lang="en">
   <head>
     <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="robots" content="noindex" />
     <title>Student Sign In</title>
   </head>
-  <body data-redirect={redirect}>
-    <p>Redirecting to Google sign-in...</p>
+  <body class="bg-background text-foreground min-h-screen flex items-center justify-center p-4" data-redirect={redirect}>
+    <div class="text-center">
+      <p class="text-muted-foreground text-sm" id="status-msg">Redirecting to Google sign-in...</p>
+      <div id="error-fallback" hidden>
+        <p class="text-destructive text-sm mb-4">Unable to connect to Google sign-in.</p>
+        <a
+          href={`/auth/login?redirect=${encodeURIComponent(redirect)}`}
+          class="text-primary text-sm font-medium underline underline-offset-4"
+        >
+          Try again
+        </a>
+      </div>
+    </div>
     <script>
       import { createAuthClient } from "better-auth/client";
+
+      function safeRedirect(url: string | null, fallback: string): string {
+        if (!url) return fallback;
+        if (url.startsWith('/') && !url.startsWith('//')) return url;
+        return fallback;
+      }
 
       const authClient = createAuthClient({
         baseURL: window.location.origin + "/api/auth",
       });
 
       const serverRedirect = document.body.getAttribute('data-redirect') || '/student/';
-      const redirectParam = new URLSearchParams(window.location.search).get('redirect') || serverRedirect;
+      const redirectParam = safeRedirect(
+        new URLSearchParams(window.location.search).get('redirect'),
+        serverRedirect
+      );
 
-      authClient.signIn.social({
-        provider: "google",
-        callbackURL: redirectParam,
-      });
+      try {
+        await authClient.signIn.social({
+          provider: "google",
+          callbackURL: redirectParam,
+        });
+      } catch {
+        const statusEl = document.getElementById('status-msg');
+        const errorEl = document.getElementById('error-fallback');
+        if (statusEl) statusEl.hidden = true;
+        if (errorEl) errorEl.hidden = false;
+      }
     </script>
   </body>
 </html>

--- a/astro-app/src/pages/portal/login.astro
+++ b/astro-app/src/pages/portal/login.astro
@@ -6,138 +6,132 @@
  */
 export const prerender = false;
 
-const redirect = Astro.url.searchParams.get('redirect') || '/portal/';
+import "../../styles/global.css";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+
+function safeRedirect(url: string | null, fallback: string): string {
+  if (!url) return fallback;
+  if (url.startsWith('/') && !url.startsWith('//')) return url;
+  return fallback;
+}
+
+const redirect = safeRedirect(Astro.url.searchParams.get('redirect'), '/portal/');
 ---
 
 <html lang="en">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="robots" content="noindex" />
+    <meta name="description" content="Sign in to the Sponsor Portal" />
     <title>Sponsor Portal — Sign In</title>
-    <style>
-      * { box-sizing: border-box; margin: 0; padding: 0; }
-      body {
-        font-family: system-ui, -apple-system, sans-serif;
-        background: #f8fafc;
-        min-height: 100vh;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        padding: 1rem;
-      }
-      .login-card {
-        background: white;
-        border-radius: 12px;
-        box-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1);
-        padding: 2.5rem;
-        width: 100%;
-        max-width: 420px;
-      }
-      h1 { font-size: 1.5rem; font-weight: 700; margin-bottom: 0.5rem; color: #0f172a; }
-      .subtitle { color: #64748b; margin-bottom: 2rem; font-size: 0.875rem; }
-      .divider {
-        display: flex; align-items: center; gap: 1rem;
-        margin: 1.5rem 0; color: #94a3b8; font-size: 0.75rem;
-      }
-      .divider::before, .divider::after {
-        content: ''; flex: 1; height: 1px; background: #e2e8f0;
-      }
-      button, .btn {
-        display: flex; align-items: center; justify-content: center; gap: 0.5rem;
-        width: 100%; padding: 0.75rem 1rem; border-radius: 8px;
-        font-size: 0.875rem; font-weight: 500; cursor: pointer;
-        border: 1px solid #e2e8f0; background: white; color: #1e293b;
-        transition: background 0.15s, border-color 0.15s;
-      }
-      button:hover, .btn:hover { background: #f8fafc; border-color: #cbd5e1; }
-      .btn-primary {
-        background: #0f172a; color: white; border-color: #0f172a;
-      }
-      .btn-primary:hover { background: #1e293b; }
-      .btn + .btn { margin-top: 0.75rem; }
-      label { display: block; font-size: 0.875rem; font-weight: 500; margin-bottom: 0.375rem; color: #374151; }
-      input[type="email"] {
-        width: 100%; padding: 0.625rem 0.75rem; border: 1px solid #e2e8f0;
-        border-radius: 8px; font-size: 0.875rem; outline: none;
-      }
-      input[type="email"]:focus { border-color: #3b82f6; box-shadow: 0 0 0 3px rgb(59 130 246 / 0.1); }
-      .magic-form { display: flex; flex-direction: column; gap: 0.75rem; }
-      .success-msg {
-        background: #f0fdf4; border: 1px solid #bbf7d0; border-radius: 8px;
-        padding: 1rem; color: #166534; font-size: 0.875rem; text-align: center;
-      }
-      .error-msg {
-        background: #fef2f2; border: 1px solid #fecaca; border-radius: 8px;
-        padding: 0.75rem; color: #991b1b; font-size: 0.8125rem; text-align: center;
-        margin-top: 0.75rem;
-      }
-      [hidden] { display: none !important; }
-    </style>
   </head>
-  <body>
-    <div class="login-card" data-redirect={redirect}>
-      <h1>Sponsor Portal</h1>
-      <p class="subtitle">Sign in to access your capstone project dashboard.</p>
+  <body class="bg-background text-foreground min-h-screen flex items-center justify-center p-4">
+    <div class="bg-card text-card-foreground border border-border p-10 w-full max-w-md" data-redirect={redirect}>
+      <div class="flex justify-center mb-6">
+        <img src="/logos/njit-logo-plain.svg" alt="NJIT" class="h-10 w-auto" width="160" height="40" />
+      </div>
+      <h1 class="text-2xl font-bold mb-2">Sponsor Portal</h1>
+      <p class="text-muted-foreground text-sm mb-8">Sign in to access your capstone project dashboard.</p>
 
-      <button class="btn" id="google-signin">
-        <svg width="18" height="18" viewBox="0 0 18 18"><path fill="#4285F4" d="M17.64 9.2c0-.637-.057-1.251-.164-1.84H9v3.481h4.844a4.14 4.14 0 0 1-1.796 2.716v2.259h2.908c1.702-1.567 2.684-3.875 2.684-6.615Z"/><path fill="#34A853" d="M9 18c2.43 0 4.467-.806 5.956-2.18l-2.908-2.259c-.806.54-1.837.86-3.048.86-2.344 0-4.328-1.584-5.036-3.711H.957v2.332A8.997 8.997 0 0 0 9 18Z"/><path fill="#FBBC05" d="M3.964 10.71A5.41 5.41 0 0 1 3.682 9c0-.593.102-1.17.282-1.71V4.958H.957A8.997 8.997 0 0 0 0 9c0 1.452.348 2.827.957 4.042l3.007-2.332Z"/><path fill="#EA4335" d="M9 3.58c1.321 0 2.508.454 3.44 1.345l2.582-2.58C13.463.891 11.426 0 9 0A8.997 8.997 0 0 0 .957 4.958L3.964 7.29C4.672 5.163 6.656 3.58 9 3.58Z"/></svg>
+      <Button variant="outline" id="google-signin" class="w-full">
+        <svg width="18" height="18" viewBox="0 0 18 18" aria-hidden="true"><path fill="#4285F4" d="M17.64 9.2c0-.637-.057-1.251-.164-1.84H9v3.481h4.844a4.14 4.14 0 0 1-1.796 2.716v2.259h2.908c1.702-1.567 2.684-3.875 2.684-6.615Z"/><path fill="#34A853" d="M9 18c2.43 0 4.467-.806 5.956-2.18l-2.908-2.259c-.806.54-1.837.86-3.048.86-2.344 0-4.328-1.584-5.036-3.711H.957v2.332A8.997 8.997 0 0 0 9 18Z"/><path fill="#FBBC05" d="M3.964 10.71A5.41 5.41 0 0 1 3.682 9c0-.593.102-1.17.282-1.71V4.958H.957A8.997 8.997 0 0 0 0 9c0 1.452.348 2.827.957 4.042l3.007-2.332Z"/><path fill="#EA4335" d="M9 3.58c1.321 0 2.508.454 3.44 1.345l2.582-2.58C13.463.891 11.426 0 9 0A8.997 8.997 0 0 0 .957 4.958L3.964 7.29C4.672 5.163 6.656 3.58 9 3.58Z"/></svg>
         Sign in with Google
-      </button>
+      </Button>
 
-      <button class="btn" id="github-signin">
-        <svg width="18" height="18" viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8Z"/></svg>
+      <Button variant="outline" id="github-signin" class="w-full mt-3">
+        <svg width="18" height="18" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8Z"/></svg>
         Sign in with GitHub
-      </button>
+      </Button>
 
-      <div class="divider">or</div>
+      <div class="flex items-center gap-4 my-6 text-muted-foreground text-xs">
+        <div class="flex-1 h-px bg-border"></div>
+        or
+        <div class="flex-1 h-px bg-border"></div>
+      </div>
 
-      <form class="magic-form" id="magic-link-form">
-        <label for="email">Sign in with Email</label>
-        <input type="email" id="email" placeholder="you@company.com" required />
-        <button type="submit" class="btn btn-primary">Send sign-in link</button>
+      <form class="flex flex-col gap-3" id="magic-link-form">
+        <label for="email" class="text-sm font-medium text-foreground">Sign in with Email</label>
+        <Input type="email" id="email" placeholder="you@company.com" required />
+        <Button type="submit" id="magic-link-submit">
+          Send sign-in link
+        </Button>
       </form>
 
-      <div class="success-msg" id="magic-link-success" hidden>
+      <div class="border border-border bg-secondary text-foreground text-sm text-center p-4 mt-3" id="magic-link-success" aria-live="polite" hidden>
         Check your email for a sign-in link.
       </div>
 
-      <div class="error-msg" id="error-msg" hidden></div>
+      <div class="border border-destructive bg-destructive/5 text-destructive text-sm text-center p-3 mt-3" id="error-msg" role="alert" hidden></div>
     </div>
 
     <script>
       import { createAuthClient } from "better-auth/client";
       import { magicLinkClient } from "better-auth/client/plugins";
 
+      function safeRedirect(url: string | null, fallback: string): string {
+        if (!url) return fallback;
+        if (url.startsWith('/') && !url.startsWith('//')) return url;
+        return fallback;
+      }
+
       const authClient = createAuthClient({
         baseURL: window.location.origin + "/api/auth",
         plugins: [magicLinkClient()],
       });
 
-      const serverRedirect = document.querySelector('.login-card')?.getAttribute('data-redirect') || '/portal/';
-      const redirectParam = new URLSearchParams(window.location.search).get('redirect') || serverRedirect;
+      const serverRedirect = document.querySelector('[data-redirect]')?.getAttribute('data-redirect') || '/portal/';
+      const redirectParam = safeRedirect(
+        new URLSearchParams(window.location.search).get('redirect'),
+        serverRedirect
+      );
 
-      document.getElementById('google-signin')?.addEventListener('click', () => {
+      const googleBtn = document.getElementById('google-signin');
+      const githubBtn = document.getElementById('github-signin');
+
+      googleBtn?.addEventListener('click', () => {
+        googleBtn.setAttribute('disabled', '');
+        googleBtn.setAttribute('aria-busy', 'true');
         authClient.signIn.social({ provider: "google", callbackURL: redirectParam });
       });
 
-      document.getElementById('github-signin')?.addEventListener('click', () => {
+      githubBtn?.addEventListener('click', () => {
+        githubBtn.setAttribute('disabled', '');
+        githubBtn.setAttribute('aria-busy', 'true');
         authClient.signIn.social({ provider: "github", callbackURL: redirectParam });
       });
 
       document.getElementById('magic-link-form')?.addEventListener('submit', async (e) => {
         e.preventDefault();
-        const emailInput = document.getElementById('email') as HTMLInputElement;
+        const emailInput = document.getElementById('email') as HTMLInputElement | null;
+        const submitBtn = document.getElementById('magic-link-submit');
+        const errorEl = document.getElementById('error-msg');
+        const formEl = document.getElementById('magic-link-form');
+        const successEl = document.getElementById('magic-link-success');
+
+        if (!emailInput || !errorEl) return;
         const email = emailInput.value;
-        const errorEl = document.getElementById('error-msg')!;
         errorEl.hidden = true;
+
+        if (submitBtn) {
+          submitBtn.setAttribute('disabled', '');
+          submitBtn.setAttribute('aria-busy', 'true');
+        }
+        if (emailInput) emailInput.disabled = true;
 
         try {
           await authClient.signIn.magicLink({ email, callbackURL: redirectParam });
-          document.getElementById('magic-link-form')!.hidden = true;
-          document.getElementById('magic-link-success')!.hidden = false;
-        } catch (err) {
+          if (formEl) formEl.hidden = true;
+          if (successEl) successEl.hidden = false;
+        } catch {
           errorEl.textContent = 'Failed to send sign-in link. Please try again.';
           errorEl.hidden = false;
+          if (submitBtn) {
+            submitBtn.removeAttribute('disabled');
+            submitBtn.removeAttribute('aria-busy');
+          }
+          if (emailInput) emailInput.disabled = false;
         }
       });
     </script>


### PR DESCRIPTION
## Summary

- **Both login pages** (`/auth/login` and `/portal/login`) were completely outside our design system — hardcoded colors, wrong fonts, rounded corners, no accessibility support
- This PR brings them into compliance with our [UX Design Specification](../_bmad-output/planning-artifacts/ux-design-specification.md) and fixes several security and accessibility issues found during review

## What changed and why

### Files modified
- `astro-app/src/pages/auth/login.astro` — the student auto-redirect login page
- `astro-app/src/pages/portal/login.astro` — the sponsor portal login page with Google, GitHub, and magic link sign-in

### Design system compliance
Both pages previously used **hardcoded hex colors** (like `#f8fafc`, `#0f172a`, `#3b82f6`) and `system-ui` fonts instead of our design tokens. Now they:

- **Import `global.css`** so they get the correct Helvetica Neue font stack, semantic color tokens, and base styles
- **Use semantic tokens everywhere** (`bg-background`, `text-foreground`, `text-muted-foreground`, etc.) instead of raw colors
- **Use zero border-radius** (sharp corners) per the Swiss design spec — the old pages had `border-radius: 12px` and `8px`
- **Remove decorative box-shadow** on the login card — replaced with a clean `border-border`
- **Use the project's `Button` and `Input` components** instead of hand-rolled button/input styles, so if the design system changes, these pages stay in sync

### Security fix — open redirect
**Before:** The `?redirect=` query parameter was passed directly to the auth library's `callbackURL` with no validation. An attacker could craft a URL like `/portal/login?redirect=https://evil.com` to redirect users to a malicious site after login.

**After:** A `safeRedirect()` function validates that the redirect URL starts with `/` (relative path) and blocks protocol-relative URLs (`//evil.com`). This validation runs on both the server (Astro frontmatter) and client (JavaScript).

### Accessibility improvements
- **`aria-live="polite"`** on the success message — screen readers will announce "Check your email for a sign-in link" when it appears
- **`role="alert"`** on the error message — screen readers will immediately announce errors
- **`aria-hidden="true"`** on decorative SVG icons (Google/GitHub logos) so screen readers skip them
- **`focus-visible:`** instead of `focus:` on the email input — focus rings only show for keyboard navigation, not mouse clicks
- **Loading states** — buttons get `disabled` + `aria-busy="true"` during async operations to prevent double-clicks and communicate state to assistive technology

### Other improvements
- **NJIT logo** added above the "Sponsor Portal" heading
- **Error fallback** on `/auth/login` — if Google sign-in fails, shows an error message with a "Try again" link instead of leaving the user stuck on "Redirecting..."
- **`<meta name="robots" content="noindex">`** added to both pages so search engines don't index login pages
- **Null-safe DOM access** — replaced `!` (non-null assertions) with `?.` (optional chaining) for safer JavaScript

## Test plan

- [x] `npm run build -w astro-app` — builds cleanly
- [x] `npm run test:unit` — 718 tests pass, 0 regressions
- [ ] Manual: visit `/portal/login` and verify logo, buttons, input, divider render correctly
- [ ] Manual: visit `/auth/login` and verify redirect to Google sign-in works
- [ ] Manual: test `/portal/login?redirect=https://evil.com` — should fall back to `/portal/` instead of redirecting externally
- [ ] Manual: tab through portal login form to verify focus rings appear correctly