### PR TITLE
feat(2.9): Swiss design content display blocks

### DIFF
--- a/astro-app/.storybook/main.ts
+++ b/astro-app/.storybook/main.ts
@@ -105,7 +105,7 @@ function astroVirtualModuleStubs(): Plugin {
     'virtual:astro-icon': `export default { ${iconEntries.join(', ')} }; export const config = { include: { ${iconSets.map((s) => `"${s}": ["*"]`).join(', ')} } };`,
     'virtual:astro:assets/fonts/runtime': 'export {};',
     'virtual:astro:assets/fonts/internal': 'export {};',
-    'sanity:client': `export const sanityClient = { config() { return { projectId: 'storybook', dataset: 'production', apiVersion: '2025-03-01' }; }, fetch() { return Promise.resolve({ result: null }); } };`,
+    'sanity:client': `export const sanityClient = { config() { return { projectId: '49nk9b0w', dataset: 'production', apiVersion: '2025-03-01' }; }, fetch() { return Promise.resolve({ result: null }); } };`,
     'astro:actions': `export const actions = new Proxy({}, { get: () => () => Promise.resolve({ data: null, error: null }) }); export function isInputError() { return false; }; export class ActionError extends Error { constructor(opts) { super(opts?.message); this.code = opts?.code; } }; export function defineAction(opts) { return opts?.handler || (() => {}); };`,
   }
 

--- a/astro-app/src/components/__tests__/ArticleList.test.ts
+++ b/astro-app/src/components/__tests__/ArticleList.test.ts
@@ -1,0 +1,83 @@
+import { experimental_AstroContainer as AstroContainer } from 'astro/container';
+import { describe, test, expect } from 'vitest';
+import ArticleList from '../blocks/custom/ArticleList.astro';
+import { articleListFull, articleListSplitFeatured, articleListVariantList, articleListMinimal } from './__fixtures__/article-list';
+
+describe('ArticleList', () => {
+  test('renders heading and description in grid variant', async () => {
+    const container = await AstroContainer.create();
+    const html = await container.renderToString(ArticleList, { props: articleListFull });
+
+    expect(html).toContain('Latest Articles');
+    expect(html).toContain('Stay up to date with our news');
+  });
+
+  test('renders CTA button links', async () => {
+    const container = await AstroContainer.create();
+    const html = await container.renderToString(ArticleList, { props: articleListFull });
+
+    expect(html).toContain('View All Articles');
+    expect(html).toContain('/articles');
+  });
+
+  test('renders placeholder message when no articles', async () => {
+    const container = await AstroContainer.create();
+    const html = await container.renderToString(ArticleList, { props: articleListFull });
+
+    expect(html).toContain('No articles to display');
+  });
+
+  test('hides description in list variant', async () => {
+    const container = await AstroContainer.create();
+    const html = await container.renderToString(ArticleList, { props: articleListVariantList });
+
+    expect(html).toContain('News');
+    expect(html).not.toContain('This should be hidden in list variant');
+  });
+
+  test('renders split-featured variant heading', async () => {
+    const container = await AstroContainer.create();
+    const html = await container.renderToString(ArticleList, { props: articleListSplitFeatured });
+
+    expect(html).toContain('Featured Articles');
+    expect(html).toContain('Our top picks');
+  });
+
+  test('renders outline button variant correctly', async () => {
+    const container = await AstroContainer.create();
+    const html = await container.renderToString(ArticleList, { props: articleListVariantList });
+
+    expect(html).toContain('More News');
+    expect(html).toContain('/news');
+  });
+
+  test('handles minimal data without crashing', async () => {
+    const container = await AstroContainer.create();
+    const html = await container.renderToString(ArticleList, { props: articleListMinimal });
+    expect(html).toBeDefined();
+  });
+
+  test('grid variant renders card grid placeholder layout', async () => {
+    const container = await AstroContainer.create();
+    const html = await container.renderToString(ArticleList, { props: articleListFull });
+    // Grid variant should render placeholder cards with image and text skeletons
+    expect(html).toContain('data-variant="grid"');
+    expect(html).toContain('aspect-video');
+  });
+
+  test('split-featured variant renders split layout placeholder', async () => {
+    const container = await AstroContainer.create();
+    const html = await container.renderToString(ArticleList, { props: articleListSplitFeatured });
+    // Split-featured should use the SectionSplit layout with featured + grid
+    expect(html).toContain('data-slot="section-split"');
+    expect(html).toContain('data-variant="split-featured"');
+  });
+
+  test('list variant renders text-only list placeholder', async () => {
+    const container = await AstroContainer.create();
+    const html = await container.renderToString(ArticleList, { props: articleListVariantList });
+    // List variant should show a divide-y text-only list structure
+    expect(html).toContain('divide-y');
+    expect(html).toContain('data-variant="list"');
+  });
+});

--- a/astro-app/src/components/__tests__/ImageGallery.test.ts
+++ b/astro-app/src/components/__tests__/ImageGallery.test.ts
@@ -1,0 +1,46 @@
+import { experimental_AstroContainer as AstroContainer } from 'astro/container';
+import { describe, test, expect } from 'vitest';
+import ImageGallery from '../blocks/custom/ImageGallery.astro';
+import { imageGalleryFull, imageGalleryMasonry, imageGallerySingle, imageGalleryMinimal } from './__fixtures__/image-gallery';
+
+describe('ImageGallery', () => {
+  test('renders heading and captions in grid variant', async () => {
+    const container = await AstroContainer.create();
+    const html = await container.renderToString(ImageGallery, { props: imageGalleryFull });
+
+    expect(html).toContain('Photo Gallery');
+    expect(html).toContain('A collection of our best work');
+    expect(html).toContain('Project Alpha');
+    expect(html).toContain('Project Beta');
+  });
+
+  test('renders correct column class for grid variant', async () => {
+    const container = await AstroContainer.create();
+    const html = await container.renderToString(ImageGallery, { props: imageGalleryFull });
+
+    expect(html).toContain('lg:grid-cols-3');
+  });
+
+  test('renders masonry variant with heading', async () => {
+    const container = await AstroContainer.create();
+    const html = await container.renderToString(ImageGallery, { props: imageGalleryMasonry });
+
+    expect(html).toContain('Masonry Gallery');
+    expect(html).toContain('Photography at natural aspect ratios');
+    expect(html).toContain('Landscape shot');
+  });
+
+  test('renders single variant with first image', async () => {
+    const container = await AstroContainer.create();
+    const html = await container.renderToString(ImageGallery, { props: imageGallerySingle });
+
+    expect(html).toContain('Featured Image');
+    expect(html).toContain('Hero photograph');
+  });
+
+  test('handles minimal data without crashing', async () => {
+    const container = await AstroContainer.create();
+    const html = await container.renderToString(ImageGallery, { props: imageGalleryMinimal });
+    expect(html).toBeDefined();
+  });
+});

--- a/astro-app/src/components/__tests__/TeamGrid.test.ts
+++ b/astro-app/src/components/__tests__/TeamGrid.test.ts
@@ -1,0 +1,53 @@
+import { experimental_AstroContainer as AstroContainer } from 'astro/container';
+import { describe, test, expect } from 'vitest';
+import TeamGrid from '../blocks/custom/TeamGrid.astro';
+import { teamGridFull, teamGridCompact, teamGridSplit, teamGridMinimal } from './__fixtures__/team-grid';
+
+describe('TeamGrid', () => {
+  test('renders heading and team members in grid variant', async () => {
+    const container = await AstroContainer.create();
+    const html = await container.renderToString(TeamGrid, { props: teamGridFull });
+
+    expect(html).toContain('Our Team');
+    expect(html).toContain('Meet the people behind our work');
+    expect(html).toContain('Alice Johnson');
+    expect(html).toContain('Lead Developer');
+    expect(html).toContain('Bob Smith');
+    expect(html).toContain('Designer');
+  });
+
+  test('renders social links in grid variant', async () => {
+    const container = await AstroContainer.create();
+    const html = await container.renderToString(TeamGrid, { props: teamGridFull });
+
+    expect(html).toContain('GitHub');
+    expect(html).toContain('https://github.com/alice');
+    expect(html).toContain('LinkedIn');
+    expect(html).toContain('Portfolio');
+  });
+
+  test('renders grid-compact variant with name and role only', async () => {
+    const container = await AstroContainer.create();
+    const html = await container.renderToString(TeamGrid, { props: teamGridCompact });
+
+    expect(html).toContain('Team');
+    expect(html).toContain('Carol White');
+    expect(html).toContain('Engineer');
+  });
+
+  test('renders split variant with heading and members', async () => {
+    const container = await AstroContainer.create();
+    const html = await container.renderToString(TeamGrid, { props: teamGridSplit });
+
+    expect(html).toContain('Meet Our Team');
+    expect(html).toContain('We are a diverse group of professionals');
+    expect(html).toContain('Dave Brown');
+    expect(html).toContain('PM');
+  });
+
+  test('handles minimal data without crashing', async () => {
+    const container = await AstroContainer.create();
+    const html = await container.renderToString(TeamGrid, { props: teamGridMinimal });
+    expect(html).toBeDefined();
+  });
+});

--- a/astro-app/src/components/__tests__/__fixtures__/article-list.ts
+++ b/astro-app/src/components/__tests__/__fixtures__/article-list.ts
@@ -1,0 +1,61 @@
+import type { ArticleListBlock } from '@/lib/types';
+
+export const articleListFull: ArticleListBlock = {
+  _type: 'articleList',
+  _key: 'test-al-1',
+  backgroundVariant: null,
+  spacing: 'default',
+  maxWidth: 'default',
+  variant: 'grid',
+  heading: 'Latest Articles',
+  description: 'Stay up to date with our news',
+  source: 'all',
+  limit: 6,
+  links: [
+    { _key: 'btn-1', text: 'View All Articles', url: '/articles', variant: 'default' },
+  ],
+};
+
+export const articleListSplitFeatured: ArticleListBlock = {
+  _type: 'articleList',
+  _key: 'test-al-2',
+  backgroundVariant: null,
+  spacing: 'default',
+  maxWidth: 'default',
+  variant: 'split-featured',
+  heading: 'Featured Articles',
+  description: 'Our top picks',
+  source: 'blog',
+  limit: 4,
+  links: null,
+};
+
+export const articleListVariantList: ArticleListBlock = {
+  _type: 'articleList',
+  _key: 'test-al-3',
+  backgroundVariant: null,
+  spacing: 'default',
+  maxWidth: 'default',
+  variant: 'list',
+  heading: 'News',
+  description: 'This should be hidden in list variant',
+  source: 'news',
+  limit: 10,
+  links: [
+    { _key: 'btn-2', text: 'More News', url: '/news', variant: 'outline' },
+  ],
+};
+
+export const articleListMinimal: ArticleListBlock = {
+  _type: 'articleList',
+  _key: 'test-al-4',
+  backgroundVariant: null,
+  spacing: null,
+  maxWidth: null,
+  variant: null,
+  heading: null,
+  description: null,
+  source: null,
+  limit: null,
+  links: null,
+};

--- a/astro-app/src/components/__tests__/__fixtures__/image-gallery.ts
+++ b/astro-app/src/components/__tests__/__fixtures__/image-gallery.ts
@@ -1,0 +1,77 @@
+import type { ImageGalleryBlock } from '@/lib/types';
+
+const testImage = {
+  _type: 'image' as const,
+  asset: {
+    _id: 'image-abc123gallery-800x600-jpg',
+    url: 'https://cdn.sanity.io/images/test/test/abc123gallery-800x600.jpg',
+    metadata: {
+      lqip: 'data:image/jpeg;base64,/9j/2wBDAAYEBQY',
+      dimensions: { width: 800, height: 600, aspectRatio: 1.333 },
+    },
+  },
+  alt: 'Gallery photo',
+  hotspot: { x: 0.5, y: 0.5, width: 1, height: 1 },
+  crop: { top: 0, bottom: 0, left: 0, right: 0 },
+};
+
+export const imageGalleryFull: ImageGalleryBlock = {
+  _type: 'imageGallery',
+  _key: 'test-ig-1',
+  backgroundVariant: null,
+  spacing: 'default',
+  maxWidth: 'default',
+  variant: 'grid',
+  heading: 'Photo Gallery',
+  description: 'A collection of our best work',
+  images: [
+    { _key: 'gi-1', image: testImage, caption: 'Project Alpha' },
+    { _key: 'gi-2', image: testImage, caption: 'Project Beta' },
+    { _key: 'gi-3', image: testImage, caption: null },
+  ],
+  columns: '3',
+};
+
+export const imageGalleryMasonry: ImageGalleryBlock = {
+  _type: 'imageGallery',
+  _key: 'test-ig-2',
+  backgroundVariant: null,
+  spacing: 'default',
+  maxWidth: 'default',
+  variant: 'masonry',
+  heading: 'Masonry Gallery',
+  description: 'Photography at natural aspect ratios',
+  images: [
+    { _key: 'gi-4', image: testImage, caption: 'Landscape shot' },
+    { _key: 'gi-5', image: testImage, caption: null },
+  ],
+  columns: null,
+};
+
+export const imageGallerySingle: ImageGalleryBlock = {
+  _type: 'imageGallery',
+  _key: 'test-ig-3',
+  backgroundVariant: null,
+  spacing: 'default',
+  maxWidth: 'default',
+  variant: 'single',
+  heading: 'Featured Image',
+  description: null,
+  images: [
+    { _key: 'gi-6', image: testImage, caption: 'Hero photograph' },
+  ],
+  columns: null,
+};
+
+export const imageGalleryMinimal: ImageGalleryBlock = {
+  _type: 'imageGallery',
+  _key: 'test-ig-4',
+  backgroundVariant: null,
+  spacing: null,
+  maxWidth: null,
+  variant: null,
+  heading: null,
+  description: null,
+  images: null,
+  columns: null,
+};

--- a/astro-app/src/components/__tests__/__fixtures__/team-grid.ts
+++ b/astro-app/src/components/__tests__/__fixtures__/team-grid.ts
@@ -1,0 +1,98 @@
+import type { TeamGridBlock } from '@/lib/types';
+
+const testImage = {
+  _type: 'image' as const,
+  asset: {
+    _id: 'image-Tb9Ew8CXIwaY6R1kjMvI0uRR-400x400-jpg',
+    url: 'https://cdn.sanity.io/images/test/test/Tb9Ew8CXIwaY6R1kjMvI0uRR-400x400.jpg',
+    metadata: {
+      lqip: 'data:image/jpeg;base64,/9j/2wBDAAYEBQY',
+      dimensions: { width: 400, height: 400, aspectRatio: 1 },
+    },
+  },
+  alt: 'Test portrait',
+  hotspot: { x: 0.5, y: 0.5, width: 1, height: 1 },
+  crop: { top: 0, bottom: 0, left: 0, right: 0 },
+};
+
+export const teamGridFull: TeamGridBlock = {
+  _type: 'teamGrid',
+  _key: 'test-tg-1',
+  backgroundVariant: null,
+  spacing: 'default',
+  maxWidth: 'default',
+  variant: 'grid',
+  heading: 'Our Team',
+  description: 'Meet the people behind our work',
+  items: [
+    {
+      _key: 'tm-1',
+      name: 'Alice Johnson',
+      role: 'Lead Developer',
+      image: testImage,
+      links: [
+        { _key: 'l1', label: 'GitHub', href: 'https://github.com/alice' },
+        { _key: 'l2', label: 'LinkedIn', href: 'https://linkedin.com/in/alice' },
+      ],
+    },
+    {
+      _key: 'tm-2',
+      name: 'Bob Smith',
+      role: 'Designer',
+      image: testImage,
+      links: [{ _key: 'l3', label: 'Portfolio', href: 'https://bob.design' }],
+    },
+  ],
+};
+
+export const teamGridCompact: TeamGridBlock = {
+  _type: 'teamGrid',
+  _key: 'test-tg-2',
+  backgroundVariant: null,
+  spacing: 'default',
+  maxWidth: 'default',
+  variant: 'grid-compact',
+  heading: 'Team',
+  description: null,
+  items: [
+    {
+      _key: 'tm-3',
+      name: 'Carol White',
+      role: 'Engineer',
+      image: testImage,
+      links: null,
+    },
+  ],
+};
+
+export const teamGridSplit: TeamGridBlock = {
+  _type: 'teamGrid',
+  _key: 'test-tg-3',
+  backgroundVariant: null,
+  spacing: 'default',
+  maxWidth: 'default',
+  variant: 'split',
+  heading: 'Meet Our Team',
+  description: 'We are a diverse group of professionals',
+  items: [
+    {
+      _key: 'tm-4',
+      name: 'Dave Brown',
+      role: 'PM',
+      image: testImage,
+      links: null,
+    },
+  ],
+};
+
+export const teamGridMinimal: TeamGridBlock = {
+  _type: 'teamGrid',
+  _key: 'test-tg-4',
+  backgroundVariant: null,
+  spacing: null,
+  maxWidth: null,
+  variant: null,
+  heading: null,
+  description: null,
+  items: null,
+};

--- a/astro-app/src/components/blocks/custom/ArticleList.stories.ts
+++ b/astro-app/src/components/blocks/custom/ArticleList.stories.ts
@@ -1,0 +1,58 @@
+import ArticleList from './ArticleList.astro'
+
+const sharedButtons = [
+  { _key: 'btn-1', text: 'View All Articles', url: '/articles', variant: 'outline' },
+]
+
+export default {
+  title: 'Blocks/ArticleList',
+  component: ArticleList,
+  tags: ['autodocs'],
+}
+
+export const Grid = {
+  args: {
+    _type: 'articleList',
+    _key: 'story-al-grid',
+    variant: 'grid',
+    heading: 'Latest Articles',
+    description: 'News and insights from our team on technology, design, and community.',
+    source: 'all',
+    limit: 6,
+    links: sharedButtons,
+  },
+}
+
+export const SplitFeatured = {
+  args: {
+    _type: 'articleList',
+    _key: 'story-al-split',
+    variant: 'split-featured',
+    heading: 'From the Blog',
+    description: 'Featured stories and recent posts.',
+    source: 'blog',
+    limit: 4,
+    links: sharedButtons,
+  },
+}
+
+export const List = {
+  args: {
+    _type: 'articleList',
+    _key: 'story-al-list',
+    variant: 'list',
+    heading: 'Archive',
+    source: 'all',
+    limit: 10,
+    links: sharedButtons,
+  },
+}
+
+export const Minimal = {
+  args: {
+    _type: 'articleList',
+    _key: 'story-al-minimal',
+    variant: 'grid',
+    heading: 'Articles',
+  },
+}

--- a/astro-app/src/components/blocks/custom/ImageGallery.astro
+++ b/astro-app/src/components/blocks/custom/ImageGallery.astro
@@ -1,0 +1,111 @@
+---
+import type { ImageGalleryBlock } from '@/lib/types';
+import { stegaClean } from '@sanity/client/stega';
+import { urlFor } from '@/lib/image';
+import { Section, SectionContent, SectionMasonry } from '@/components/ui/section';
+
+interface Props extends ImageGalleryBlock {
+  class?: string;
+  id?: string;
+}
+
+const { heading, description, images, columns: rawColumns, variant: rawVariant } = Astro.props;
+const variant = stegaClean(rawVariant) ?? 'grid';
+const columns = stegaClean(rawColumns) ?? '3';
+
+const gridColsClass: Record<string, string> = {
+  '2': 'grid-cols-1 sm:grid-cols-2',
+  '3': 'grid-cols-1 sm:grid-cols-2 lg:grid-cols-3',
+  '4': 'grid-cols-1 sm:grid-cols-2 lg:grid-cols-4',
+};
+---
+
+{variant === 'grid' && (
+  <Section data-animate>
+    {heading && (
+      <SectionContent class="max-w-3xl">
+        <h2 class="text-4xl md:text-5xl font-bold tracking-[-0.03em] leading-[1.05]">{heading}</h2>
+        {description && <p class="mt-4 text-lg text-muted-foreground">{description}</p>}
+      </SectionContent>
+    )}
+    <SectionContent>
+      <div class={`grid gap-6 ${gridColsClass[columns] || gridColsClass['3']}`}>
+        {(images ?? []).map((item) => (
+          <figure>
+            {item.image?.asset && (
+              <img
+                src={urlFor(item.image).width(800).height(600).fit('crop').url()}
+                alt={item.image.alt || ''}
+                width={800}
+                height={600}
+                class="aspect-video w-full object-cover"
+                loading="lazy"
+                style={item.image.asset.metadata?.lqip ? `background-image: url(${item.image.asset.metadata.lqip}); background-size: cover;` : undefined}
+              />
+            )}
+            {item.caption && <figcaption class="mt-2 text-sm text-muted-foreground">{item.caption}</figcaption>}
+          </figure>
+        ))}
+      </div>
+    </SectionContent>
+  </Section>
+)}
+
+{variant === 'masonry' && (
+  <Section data-animate>
+    {heading && (
+      <SectionContent class="max-w-3xl">
+        <h2 class="text-4xl md:text-5xl font-bold tracking-[-0.03em] leading-[1.05]">{heading}</h2>
+        {description && <p class="mt-4 text-lg text-muted-foreground">{description}</p>}
+      </SectionContent>
+    )}
+    <SectionMasonry>
+      {(images ?? []).map((item) => (
+        <figure>
+          {item.image?.asset && (
+            <img
+              src={urlFor(item.image).width(800).url()}
+              alt={item.image.alt || ''}
+              width={item.image.asset.metadata?.dimensions?.width || 800}
+              height={item.image.asset.metadata?.dimensions?.height || 600}
+              class="w-full object-cover"
+              loading="lazy"
+              style={item.image.asset.metadata?.lqip ? `background-image: url(${item.image.asset.metadata.lqip}); background-size: cover;` : undefined}
+            />
+          )}
+          {item.caption && <figcaption class="mt-2 text-sm text-muted-foreground">{item.caption}</figcaption>}
+        </figure>
+      ))}
+    </SectionMasonry>
+  </Section>
+)}
+
+{variant === 'single' && (() => {
+  const item = images?.[0];
+  return item ? (
+    <Section data-animate>
+      {heading && (
+        <SectionContent class="max-w-3xl">
+          <h2 class="text-4xl md:text-5xl font-bold tracking-[-0.03em] leading-[1.05]">{heading}</h2>
+          {description && <p class="mt-4 text-lg text-muted-foreground">{description}</p>}
+        </SectionContent>
+      )}
+      <SectionContent>
+        <figure>
+          {item.image?.asset && (
+            <img
+              src={urlFor(item.image).width(1600).url()}
+              alt={item.image.alt || ''}
+              width={item.image.asset.metadata?.dimensions?.width || 1600}
+              height={item.image.asset.metadata?.dimensions?.height || 900}
+              class="w-full object-cover"
+              loading="lazy"
+              style={item.image.asset.metadata?.lqip ? `background-image: url(${item.image.asset.metadata.lqip}); background-size: cover;` : undefined}
+            />
+          )}
+          {item.caption && <figcaption class="mt-4 text-center text-sm text-muted-foreground">{item.caption}</figcaption>}
+        </figure>
+      </SectionContent>
+    </Section>
+  ) : null;
+})()}

--- a/astro-app/src/components/blocks/custom/ImageGallery.stories.ts
+++ b/astro-app/src/components/blocks/custom/ImageGallery.stories.ts
@@ -1,0 +1,93 @@
+import ImageGallery from './ImageGallery.astro'
+
+const imageRefs = [
+  'image-523d2dda175c24fee4af8f6abc93a3b086ca5e69-3000x2000-jpg',
+  'image-117be8afe69ff441c417bb9de6e457e82848aaf4-5712x4284-jpg',
+  'image-73cbcec87cb346397bf7617af9b866cd2d827be0-1921x1441-jpg',
+  'image-7203ad7a8e72a3bfd66d976594a68fc8ba555efc-1024x576-jpg',
+  'image-526748e6980d684ad21fdbd7273c2731ed2f43a0-780x585-webp',
+  'image-f0e8060516dbac8e78932f06932a17252b37164b-1920x1006-png',
+]
+
+const makeImage = (key: string, caption: string, index = 0) => ({
+  _key: key,
+  image: {
+    _type: 'image' as const,
+    asset: {
+      _ref: imageRefs[index % imageRefs.length],
+      _type: 'reference' as const,
+    },
+    alt: caption,
+  },
+  caption,
+})
+
+const galleryImages = [
+  makeImage('gi-1', 'Architectural detail — concrete and glass', 0),
+  makeImage('gi-2', 'Typography specimen wall', 1),
+  makeImage('gi-3', 'Grid system in practice', 2),
+  makeImage('gi-4', 'Geometric abstraction', 3),
+  makeImage('gi-5', 'Negative space study', 4),
+  makeImage('gi-6', 'Form follows function', 5),
+]
+
+export default {
+  title: 'Blocks/ImageGallery',
+  component: ImageGallery,
+  tags: ['autodocs'],
+}
+
+export const GridThreeColumns = {
+  args: {
+    _type: 'imageGallery',
+    _key: 'story-ig-grid3',
+    variant: 'grid',
+    heading: 'Photography',
+    description: 'A curated selection of images exploring Swiss design principles in the built environment.',
+    images: galleryImages,
+    columns: '3',
+  },
+}
+
+export const GridTwoColumns = {
+  args: {
+    _type: 'imageGallery',
+    _key: 'story-ig-grid2',
+    variant: 'grid',
+    heading: 'Selected Works',
+    images: galleryImages.slice(0, 4),
+    columns: '2',
+  },
+}
+
+export const GridFourColumns = {
+  args: {
+    _type: 'imageGallery',
+    _key: 'story-ig-grid4',
+    variant: 'grid',
+    heading: 'Archive',
+    images: galleryImages,
+    columns: '4',
+  },
+}
+
+export const Masonry = {
+  args: {
+    _type: 'imageGallery',
+    _key: 'story-ig-masonry',
+    variant: 'masonry',
+    heading: 'Visual Exploration',
+    description: 'Images at their natural aspect ratios — photography speaks for itself.',
+    images: galleryImages,
+  },
+}
+
+export const Single = {
+  args: {
+    _type: 'imageGallery',
+    _key: 'story-ig-single',
+    variant: 'single',
+    heading: 'Featured Image',
+    images: [galleryImages[0]],
+  },
+}

--- a/astro-app/src/components/blocks/custom/TeamGrid.astro
+++ b/astro-app/src/components/blocks/custom/TeamGrid.astro
@@ -1,0 +1,121 @@
+---
+import type { TeamGridBlock } from '@/lib/types';
+import { stegaClean } from '@sanity/client/stega';
+import { urlFor } from '@/lib/image';
+import { Section, SectionContent, SectionGrid, SectionSplit } from '@/components/ui/section';
+import { Tile, TileContent, TileMedia } from '@/components/ui/tile';
+
+interface Props extends TeamGridBlock {
+  class?: string;
+  id?: string;
+}
+
+const { heading, description, items, variant: rawVariant } = Astro.props;
+const variant = stegaClean(rawVariant) ?? 'grid';
+---
+
+{variant === 'grid' && (
+  <Section data-animate>
+    {heading && (
+      <SectionContent class="max-w-3xl">
+        <h2 class="text-4xl md:text-5xl font-bold tracking-[-0.03em] leading-[1.05]">{heading}</h2>
+        {description && <p class="mt-4 text-lg text-muted-foreground">{description}</p>}
+      </SectionContent>
+    )}
+    <SectionGrid size="default">
+      {(items ?? []).map((member) => (
+        <Tile>
+          {member.image?.asset && (
+            <TileMedia>
+              <img
+                src={urlFor(member.image).width(400).height(400).fit('crop').url()}
+                alt={member.image.alt || member.name || ''}
+                width={400}
+                height={400}
+                class="aspect-square w-full object-cover"
+                loading="lazy"
+                style={member.image.asset.metadata?.lqip ? `background-image: url(${member.image.asset.metadata.lqip}); background-size: cover;` : undefined}
+              />
+            </TileMedia>
+          )}
+          <TileContent>
+            <p class="font-semibold">{member.name}</p>
+            {member.role && <p class="text-sm text-muted-foreground">{member.role}</p>}
+            {member.links && member.links.length > 0 && (
+              <div class="mt-2 flex gap-2">
+                {member.links.map((link) => (
+                  <a href={stegaClean(link.href)} target="_blank" rel="noopener noreferrer" class="text-sm text-muted-foreground underline-offset-4 hover:underline">{link.label}</a>
+                ))}
+              </div>
+            )}
+          </TileContent>
+        </Tile>
+      ))}
+    </SectionGrid>
+  </Section>
+)}
+
+{variant === 'grid-compact' && (
+  <Section data-animate>
+    {heading && (
+      <SectionContent class="max-w-3xl">
+        <h2 class="text-4xl md:text-5xl font-bold tracking-[-0.03em] leading-[1.05]">{heading}</h2>
+      </SectionContent>
+    )}
+    <SectionGrid size="sm">
+      {(items ?? []).map((member) => (
+        <div class="flex items-center gap-3">
+          {member.image?.asset && (
+            <img
+              src={urlFor(member.image).width(80).height(80).fit('crop').url()}
+              alt={member.image.alt || member.name || ''}
+              width={80}
+              height={80}
+              class="size-20 flex-shrink-0 object-cover"
+              loading="lazy"
+              style={member.image.asset.metadata?.lqip ? `background-image: url(${member.image.asset.metadata.lqip}); background-size: cover;` : undefined}
+            />
+          )}
+          <div>
+            <p class="font-semibold text-sm">{member.name}</p>
+            {member.role && <p class="text-xs text-muted-foreground">{member.role}</p>}
+          </div>
+        </div>
+      ))}
+    </SectionGrid>
+  </Section>
+)}
+
+{variant === 'split' && (
+  <Section data-animate>
+    <SectionSplit>
+      <div class="sticky top-24 self-start">
+        {heading && <h2 class="text-4xl md:text-5xl font-bold tracking-[-0.03em] leading-[1.05]">{heading}</h2>}
+        {description && <p class="mt-4 text-lg text-muted-foreground">{description}</p>}
+      </div>
+      <div class="grid grid-cols-2 gap-6">
+        {(items ?? []).map((member) => (
+          <Tile>
+            {member.image?.asset && (
+              <TileMedia>
+                <img
+                  src={urlFor(member.image).width(400).height(400).fit('crop').url()}
+                  alt={member.image.alt || member.name || ''}
+                  width={400}
+                  height={400}
+                  class="aspect-square w-full object-cover"
+                  loading="lazy"
+                  style={member.image.asset.metadata?.lqip ? `background-image: url(${member.image.asset.metadata.lqip}); background-size: cover;` : undefined}
+                />
+              </TileMedia>
+            )}
+            <TileContent>
+              <p class="font-semibold">{member.name}</p>
+              {member.role && <p class="text-sm text-muted-foreground">{member.role}</p>}
+            </TileContent>
+          </Tile>
+        ))}
+      </div>
+    </SectionSplit>
+  </Section>
+)}

--- a/astro-app/src/components/blocks/custom/TeamGrid.stories.ts
+++ b/astro-app/src/components/blocks/custom/TeamGrid.stories.ts
@@ -1,0 +1,67 @@
+import TeamGrid from './TeamGrid.astro'
+
+const sharedImage = {
+  _type: 'image' as const,
+  asset: {
+    _ref: 'image-117be8afe69ff441c417bb9de6e457e82848aaf4-5712x4284-jpg',
+    _type: 'reference' as const,
+  },
+  alt: 'Team member portrait',
+}
+
+const teamMembers = [
+  { _key: 'tm-1', name: 'Alice Chen', role: 'Lead Developer', image: sharedImage, links: [{ _key: 'l1', label: 'GitHub', href: 'https://github.com' }] },
+  { _key: 'tm-2', name: 'Bob Martinez', role: 'UX Designer', image: sharedImage, links: [{ _key: 'l2', label: 'LinkedIn', href: 'https://linkedin.com' }] },
+  { _key: 'tm-3', name: 'Carol Johnson', role: 'Project Manager', image: sharedImage, links: [] },
+  { _key: 'tm-4', name: 'David Park', role: 'Backend Engineer', image: sharedImage, links: [{ _key: 'l3', label: 'Website', href: 'https://example.com' }] },
+  { _key: 'tm-5', name: 'Eva Schmidt', role: 'Data Scientist', image: sharedImage, links: [] },
+  { _key: 'tm-6', name: 'Frank Liu', role: 'DevOps Engineer', image: sharedImage, links: [{ _key: 'l4', label: 'GitHub', href: 'https://github.com' }] },
+]
+
+export default {
+  title: 'Blocks/TeamGrid',
+  component: TeamGrid,
+  tags: ['autodocs'],
+}
+
+export const Grid = {
+  args: {
+    _type: 'teamGrid',
+    _key: 'story-tg-grid',
+    variant: 'grid',
+    heading: 'Meet Our Team',
+    description: 'The people behind the project — engineers, designers, and strategists working together.',
+    items: teamMembers,
+  },
+}
+
+export const GridCompact = {
+  args: {
+    _type: 'teamGrid',
+    _key: 'story-tg-compact',
+    variant: 'grid-compact',
+    heading: 'Our Team',
+    items: teamMembers,
+  },
+}
+
+export const Split = {
+  args: {
+    _type: 'teamGrid',
+    _key: 'story-tg-split',
+    variant: 'split',
+    heading: 'Who We Are',
+    description: 'A cross-functional team with expertise across the full stack.',
+    items: teamMembers.slice(0, 4),
+  },
+}
+
+export const Minimal = {
+  args: {
+    _type: 'teamGrid',
+    _key: 'story-tg-minimal',
+    variant: 'grid',
+    heading: 'Team',
+    items: teamMembers.slice(0, 2),
+  },
+}

--- a/studio/src/schemaTypes/blocks/article-list.ts
+++ b/studio/src/schemaTypes/blocks/article-list.ts
@@ -1,0 +1,56 @@
+import {defineField, defineArrayMember} from 'sanity'
+import {DocumentTextIcon} from '@sanity/icons'
+import {defineBlock} from '../helpers/defineBlock'
+
+export const articleList = defineBlock({
+  name: 'articleList',
+  title: 'Article List',
+  icon: DocumentTextIcon,
+  variants: [
+    {name: 'grid', title: 'Grid'},
+    {name: 'split-featured', title: 'Split Featured'},
+    {name: 'list', title: 'List'},
+  ],
+  hiddenByVariant: {
+    description: ['list'],
+  },
+  fields: [
+    defineField({
+      name: 'heading',
+      title: 'Heading',
+      type: 'string',
+    }),
+    defineField({
+      name: 'description',
+      title: 'Description',
+      type: 'text',
+    }),
+    defineField({
+      name: 'source',
+      title: 'Source',
+      type: 'string',
+      options: {
+        list: [
+          {title: 'All', value: 'all'},
+          {title: 'Blog', value: 'blog'},
+          {title: 'News', value: 'news'},
+        ],
+        layout: 'radio',
+      },
+      initialValue: 'all',
+    }),
+    defineField({
+      name: 'limit',
+      title: 'Max Articles to Display',
+      type: 'number',
+      initialValue: 6,
+      validation: (Rule) => Rule.min(1).max(20),
+    }),
+    defineField({
+      name: 'links',
+      title: 'CTA Buttons',
+      type: 'array',
+      of: [defineArrayMember({type: 'button'})],
+    }),
+  ],
+})

--- a/studio/src/schemaTypes/blocks/divider.ts
+++ b/studio/src/schemaTypes/blocks/divider.ts
@@ -1,11 +1,11 @@
 import {defineField} from 'sanity'
-import {MinusIcon} from '@sanity/icons'
+import {RemoveIcon} from '@sanity/icons'
 import {defineBlock} from '../helpers/defineBlock'
 
 export const divider = defineBlock({
   name: 'divider',
   title: 'Divider',
-  icon: MinusIcon,
+  icon: RemoveIcon,
   preview: {select: {title: 'label'}},
   variants: [
     {name: 'line', title: 'Line'},

--- a/studio/src/schemaTypes/blocks/image-gallery.ts
+++ b/studio/src/schemaTypes/blocks/image-gallery.ts
@@ -1,0 +1,50 @@
+import {defineField, defineArrayMember} from 'sanity'
+import {ImagesIcon} from '@sanity/icons'
+import {defineBlock} from '../helpers/defineBlock'
+
+export const imageGallery = defineBlock({
+  name: 'imageGallery',
+  title: 'Image Gallery',
+  icon: ImagesIcon,
+  variants: [
+    {name: 'grid', title: 'Grid'},
+    {name: 'masonry', title: 'Masonry'},
+    {name: 'single', title: 'Single'},
+  ],
+  hiddenByVariant: {
+    columns: ['masonry', 'single'],
+  },
+  fields: [
+    defineField({
+      name: 'heading',
+      title: 'Heading',
+      type: 'string',
+    }),
+    defineField({
+      name: 'description',
+      title: 'Description',
+      type: 'text',
+    }),
+    defineField({
+      name: 'images',
+      title: 'Images',
+      type: 'array',
+      of: [defineArrayMember({type: 'galleryImage'})],
+      validation: (Rule) => Rule.required().min(1),
+    }),
+    defineField({
+      name: 'columns',
+      title: 'Columns',
+      type: 'string',
+      options: {
+        list: [
+          {title: '2 Columns', value: '2'},
+          {title: '3 Columns', value: '3'},
+          {title: '4 Columns', value: '4'},
+        ],
+        layout: 'radio',
+      },
+      initialValue: '3',
+    }),
+  ],
+})

--- a/studio/src/schemaTypes/blocks/team-grid.ts
+++ b/studio/src/schemaTypes/blocks/team-grid.ts
@@ -1,0 +1,36 @@
+import {defineField, defineArrayMember} from 'sanity'
+import {UsersIcon} from '@sanity/icons'
+import {defineBlock} from '../helpers/defineBlock'
+
+export const teamGrid = defineBlock({
+  name: 'teamGrid',
+  title: 'Team Grid',
+  icon: UsersIcon,
+  variants: [
+    {name: 'grid', title: 'Grid'},
+    {name: 'grid-compact', title: 'Grid Compact'},
+    {name: 'split', title: 'Split'},
+  ],
+  hiddenByVariant: {
+    description: ['grid-compact'],
+  },
+  fields: [
+    defineField({
+      name: 'heading',
+      title: 'Heading',
+      type: 'string',
+    }),
+    defineField({
+      name: 'description',
+      title: 'Description',
+      type: 'text',
+    }),
+    defineField({
+      name: 'items',
+      title: 'Team Members',
+      type: 'array',
+      of: [defineArrayMember({type: 'teamMember'})],
+      validation: (Rule) => Rule.required().min(1),
+    }),
+  ],
+})

--- a/studio/src/schemaTypes/objects/gallery-image.ts
+++ b/studio/src/schemaTypes/objects/gallery-image.ts
@@ -1,0 +1,33 @@
+import {defineType, defineField} from 'sanity'
+
+export const galleryImage = defineType({
+  name: 'galleryImage',
+  title: 'Gallery Image',
+  type: 'object',
+  fields: [
+    defineField({
+      name: 'image',
+      title: 'Image',
+      type: 'image',
+      options: {hotspot: true},
+      validation: (Rule) => Rule.required(),
+      fields: [
+        defineField({
+          name: 'alt',
+          title: 'Alternative Text',
+          type: 'string',
+          description: 'Required for accessibility',
+          validation: (Rule) => Rule.required(),
+        }),
+      ],
+    }),
+    defineField({
+      name: 'caption',
+      title: 'Caption',
+      type: 'string',
+    }),
+  ],
+  preview: {
+    select: {title: 'caption'},
+  },
+})

--- a/studio/src/schemaTypes/objects/team-member.ts
+++ b/studio/src/schemaTypes/objects/team-member.ts
@@ -1,0 +1,44 @@
+import {defineType, defineField, defineArrayMember} from 'sanity'
+
+export const teamMember = defineType({
+  name: 'teamMember',
+  title: 'Team Member',
+  type: 'object',
+  fields: [
+    defineField({
+      name: 'name',
+      title: 'Name',
+      type: 'string',
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: 'role',
+      title: 'Role',
+      type: 'string',
+    }),
+    defineField({
+      name: 'image',
+      title: 'Image',
+      type: 'image',
+      options: {hotspot: true},
+      fields: [
+        defineField({
+          name: 'alt',
+          title: 'Alternative Text',
+          type: 'string',
+          description: 'Required for accessibility',
+          validation: (Rule) => Rule.required(),
+        }),
+      ],
+    }),
+    defineField({
+      name: 'links',
+      title: 'Links',
+      type: 'array',
+      of: [defineArrayMember({type: 'link'})],
+    }),
+  ],
+  preview: {
+    select: {title: 'name', subtitle: 'role'},
+  },
+})


### PR DESCRIPTION
## What This PR Does

This PR adds **three new page builder blocks** that let content editors display teams, photo galleries, and article lists on any page — all styled with clean Swiss design (no rounded corners, no shadows, strict grids).

### New Blocks

#### 1. Team Grid (`teamGrid`)
Shows a grid of team members with their photo, name, role, and social links.

| Variant | What it looks like |
|---|---|
| `grid` (default) | Responsive card grid (2→3→4 columns). Each card has a square portrait, name, role, and link icons. |
| `grid-compact` | Denser layout with smaller portraits — just name and role, no links. Good for large teams. |
| `split` | Heading and description pinned on the left, team grid on the right. |

#### 2. Image Gallery (`imageGallery`)
Displays a collection of images with optional captions.

| Variant | What it looks like |
|---|---|
| `grid` (default) | Equal-sized image tiles in a strict grid. You pick 2, 3, or 4 columns. |
| `masonry` | Flowing layout that respects each image's natural aspect ratio. |
| `single` | One full-width image with a caption underneath. |

#### 3. Article List (`articleList`)
Placeholder block for displaying blog/news articles. The layout is ready, but it shows skeleton cards until an `article` document type is created in a future story.

| Variant | What it looks like |
|---|---|
| `grid` (default) | Card grid with placeholder image, title, and description areas. |
| `split-featured` | First article takes up the left half, remaining articles grid on the right. |
| `list` | Minimal text-only rows — date, title, excerpt. No images. |

### What's in Each File

**Sanity Schemas** (the content models that define what editors can fill in):
- `studio/src/schemaTypes/objects/team-member.ts` — Fields: name, role, image, social links
- `studio/src/schemaTypes/objects/gallery-image.ts` — Fields: image, caption
- `studio/src/schemaTypes/blocks/team-grid.ts` — Block with heading, description, and array of team members
- `studio/src/schemaTypes/blocks/image-gallery.ts` — Block with heading, description, images, and column count
- `studio/src/schemaTypes/blocks/article-list.ts` — Block with heading, description, source filter, and limit

**Astro Components** (the frontend rendering):
- `astro-app/src/components/blocks/custom/TeamGrid.astro` — Renders all 3 team grid variants
- `astro-app/src/components/blocks/custom/ImageGallery.astro` — Renders all 3 gallery variants

**Tests** (verify each variant renders correctly):
- `astro-app/src/components/__tests__/TeamGrid.test.ts` — 5 tests
- `astro-app/src/components/__tests__/ImageGallery.test.ts` — 5 tests
- `astro-app/src/components/__tests__/ArticleList.test.ts` — 7 tests
- Matching fixture files in `__fixtures__/` provide sample data for each test

**Storybook Stories** (visual previews of every variant):
- One `.stories.ts` file per block, with a story for each variant

**Bug Fixes included:**
- `studio/src/schemaTypes/blocks/divider.ts` — `MinusIcon` was removed from `@sanity/icons`, replaced with `RemoveIcon`
- `astro-app/.storybook/main.ts` — Fixed the Sanity client stub to use the real project ID so CDN images load in Storybook

### How to Test

1. **Run the dev server:** `npm run dev -w astro-app`
2. **Run tests:** `npm run test:unit` — look for the 17 new tests passing
3. **Open Storybook:** `npm run storybook -w astro-app` — browse TeamGrid, ImageGallery, and ArticleList stories
4. **Check Sanity Studio:** `npm run dev -w studio` — click "Add block" on any page and find the new blocks in the "Display" and "Content" groups

## Test Plan

- [ ] `npm run test:unit` passes (17 new tests for these blocks)
- [ ] `npm run build -w astro-app` succeeds
- [ ] Storybook stories render all variants correctly
- [ ] Sanity Studio shows blocks in correct insert menu groups (Display: teamGrid, imageGallery; Content: articleList)