### PR TITLE
fix(auth): harden Better Auth — security, account linking, and client consolidation

### DIFF
--- a/astro-app/src/__tests__/middleware.test.ts
+++ b/astro-app/src/__tests__/middleware.test.ts
@@ -375,6 +375,35 @@ describe('middleware — unified auth routing', () => {
     });
   });
 
+  describe('Runtime env guard', () => {
+    it('returns 503 when runtime env is not available', async () => {
+      const ctx = createMockContext('/portal/index', {
+        overrides: { runtime: { env: undefined as any } } as any,
+      });
+
+      const result = await onRequest(ctx as any, mockNext);
+
+      expect(result.status).toBe(503);
+      expect(mockNext).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Cookie extraction — __Secure- prefix', () => {
+    it('extracts session token from __Secure- prefixed cookie', async () => {
+      const secureCookie = '__Secure-better-auth.session_token=secure-tok-789; Path=/';
+      mockGetSession.mockResolvedValue({
+        user: { id: '1', email: 'student@test.com', name: 'Student', role: 'student' },
+        session: { id: 's1' },
+      });
+      const ctx = createMockContext('/student/dashboard', { headers: { cookie: secureCookie } });
+
+      await onRequest(ctx as any, mockNext);
+
+      expect(ctx.locals.user).toEqual({ email: 'student@test.com', name: 'Student', role: 'student' });
+      expect(mockNext).toHaveBeenCalled();
+    });
+  });
+
   describe('Dev mode bypass', () => {
     it('sets role "sponsor" with dev email and name for portal routes', async () => {
       import.meta.env.DEV = true;

--- a/astro-app/src/lib/__tests__/auth-client.test.ts
+++ b/astro-app/src/lib/__tests__/auth-client.test.ts
@@ -1,16 +1,21 @@
 import { describe, it, expect, vi } from 'vitest';
 
-const { mockCreateAuthClient } = vi.hoisted(() => {
+const { mockCreateAuthClient, mockMagicLinkClient } = vi.hoisted(() => {
   const mockCreateAuthClient = vi.fn().mockReturnValue({
-    signIn: { social: vi.fn() },
+    signIn: { social: vi.fn(), magicLink: vi.fn() },
     signOut: vi.fn(),
     getSession: vi.fn(),
   });
-  return { mockCreateAuthClient };
+  const mockMagicLinkClient = vi.fn().mockReturnValue({ id: 'magic-link' });
+  return { mockCreateAuthClient, mockMagicLinkClient };
 });
 
 vi.mock('better-auth/client', () => ({
   createAuthClient: mockCreateAuthClient,
+}));
+
+vi.mock('better-auth/client/plugins', () => ({
+  magicLinkClient: mockMagicLinkClient,
 }));
 
 import { authClient } from '@/lib/auth-client';
@@ -25,6 +30,10 @@ describe('authClient — client-side auth', () => {
     expect(authClient.signIn.social).toBeTypeOf('function');
   });
 
+  it('provides signIn.magicLink method', () => {
+    expect(authClient.signIn.magicLink).toBeTypeOf('function');
+  });
+
   it('provides signOut method', () => {
     expect(authClient.signOut).toBeTypeOf('function');
   });
@@ -36,6 +45,15 @@ describe('authClient — client-side auth', () => {
   it('configures baseURL to /api/auth', () => {
     expect(mockCreateAuthClient).toHaveBeenCalledWith(
       expect.objectContaining({ baseURL: '/api/auth' }),
+    );
+  });
+
+  it('includes magicLinkClient plugin', () => {
+    expect(mockMagicLinkClient).toHaveBeenCalled();
+    expect(mockCreateAuthClient).toHaveBeenCalledWith(
+      expect.objectContaining({
+        plugins: expect.arrayContaining([{ id: 'magic-link' }]),
+      }),
     );
   });
 });

--- a/astro-app/src/lib/__tests__/auth-config.test.ts
+++ b/astro-app/src/lib/__tests__/auth-config.test.ts
@@ -76,6 +76,12 @@ describe('createAuth() — unified auth factory', () => {
     });
   });
 
+  it('enables account linking', () => {
+    createAuth({ db: mockDb, env: mockEnv });
+    const config = mockBetterAuth.mock.calls[0][0];
+    expect(config.account.accountLinking).toEqual({ enabled: true });
+  });
+
   it('registers Magic Link plugin', () => {
     createAuth({ db: mockDb, env: mockEnv });
     expect(mockMagicLink).toHaveBeenCalled();

--- a/astro-app/src/lib/auth-client.ts
+++ b/astro-app/src/lib/auth-client.ts
@@ -1,10 +1,16 @@
 /**
  * Client-side Better Auth client for authenticated pages (student + sponsor).
  * Provides typed methods for sign-in, sign-out, and session retrieval.
- * Imported by student portal pages (Story 16.3+) for client-side auth interactions.
+ * Imported by portal login, student pages, and denied page for client-side auth interactions.
+ *
+ * Note: Full type inference for custom fields (e.g., role) requires
+ * `createAuthClient<typeof auth>()` but the server auth type can't be
+ * imported client-side due to server-only dependencies (drizzle, resend).
  */
 import { createAuthClient } from 'better-auth/client';
+import { magicLinkClient } from 'better-auth/client/plugins';
 
 export const authClient = createAuthClient({
   baseURL: '/api/auth',
+  plugins: [magicLinkClient()],
 });

--- a/astro-app/src/lib/auth-config.ts
+++ b/astro-app/src/lib/auth-config.ts
@@ -94,6 +94,8 @@ export function createAuth({ db, env, requestOrigin }: CreateAuthOptions) {
     origins.push(requestOrigin);
   }
 
+  const resendClient = new Resend(env.RESEND_API_KEY);
+
   return betterAuth({
     baseURL,
     secret: env.BETTER_AUTH_SECRET,
@@ -120,6 +122,9 @@ export function createAuth({ db, env, requestOrigin }: CreateAuthOptions) {
         clientSecret: env.GITHUB_CLIENT_SECRET,
       },
     },
+    account: {
+      accountLinking: { enabled: true },
+    },
     plugins: [
       magicLink({
         sendMagicLink: async ({ email, url }) => {
@@ -127,12 +132,12 @@ export function createAuth({ db, env, requestOrigin }: CreateAuthOptions) {
           if (!env.RESEND_FROM_EMAIL) {
             console.warn('[auth] RESEND_FROM_EMAIL not set — using default .pages.dev sender. Set RESEND_FROM_EMAIL to a verified domain for production.');
           }
-          const resendClient = new Resend(env.RESEND_API_KEY);
+          const safeUrl = url.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
           await resendClient.emails.send({
             from: fromAddress,
             to: email,
             subject: 'Sign in to the Sponsor Portal',
-            html: `<p>Click the link below to sign in to the Sponsor Portal:</p><p><a href="${url}">Sign in to Sponsor Portal</a></p><p>This link expires in 10 minutes.</p>`,
+            html: `<p>Click the link below to sign in to the Sponsor Portal:</p><p><a href="${safeUrl}">Sign in to Sponsor Portal</a></p><p>This link expires in 10 minutes.</p>`,
           });
         },
       }),

--- a/astro-app/src/middleware.ts
+++ b/astro-app/src/middleware.ts
@@ -47,9 +47,13 @@ export const onRequest = defineMiddleware(async (context, next) => {
   const { createAuth, checkSponsorWhitelist } = await import("@/lib/auth-config");
 
   const runtimeEnv = context.locals.runtime?.env;
+  if (!runtimeEnv) {
+    console.error("[middleware] Cloudflare runtime env not available");
+    return new Response("Service Unavailable", { status: 503 });
+  }
 
   // Rate limiting — per-IP sliding window via Durable Object (fail-open)
-  const rateLimiter = runtimeEnv?.RATE_LIMITER;
+  const rateLimiter = runtimeEnv.RATE_LIMITER;
   if (rateLimiter) {
     const ip = context.request.headers.get("CF-Connecting-IP") ?? "unknown";
     try {
@@ -94,13 +98,13 @@ export const onRequest = defineMiddleware(async (context, next) => {
       const auth = createAuth({
         db,
         env: {
-          GOOGLE_CLIENT_ID: runtimeEnv!.GOOGLE_CLIENT_ID,
-          GOOGLE_CLIENT_SECRET: runtimeEnv!.GOOGLE_CLIENT_SECRET,
-          GITHUB_CLIENT_ID: runtimeEnv!.GITHUB_CLIENT_ID,
-          GITHUB_CLIENT_SECRET: runtimeEnv!.GITHUB_CLIENT_SECRET,
-          BETTER_AUTH_SECRET: runtimeEnv!.BETTER_AUTH_SECRET,
-          BETTER_AUTH_URL: runtimeEnv!.BETTER_AUTH_URL,
-          RESEND_API_KEY: runtimeEnv!.RESEND_API_KEY,
+          GOOGLE_CLIENT_ID: runtimeEnv.GOOGLE_CLIENT_ID,
+          GOOGLE_CLIENT_SECRET: runtimeEnv.GOOGLE_CLIENT_SECRET,
+          GITHUB_CLIENT_ID: runtimeEnv.GITHUB_CLIENT_ID,
+          GITHUB_CLIENT_SECRET: runtimeEnv.GITHUB_CLIENT_SECRET,
+          BETTER_AUTH_SECRET: runtimeEnv.BETTER_AUTH_SECRET,
+          BETTER_AUTH_URL: runtimeEnv.BETTER_AUTH_URL,
+          RESEND_API_KEY: runtimeEnv.RESEND_API_KEY,
         },
         requestOrigin: context.url.origin,
       });
@@ -176,9 +180,11 @@ export const onRequest = defineMiddleware(async (context, next) => {
   }
 });
 
-/** Extract Better Auth session token from Cookie header */
+/** Extract Better Auth session token from Cookie header.
+ *  Handles both standard and __Secure- prefixed cookie names
+ *  (the latter is used when `advanced.useSecureCookies` is enabled). */
 function extractSessionToken(cookie: string | null): string | null {
   if (!cookie) return null;
-  const match = cookie.match(/better-auth\.session_token=([^;]+)/);
+  const match = cookie.match(/(?:__Secure-)?better-auth\.session_token=([^;]+)/);
   return match?.[1] ?? null;
 }

--- a/astro-app/src/pages/auth/login.astro
+++ b/astro-app/src/pages/auth/login.astro
@@ -39,17 +39,13 @@ const redirect = safeRedirect(Astro.url.searchParams.get('redirect'), '/student/
       </div>
     </div>
     <script>
-      import { createAuthClient } from "better-auth/client";
+      import { authClient } from "@/lib/auth-client";
 
       function safeRedirect(url: string | null, fallback: string): string {
         if (!url) return fallback;
         if (url.startsWith('/') && !url.startsWith('//')) return url;
         return fallback;
       }
-
-      const authClient = createAuthClient({
-        baseURL: window.location.origin + "/api/auth",
-      });
 
       const serverRedirect = document.body.getAttribute('data-redirect') || '/student/';
       const redirectParam = safeRedirect(

--- a/astro-app/src/pages/portal/denied.astro
+++ b/astro-app/src/pages/portal/denied.astro
@@ -50,11 +50,7 @@ export const prerender = false;
     </div>
 
     <script>
-      import { createAuthClient } from "better-auth/client";
-
-      const authClient = createAuthClient({
-        baseURL: window.location.origin + "/api/auth",
-      });
+      import { authClient } from "@/lib/auth-client";
 
       document.getElementById('retry-link')?.addEventListener('click', async (e) => {
         e.preventDefault();

--- a/astro-app/src/pages/portal/login.astro
+++ b/astro-app/src/pages/portal/login.astro
@@ -67,19 +67,13 @@ const redirect = safeRedirect(Astro.url.searchParams.get('redirect'), '/portal/'
     </div>
 
     <script>
-      import { createAuthClient } from "better-auth/client";
-      import { magicLinkClient } from "better-auth/client/plugins";
+      import { authClient } from "@/lib/auth-client";
 
       function safeRedirect(url: string | null, fallback: string): string {
         if (!url) return fallback;
         if (url.startsWith('/') && !url.startsWith('//')) return url;
         return fallback;
       }
-
-      const authClient = createAuthClient({
-        baseURL: window.location.origin + "/api/auth",
-        plugins: [magicLinkClient()],
-      });
 
       const serverRedirect = document.querySelector('[data-redirect]')?.getAttribute('data-redirect') || '/portal/';
       const redirectParam = safeRedirect(

--- a/astro-app/src/pages/student/index.astro
+++ b/astro-app/src/pages/student/index.astro
@@ -32,8 +32,7 @@ if (!user?.email) {
       </button>
     </main>
     <script>
-      import { createAuthClient } from "better-auth/client";
-      const authClient = createAuthClient({ baseURL: window.location.origin + "/api/auth" });
+      import { authClient } from "@/lib/auth-client";
       document.getElementById("sign-out")?.addEventListener("click", async () => {
         await authClient.signOut();
         window.location.href = "/";


### PR DESCRIPTION
## Summary

This PR fixes **7 issues** found during a Better Auth best-practices review. The changes improve security, prevent real-world user errors, and clean up duplicated code.

- **Escape magic link email URL** — prevents XSS in the HTML email template
- **Support `__Secure-` cookie prefix** — session extraction no longer breaks if secure cookies are enabled
- **Enable account linking** — users can now sign in with Google, GitHub, or Magic Link interchangeably without "email already in use" errors
- **Guard against missing runtime env** — returns a clear 503 instead of a cryptic TypeError when Cloudflare bindings aren't available
- **Consolidate auth clients** — 4 pages were each creating their own `createAuthClient()` inline; now they all import from one shared module (`auth-client.ts`)
- **Move Resend client creation** — instantiated once per request instead of once per magic link send

## What changed and why

### Security fixes

| File | What | Why |
|------|------|-----|
| `auth-config.ts:135` | HTML-escape the magic link URL (`&`, `"`, `<`, `>`) before putting it in an `<a href="">` | Defense-in-depth against XSS — even though Better Auth generates the URL, we should never interpolate unescaped strings into HTML |
| `middleware.ts:182` | Cookie regex now matches `__Secure-better-auth.session_token` in addition to `better-auth.session_token` | If `advanced.useSecureCookies` is ever enabled in Better Auth config, the cookie name gets a `__Secure-` prefix. Without this fix, the middleware would fail to find the session and redirect all users to login |

### Functional fix

| File | What | Why |
|------|------|-----|
| `auth-config.ts` | Added `account: { accountLinking: { enabled: true } }` | Without this, if a sponsor signs in with Google first and later tries Magic Link (or vice versa) with the same email, Better Auth returns an "email already in use" error instead of linking the accounts. With 3 sign-in methods targeting the same user base, this is likely to hit real users |

### Robustness

| File | What | Why |
|------|------|-----|
| `middleware.ts:49-53` | Early guard: `if (!runtimeEnv) return 503` | Previously used `runtimeEnv!` (non-null assertion) in 7 places. If Cloudflare runtime bindings weren't available, you'd get a confusing `TypeError: Cannot read properties of undefined`. Now it returns a clear 503 with a descriptive log message |

### Code quality

| File | What | Why |
|------|------|-----|
| `auth-client.ts` | Added `magicLinkClient()` plugin to the shared client | The portal login page needs magic link support. Previously it created its own client inline with the plugin. Now all pages share one client |
| 4 page files | Replaced inline `createAuthClient()` with `import { authClient } from "@/lib/auth-client"` | Eliminates duplicated client creation across `portal/login.astro`, `auth/login.astro`, `student/index.astro`, and `portal/denied.astro` |
| `auth-config.ts` | Moved `new Resend(env.RESEND_API_KEY)` from inside the `sendMagicLink` callback to the `createAuth()` scope | Avoids re-creating the Resend HTTP client on every magic link email. Minor perf improvement |

## New tests added

| Test file | New test(s) |
|-----------|-------------|
| `middleware.test.ts` | "returns 503 when runtime env is not available" |
| `middleware.test.ts` | "extracts session token from `__Secure-` prefixed cookie" |
| `auth-config.test.ts` | "enables account linking" |
| `auth-client.test.ts` | "includes magicLinkClient plugin" + "provides signIn.magicLink method" |

## Test plan

- [x] All 82 auth unit tests pass (`npx vitest run` from `astro-app/`)
- [ ] Verify portal login works with Google OAuth
- [ ] Verify portal login works with Magic Link
- [ ] Verify student login works with Google OAuth
- [ ] Verify denied page sign-out + retry flow works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added magic link authentication for user sign-in
  * Enabled account linking functionality

* **Bug Fixes**
  * Added runtime environment validation returning 503 when unavailable
  * Enhanced cookie security handling for secure prefixed cookies
  * Added input sanitization for email content security

<!-- end of auto-generated comment: release notes by coderabbit.ai -->