### PR TITLE
fix(seo): add Cloudflare AI Search user-agent to robots.txt and fix trailing slash

### DIFF
--- a/astro-app/src/lib/__tests__/seo-metadata.test.ts
+++ b/astro-app/src/lib/__tests__/seo-metadata.test.ts
@@ -53,6 +53,16 @@ describe('SEO Metadata & Sitemap — Configuration', () => {
       expect(content).toContain('Allow: /');
     });
 
+    it('contains Cloudflare-AI-Search user-agent block', () => {
+      const content = readFileSync(endpointPath, 'utf-8');
+      expect(content).toContain('User-agent: Cloudflare-AI-Search');
+    });
+
+    it('normalizes trailing slash on SITE url before building Sitemap directive', () => {
+      const content = readFileSync(endpointPath, 'utf-8');
+      expect(content).toMatch(/replace\(\/\\\/\$\/, ['"]['"]?\)/);
+    });
+
     it('disallows /portal/ routes', () => {
       const content = readFileSync(endpointPath, 'utf-8');
       expect(content).toContain('Disallow: /portal/');

--- a/astro-app/src/pages/robots.txt.ts
+++ b/astro-app/src/pages/robots.txt.ts
@@ -1,7 +1,7 @@
 import type { APIRoute } from 'astro';
 
 export const GET: APIRoute = () => {
-  const siteUrl = import.meta.env.SITE;
+  const siteUrl = import.meta.env.SITE?.replace(/\/$/, '') ?? '';
 
   const body = `User-agent: *
 Allow: /
@@ -9,7 +9,13 @@ Disallow: /portal/
 Disallow: /auth/
 Disallow: /student/
 
-Sitemap: ${siteUrl}sitemap-index.xml`;
+User-agent: Cloudflare-AI-Search
+Allow: /
+Disallow: /portal/
+Disallow: /auth/
+Disallow: /student/
+
+Sitemap: ${siteUrl}/sitemap-index.xml`;
 
   return new Response(body, {
     headers: { 'Content-Type': 'text/plain' },


### PR DESCRIPTION
- Add explicit Cloudflare-AI-Search user-agent block per CF best practices
- Normalize trailing slash on SITE env var to prevent malformed Sitemap URL
- Add test coverage for new user-agent block and URL normalization

https://developers.cloudflare.com/ai-search/configuration/data-source/website/