### PR TITLE
fix(studio): clean up RWC workspace config and fix slug collisions

### DIFF
--- a/studio/sanity.config.ts
+++ b/studio/sanity.config.ts
@@ -45,7 +45,7 @@ function createRwcWorkspace(opts: RwcWorkspaceOptions): WorkspaceOptions {
         },
       }),
       visionTool(),
-      formSchema(),
+      formSchema({}),
     ],
     schema: {
       types: createSchemaTypesForWorkspace('rwc'),
@@ -108,7 +108,7 @@ export default defineConfig([
         },
       }),
       visionTool(),
-      formSchema(),
+      formSchema({}),
     ],
     schema: {
       types: createSchemaTypesForWorkspace('production'),

--- a/studio/src/constants.ts
+++ b/studio/src/constants.ts
@@ -3,12 +3,3 @@ export const CAPSTONE_SINGLETON_TYPES = new Set(['siteSettings'])
 
 /** Document types that have the site field (from Story 15.1) */
 export const SITE_AWARE_TYPES = ['page', 'sponsor', 'project', 'testimonial', 'event']
-
-/** RWC site configurations */
-export const RWC_SITES = [
-  {id: 'rwc-us', title: 'RWC US'},
-  {id: 'rwc-intl', title: 'RWC International'},
-] as const
-
-/** Fixed document IDs for RWC siteSettings singletons */
-export const RWC_SINGLETON_IDS = RWC_SITES.map((s) => `siteSettings-${s.id}`)

--- a/studio/src/schemaTypes/documents/event.ts
+++ b/studio/src/schemaTypes/documents/event.ts
@@ -1,6 +1,6 @@
 import {defineType, defineField} from 'sanity'
 import {CalendarIcon, SearchIcon} from '@sanity/icons'
-import {siteField} from '../fields/site-field'
+import {siteField, siteScopedIsUnique} from '../fields/site-field'
 
 export const event = defineType({
   name: 'event',
@@ -32,7 +32,7 @@ export const event = defineType({
       title: 'Slug',
       type: 'slug',
       group: 'main',
-      options: {source: 'title', maxLength: 96},
+      options: {source: 'title', maxLength: 96, isUnique: siteScopedIsUnique},
       validation: (Rule) => Rule.required(),
     }),
     {...siteField, group: 'main'},

--- a/studio/src/schemaTypes/documents/page.ts
+++ b/studio/src/schemaTypes/documents/page.ts
@@ -1,6 +1,6 @@
 import {defineType, defineField, defineArrayMember} from 'sanity'
 import {DocumentIcon} from '@sanity/icons'
-import {siteField} from '../fields/site-field'
+import {siteField, siteScopedIsUnique} from '../fields/site-field'
 
 export const page = defineType({
   name: 'page',
@@ -28,7 +28,7 @@ export const page = defineType({
       title: 'Slug',
       type: 'slug',
       group: 'layout',
-      options: {source: 'title', maxLength: 96},
+      options: {source: 'title', maxLength: 96, isUnique: siteScopedIsUnique},
       validation: (Rule) => Rule.required(),
     }),
     {...siteField, group: 'layout'},

--- a/studio/src/schemaTypes/documents/project.ts
+++ b/studio/src/schemaTypes/documents/project.ts
@@ -1,6 +1,6 @@
 import {defineType, defineField, defineArrayMember} from 'sanity'
 import {ProjectsIcon, SearchIcon} from '@sanity/icons'
-import {siteField} from '../fields/site-field'
+import {siteField, siteScopedIsUnique} from '../fields/site-field'
 
 export const project = defineType({
   name: 'project',
@@ -30,7 +30,7 @@ export const project = defineType({
       title: 'Slug',
       type: 'slug',
       group: 'main',
-      options: {source: 'title'},
+      options: {source: 'title', isUnique: siteScopedIsUnique},
       validation: (Rule) => Rule.required(),
     }),
     {...siteField, group: 'main'},

--- a/studio/src/schemaTypes/documents/sponsor.ts
+++ b/studio/src/schemaTypes/documents/sponsor.ts
@@ -1,6 +1,6 @@
 import {defineType, defineField, defineArrayMember} from 'sanity'
 import {CreditCardIcon, SearchIcon} from '@sanity/icons'
-import {siteField} from '../fields/site-field'
+import {siteField, siteScopedIsUnique} from '../fields/site-field'
 
 export const sponsor = defineType({
   name: 'sponsor',
@@ -27,7 +27,7 @@ export const sponsor = defineType({
       title: 'Slug',
       type: 'slug',
       group: 'main',
-      options: {source: 'name'},
+      options: {source: 'name', isUnique: siteScopedIsUnique},
       validation: (Rule) => Rule.required(),
     }),
     {...siteField, group: 'main'},

--- a/studio/src/schemaTypes/fields/site-field.ts
+++ b/studio/src/schemaTypes/fields/site-field.ts
@@ -1,6 +1,33 @@
 import {defineField} from 'sanity'
 
 /**
+ * Slug uniqueness scoped to the same site.
+ * In the `rwc` dataset, two different sites can share the same slug.
+ * In `production`, site is empty so this degrades to a global check.
+ */
+export async function siteScopedIsUnique(
+  slug: string,
+  context: {
+    document?: {_id: string; _type?: string; [key: string]: unknown}
+    getClient: (options: {apiVersion: string}) => {
+      fetch: <T>(query: string, params: Record<string, unknown>) => Promise<T>
+    }
+    type?: {name?: string}
+  },
+): Promise<boolean> {
+  const {document, getClient, type} = context
+  const client = getClient({apiVersion: '2024-01-01'})
+  const id = document?._id.replace(/^drafts\./, '')
+  const site = (document as {site?: string})?.site || ''
+  const docType = type?.name || document?._type
+  const count = await client.fetch<number>(
+    `count(*[_type == $type && slug.current == $slug && site == $site && !(_id in [$id, $draftId])])`,
+    {type: docType, slug, site, id, draftId: `drafts.${id}`},
+  )
+  return count === 0
+}
+
+/**
  * Reusable site field for multi-site content filtering.
  * Hidden on `production` dataset (capstone editors never see it).
  * Required on `rwc` dataset via validation callback.

--- a/studio/src/structure/rwc-desk-structure.ts
+++ b/studio/src/structure/rwc-desk-structure.ts
@@ -1,6 +1,22 @@
-import {CogIcon} from '@sanity/icons'
+import {
+  CogIcon,
+  DocumentIcon,
+  CreditCardIcon,
+  ProjectsIcon,
+  CommentIcon,
+  CalendarIcon,
+} from '@sanity/icons'
+import type {ComponentType} from 'react'
 import type {StructureBuilder} from 'sanity/structure'
 import {SITE_AWARE_TYPES} from '../constants'
+
+const TYPE_META: Record<string, {title: string; icon: ComponentType}> = {
+  page: {title: 'Pages', icon: DocumentIcon},
+  sponsor: {title: 'Sponsors', icon: CreditCardIcon},
+  project: {title: 'Projects', icon: ProjectsIcon},
+  testimonial: {title: 'Testimonials', icon: CommentIcon},
+  event: {title: 'Events', icon: CalendarIcon},
+}
 
 /**
  * Creates a desk structure scoped to a single RWC site.
@@ -20,19 +36,24 @@ export function createRwcDeskStructure(siteId: string, siteTitle: string) {
               .documentId(`siteSettings-${siteId}`),
           ),
         S.divider(),
-        ...SITE_AWARE_TYPES.map((type) =>
-          S.listItem()
-            .title(type.charAt(0).toUpperCase() + type.slice(1) + 's')
+        ...SITE_AWARE_TYPES.map((type) => {
+          const meta = TYPE_META[type] || {
+            title: type.charAt(0).toUpperCase() + type.slice(1) + 's',
+            icon: DocumentIcon,
+          }
+          return S.listItem()
+            .title(meta.title)
+            .icon(meta.icon)
             .child(
               S.documentList()
                 .schemaType(type)
-                .title(`${siteTitle} ${type}s`)
+                .title(`${siteTitle} ${meta.title}`)
                 .filter('_type == $type && site == $site')
                 .params({type, site: siteId})
                 .initialValueTemplates([
                   S.initialValueTemplateItem(`${type}-${siteId}`),
                 ]),
-            ),
-        ),
+            )
+        }),
       ])
 }


### PR DESCRIPTION
## Summary

Follow-up cleanup for the RWC workspace split (PR #606). Fixes several issues discovered during review.

### What this PR does (and why)

#### 1. Removes dead code (`constants.ts`)

When PR #606 split the single RWC workspace into two separate ones (US and International), it stopped using two constants — `RWC_SITES` and `RWC_SINGLETON_IDS`. These were only needed when a single workspace looped over all sites. Now each workspace knows its own site, so these arrays are unused. This PR deletes them to avoid confusion.

#### 2. Fixes a TypeScript error (`sanity.config.ts`)

The `formSchema()` plugin call was missing a required argument. The function signature expects an options object (even if empty), so `formSchema()` → `formSchema({})`. This was a pre-existing error in both the Capstone and RWC workspace configs.

#### 3. Adds site-scoped slug uniqueness (`site-field.ts` + 4 document schemas)

**The problem:** Both RWC sites (US and International) share the same Sanity dataset (`rwc`). Sanity's default slug uniqueness check looks at *all* documents of the same type in the dataset. This means an RWC US page with slug `home` would collide with an RWC International page also named `home` — even though they're for completely different websites.

**The fix:** A new `siteScopedIsUnique` helper function that checks slug uniqueness *within the same site only*. It queries:

```groq
count(*[_type == $type && slug.current == $slug && site == $site && !(_id in [$id, $draftId])])
```

This is applied to all four document types that have both a `slug` and a `site` field: **page**, **sponsor**, **project**, and **event**. (Testimonials don't have slugs.)

For the Capstone workspace (`production` dataset), `site` is empty, so the query degrades to a normal global uniqueness check — no behavior change.

#### 4. Adds icons to RWC sidebar items (`rwc-desk-structure.ts`)

The RWC workspace sidebar previously showed plain text labels ("Pages", "Sponsors", etc.) with no icons. This looked sparse compared to the Capstone workspace, which gets icons automatically from `S.documentTypeListItems()`.

Now each content type in the RWC sidebar has the same icon as its schema definition:

| Type | Icon |
|------|------|
| Pages | DocumentIcon |
| Sponsors | CreditCardIcon |
| Projects | ProjectsIcon |
| Testimonials | CommentIcon |
| Events | CalendarIcon |

### Content Lake migration (already applied)

The `template` field was removed from all 27 page documents across both datasets (`production` and `rwc`) and published. This cleans up stale data from the page template removal in PR #605.

## Test plan

- [x] No new TypeScript errors from these changes (pre-existing errors unchanged)
- [x] `RWC_SITES` and `RWC_SINGLETON_IDS` have zero references in the codebase
- [ ] Open Studio at `/rwc-us` — verify sidebar shows icons next to each content type
- [ ] Open Studio at `/rwc-intl` — verify same icons appear
- [ ] Create a page with slug `home` in RWC US — verify no collision error
- [ ] Create a page with slug `home` in RWC International — verify no collision error
- [ ] Verify Capstone workspace slug uniqueness still works normally