### PR TITLE
chore: merge RWC workspace split and cleanup into preview

### DIFF
--- a/studio/sanity.config.ts
+++ b/studio/sanity.config.ts
@@ -45,7 +45,7 @@ function createRwcWorkspace(opts: RwcWorkspaceOptions): WorkspaceOptions {
         },
       }),
       visionTool(),
-      formSchema(),
+      formSchema({}),
     ],
     schema: {
       types: createSchemaTypesForWorkspace('rwc'),
@@ -108,7 +108,7 @@ export default defineConfig([
         },
       }),
       visionTool(),
-      formSchema(),
+      formSchema({}),
     ],
     schema: {
       types: createSchemaTypesForWorkspace('production'),

--- a/studio/sanity.config.ts
+++ b/studio/sanity.config.ts
@@ -1,22 +1,91 @@
-import {defineConfig} from 'sanity'
+import {defineConfig, type WorkspaceOptions} from 'sanity'
 import {structureTool} from 'sanity/structure'
 import {presentationTool} from 'sanity/presentation'
 import {visionTool} from '@sanity/vision'
-import {RocketIcon, UsersIcon} from '@sanity/icons'
+import {RocketIcon, EarthAmericasIcon, EarthGlobeIcon} from '@sanity/icons'
 import {formSchema} from '@sanity/form-toolkit/form-schema'
 import {createSchemaTypesForWorkspace} from './src/schemaTypes/workspace-utils'
 import {capstoneDeskStructure} from './src/structure/capstone-desk-structure'
-import {rwcDeskStructure} from './src/structure/rwc-desk-structure'
+import {createRwcDeskStructure} from './src/structure/rwc-desk-structure'
 import {resolve} from './src/presentation/resolve'
 import {
   CAPSTONE_SINGLETON_TYPES,
   SITE_AWARE_TYPES,
-  RWC_SITES,
-  RWC_SINGLETON_IDS,
 } from './src/constants'
 
 // Environment variables for project configuration
 const projectId = process.env.SANITY_STUDIO_PROJECT_ID || '<your project ID>'
+
+interface RwcWorkspaceOptions {
+  name: string
+  title: string
+  basePath: string
+  icon: typeof EarthAmericasIcon
+  siteId: string
+  projectId: string
+  originEnv: string | undefined
+  defaultOrigin: string
+}
+
+function createRwcWorkspace(opts: RwcWorkspaceOptions): WorkspaceOptions {
+  return {
+    name: opts.name,
+    title: opts.title,
+    basePath: opts.basePath,
+    icon: opts.icon,
+    projectId: opts.projectId,
+    dataset: 'rwc',
+    plugins: [
+      structureTool({structure: createRwcDeskStructure(opts.siteId, opts.title)}),
+      presentationTool({
+        resolve,
+        previewUrl: {
+          origin: opts.originEnv || opts.defaultOrigin,
+          preview: '/',
+        },
+      }),
+      visionTool(),
+      formSchema(),
+    ],
+    schema: {
+      types: createSchemaTypesForWorkspace('rwc'),
+      templates: (prev) => {
+        const filtered = prev.filter(
+          (t) =>
+            !SITE_AWARE_TYPES.includes(t.schemaType) &&
+            t.schemaType !== 'siteSettings',
+        )
+        const siteTemplates = SITE_AWARE_TYPES.map((type) => ({
+          id: `${type}-${opts.siteId}`,
+          title: `${type.charAt(0).toUpperCase() + type.slice(1)} (${opts.title})`,
+          schemaType: type,
+          value: {site: opts.siteId},
+        }))
+        return [...filtered, ...siteTemplates]
+      },
+    },
+    document: {
+      actions: (input, context) => {
+        if (
+          context.schemaType === 'siteSettings' ||
+          context.documentId === `siteSettings-${opts.siteId}`
+        ) {
+          return input.filter(
+            ({action}) =>
+              action &&
+              ['publish', 'discardChanges', 'restore'].includes(action),
+          )
+        }
+        return input
+      },
+      newDocumentOptions: (prev) =>
+        prev.filter(
+          (t) =>
+            t.templateId !== 'siteSettings' && t.templateId !== 'submission',
+        ),
+    },
+  }
+}
 
 export default defineConfig([
   // ─── Capstone Workspace ───────────────────────────────────
@@ -61,69 +130,27 @@ export default defineConfig([
     },
   },
 
-  // ─── RWC Workspace ────────────────────────────────────────
-  {
-    name: 'rwc',
-    title: 'RWC Programs',
-    basePath: '/rwc',
-    icon: UsersIcon,
+  // ─── RWC US Workspace ──────────────────────────────────────
+  createRwcWorkspace({
+    name: 'rwc-us',
+    title: 'RWC US',
+    basePath: '/rwc-us',
+    icon: EarthAmericasIcon,
+    siteId: 'rwc-us',
     projectId,
-    dataset: 'rwc',
-    plugins: [
-      structureTool({structure: rwcDeskStructure}),
-      presentationTool({
-        resolve,
-        previewUrl: {
-          origin:
-            process.env.SANITY_STUDIO_RWC_PREVIEW_ORIGIN ||
-            'http://localhost:4322',
-          preview: '/',
-        },
-      }),
-      visionTool(),
-      formSchema(),
-    ],
-    schema: {
-      types: createSchemaTypesForWorkspace('rwc'),
-      templates: (prev) => {
-        // Remove default templates for site-aware types + siteSettings
-        const filtered = prev.filter(
-          (t) =>
-            !SITE_AWARE_TYPES.includes(t.schemaType) &&
-            t.schemaType !== 'siteSettings',
-        )
-        // Add site-specific templates (page-rwc-us, page-rwc-intl, etc.)
-        const siteTemplates = RWC_SITES.flatMap(({id: siteId, title: siteTitle}) =>
-          SITE_AWARE_TYPES.map((type) => ({
-            id: `${type}-${siteId}`,
-            title: `${type.charAt(0).toUpperCase() + type.slice(1)} (${siteTitle})`,
-            schemaType: type,
-            value: {site: siteId},
-          })),
-        )
-        return [...filtered, ...siteTemplates]
-      },
-    },
-    document: {
-      actions: (input, context) => {
-        // Guard RWC siteSettings singletons by schemaType + fixed document ID
-        if (
-          context.schemaType === 'siteSettings' ||
-          RWC_SINGLETON_IDS.includes(context.documentId || '')
-        ) {
-          return input.filter(
-            ({action}) =>
-              action &&
-              ['publish', 'discardChanges', 'restore'].includes(action),
-          )
-        }
-        return input
-      },
-      newDocumentOptions: (prev) =>
-        prev.filter(
-          (t) =>
-            t.templateId !== 'siteSettings' && t.templateId !== 'submission',
-        ),
-    },
-  },
+    originEnv: process.env.SANITY_STUDIO_RWC_US_PREVIEW_ORIGIN,
+    defaultOrigin: 'http://localhost:4322',
+  }),
+
+  // ─── RWC International Workspace ─────────────────────────
+  createRwcWorkspace({
+    name: 'rwc-intl',
+    title: 'RWC International',
+    basePath: '/rwc-intl',
+    icon: EarthGlobeIcon,
+    siteId: 'rwc-intl',
+    projectId,
+    originEnv: process.env.SANITY_STUDIO_RWC_INTL_PREVIEW_ORIGIN,
+    defaultOrigin: 'http://localhost:4323',
+  }),
 ])

--- a/studio/src/constants.ts
+++ b/studio/src/constants.ts
@@ -3,12 +3,3 @@ export const CAPSTONE_SINGLETON_TYPES = new Set(['siteSettings'])
 
 /** Document types that have the site field (from Story 15.1) */
 export const SITE_AWARE_TYPES = ['page', 'sponsor', 'project', 'testimonial', 'event']
-
-/** RWC site configurations */
-export const RWC_SITES = [
-  {id: 'rwc-us', title: 'RWC US'},
-  {id: 'rwc-intl', title: 'RWC International'},
-] as const
-
-/** Fixed document IDs for RWC siteSettings singletons */
-export const RWC_SINGLETON_IDS = RWC_SITES.map((s) => `siteSettings-${s.id}`)

--- a/studio/src/schemaTypes/documents/event.ts
+++ b/studio/src/schemaTypes/documents/event.ts
@@ -1,6 +1,6 @@
 import {defineType, defineField} from 'sanity'
 import {CalendarIcon, SearchIcon} from '@sanity/icons'
-import {siteField} from '../fields/site-field'
+import {siteField, siteScopedIsUnique} from '../fields/site-field'
 
 export const event = defineType({
   name: 'event',
@@ -32,7 +32,7 @@ export const event = defineType({
       title: 'Slug',
       type: 'slug',
       group: 'main',
-      options: {source: 'title', maxLength: 96},
+      options: {source: 'title', maxLength: 96, isUnique: siteScopedIsUnique},
       validation: (Rule) => Rule.required(),
     }),
     {...siteField, group: 'main'},

--- a/studio/src/schemaTypes/documents/page.ts
+++ b/studio/src/schemaTypes/documents/page.ts
@@ -1,6 +1,6 @@
 import {defineType, defineField, defineArrayMember} from 'sanity'
 import {DocumentIcon} from '@sanity/icons'
-import {siteField} from '../fields/site-field'
+import {siteField, siteScopedIsUnique} from '../fields/site-field'
 
 export const page = defineType({
   name: 'page',
@@ -28,7 +28,7 @@ export const page = defineType({
       title: 'Slug',
       type: 'slug',
       group: 'layout',
-      options: {source: 'title', maxLength: 96},
+      options: {source: 'title', maxLength: 96, isUnique: siteScopedIsUnique},
       validation: (Rule) => Rule.required(),
     }),
     {...siteField, group: 'layout'},

--- a/studio/src/schemaTypes/documents/project.ts
+++ b/studio/src/schemaTypes/documents/project.ts
@@ -1,6 +1,6 @@
 import {defineType, defineField, defineArrayMember} from 'sanity'
 import {ProjectsIcon, SearchIcon} from '@sanity/icons'
-import {siteField} from '../fields/site-field'
+import {siteField, siteScopedIsUnique} from '../fields/site-field'
 
 export const project = defineType({
   name: 'project',
@@ -30,7 +30,7 @@ export const project = defineType({
       title: 'Slug',
       type: 'slug',
       group: 'main',
-      options: {source: 'title'},
+      options: {source: 'title', isUnique: siteScopedIsUnique},
       validation: (Rule) => Rule.required(),
     }),
     {...siteField, group: 'main'},

--- a/studio/src/schemaTypes/documents/sponsor.ts
+++ b/studio/src/schemaTypes/documents/sponsor.ts
@@ -1,6 +1,6 @@
 import {defineType, defineField, defineArrayMember} from 'sanity'
 import {CreditCardIcon, SearchIcon} from '@sanity/icons'
-import {siteField} from '../fields/site-field'
+import {siteField, siteScopedIsUnique} from '../fields/site-field'
 
 export const sponsor = defineType({
   name: 'sponsor',
@@ -27,7 +27,7 @@ export const sponsor = defineType({
       title: 'Slug',
       type: 'slug',
       group: 'main',
-      options: {source: 'name'},
+      options: {source: 'name', isUnique: siteScopedIsUnique},
       validation: (Rule) => Rule.required(),
     }),
     {...siteField, group: 'main'},

--- a/studio/src/schemaTypes/fields/site-field.ts
+++ b/studio/src/schemaTypes/fields/site-field.ts
@@ -1,6 +1,33 @@
 import {defineField} from 'sanity'
 
 /**
+ * Slug uniqueness scoped to the same site.
+ * In the `rwc` dataset, two different sites can share the same slug.
+ * In `production`, site is empty so this degrades to a global check.
+ */
+export async function siteScopedIsUnique(
+  slug: string,
+  context: {
+    document?: {_id: string; _type?: string; [key: string]: unknown}
+    getClient: (options: {apiVersion: string}) => {
+      fetch: <T>(query: string, params: Record<string, unknown>) => Promise<T>
+    }
+    type?: {name?: string}
+  },
+): Promise<boolean> {
+  const {document, getClient, type} = context
+  const client = getClient({apiVersion: '2024-01-01'})
+  const id = document?._id.replace(/^drafts\./, '')
+  const site = (document as {site?: string})?.site || ''
+  const docType = type?.name || document?._type
+  const count = await client.fetch<number>(
+    `count(*[_type == $type && slug.current == $slug && site == $site && !(_id in [$id, $draftId])])`,
+    {type: docType, slug, site, id, draftId: `drafts.${id}`},
+  )
+  return count === 0
+}
+
+/**
  * Reusable site field for multi-site content filtering.
  * Hidden on `production` dataset (capstone editors never see it).
  * Required on `rwc` dataset via validation callback.

--- a/studio/src/structure/rwc-desk-structure.ts
+++ b/studio/src/structure/rwc-desk-structure.ts
@@ -1,6 +1,22 @@
-import {CogIcon} from '@sanity/icons'
+import {
+  CogIcon,
+  DocumentIcon,
+  CreditCardIcon,
+  ProjectsIcon,
+  CommentIcon,
+  CalendarIcon,
+} from '@sanity/icons'
+import type {ComponentType} from 'react'
 import type {StructureBuilder} from 'sanity/structure'
 import {SITE_AWARE_TYPES} from '../constants'
+
+const TYPE_META: Record<string, {title: string; icon: ComponentType}> = {
+  page: {title: 'Pages', icon: DocumentIcon},
+  sponsor: {title: 'Sponsors', icon: CreditCardIcon},
+  project: {title: 'Projects', icon: ProjectsIcon},
+  testimonial: {title: 'Testimonials', icon: CommentIcon},
+  event: {title: 'Events', icon: CalendarIcon},
+}
 
 /**
  * Creates a desk structure scoped to a single RWC site.
@@ -20,19 +36,24 @@ export function createRwcDeskStructure(siteId: string, siteTitle: string) {
               .documentId(`siteSettings-${siteId}`),
           ),
         S.divider(),
-        ...SITE_AWARE_TYPES.map((type) =>
-          S.listItem()
-            .title(type.charAt(0).toUpperCase() + type.slice(1) + 's')
+        ...SITE_AWARE_TYPES.map((type) => {
+          const meta = TYPE_META[type] || {
+            title: type.charAt(0).toUpperCase() + type.slice(1) + 's',
+            icon: DocumentIcon,
+          }
+          return S.listItem()
+            .title(meta.title)
+            .icon(meta.icon)
             .child(
               S.documentList()
                 .schemaType(type)
-                .title(`${siteTitle} ${type}s`)
+                .title(`${siteTitle} ${meta.title}`)
                 .filter('_type == $type && site == $site')
                 .params({type, site: siteId})
                 .initialValueTemplates([
                   S.initialValueTemplateItem(`${type}-${siteId}`),
                 ]),
-            ),
-        ),
+            )
+        }),
       ])
 }

--- a/studio/src/structure/rwc-desk-structure.ts
+++ b/studio/src/structure/rwc-desk-structure.ts
@@ -1,52 +1,38 @@
-import type {ComponentType} from 'react'
-import {CogIcon, EarthAmericasIcon, EarthGlobeIcon} from '@sanity/icons'
+import {CogIcon} from '@sanity/icons'
 import type {StructureBuilder} from 'sanity/structure'
 import {SITE_AWARE_TYPES} from '../constants'
 
-function siteGroup(
-  S: StructureBuilder,
-  siteId: string,
-  title: string,
-  icon: ComponentType,
-) {
-  return S.listItem()
-    .title(title)
-    .icon(icon)
-    .child(
-      S.list()
-        .title(title)
-        .items([
-          S.listItem()
-            .title('Site Settings')
-            .icon(CogIcon)
-            .child(
-              S.document()
-                .schemaType('siteSettings')
-                .documentId(`siteSettings-${siteId}`),
-            ),
-          S.divider(),
-          ...SITE_AWARE_TYPES.map((type) =>
-            S.listItem()
-              .title(type.charAt(0).toUpperCase() + type.slice(1) + 's')
-              .child(
-                S.documentList()
-                  .schemaType(type)
-                  .title(`${title} ${type}s`)
-                  .filter('_type == $type && site == $site')
-                  .params({type, site: siteId})
-                  .initialValueTemplates([
-                    S.initialValueTemplateItem(`${type}-${siteId}`),
-                  ]),
-              ),
+/**
+ * Creates a desk structure scoped to a single RWC site.
+ * Each RWC workspace gets its own desk showing only that site's content.
+ */
+export function createRwcDeskStructure(siteId: string, siteTitle: string) {
+  return (S: StructureBuilder) =>
+    S.list()
+      .title(`${siteTitle} Content`)
+      .items([
+        S.listItem()
+          .title('Site Settings')
+          .icon(CogIcon)
+          .child(
+            S.document()
+              .schemaType('siteSettings')
+              .documentId(`siteSettings-${siteId}`),
           ),
-        ]),
-    )
+        S.divider(),
+        ...SITE_AWARE_TYPES.map((type) =>
+          S.listItem()
+            .title(type.charAt(0).toUpperCase() + type.slice(1) + 's')
+            .child(
+              S.documentList()
+                .schemaType(type)
+                .title(`${siteTitle} ${type}s`)
+                .filter('_type == $type && site == $site')
+                .params({type, site: siteId})
+                .initialValueTemplates([
+                  S.initialValueTemplateItem(`${type}-${siteId}`),
+                ]),
+            ),
+        ),
+      ])
 }
-
-export const rwcDeskStructure = (S: StructureBuilder) =>
-  S.list()
-    .title('RWC Content')
-    .items([
-      siteGroup(S, 'rwc-us', 'RWC US', EarthAmericasIcon),
-      siteGroup(S, 'rwc-intl', 'RWC International', EarthGlobeIcon),
-    ])


### PR DESCRIPTION
## Summary

Brings the RWC workspace split and its follow-up cleanup into the `preview` branch for deployment.

### What's included

This PR collects three already-reviewed PRs that were merged into each other's branches but haven't reached `preview` yet:

| PR | What it does |
|----|-------------|
| **#605** | Removes the page template system — all pages now use full-width layout (already in preview) |
| **#606** | Splits the single RWC Studio workspace into separate US and International workspaces, each with its own preview URL and desk structure |
| **#607** | Cleans up dead constants, fixes `formSchema()` TypeScript error, adds site-scoped slug uniqueness so both RWC sites can have pages with the same slug (e.g. `home`), and adds icons to RWC sidebar |

### Why this is needed

PRs #606 and #607 were merged into their parent branches (`refactor/remove-page-templates` and `refactor/split-rwc-workspaces`) but those merges don't automatically cascade into `preview`. This PR bridges that gap.

### Content Lake changes (already applied)

- Removed the `template` field from all 27 page documents across `production` and `rwc` datasets
- This was done live via Sanity MCP tools — no migration script needed at deploy time

## Test plan

- [ ] Studio loads at `/capstone`, `/rwc-us`, and `/rwc-intl`
- [ ] RWC US and RWC International sidebars show icons (Pages, Sponsors, etc.)
- [ ] Both RWC sites can have a page with slug `home` without collision
- [ ] Preview sites render pages with full-width layout (no `max-w-7xl` container around content)
- [ ] Hero banner with overlay variant goes full-bleed edge-to-edge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for multiple dynamically configured workspaces with customizable base paths, icons, and preview origins.
  * Implemented site-scoped slug uniqueness validation for pages, projects, events, and sponsors—slugs are now unique per-site rather than globally.

* **Chores**
  * Refactored workspace and desk structure configuration for improved flexibility and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->