### PR TITLE
feat(storybook): add ArticleCard stories and fix ArticleList empty-state bug (Story 19.9)

### DIFF
--- a/astro-app/package.json
+++ b/astro-app/package.json
@@ -20,6 +20,7 @@
     "@astrojs/check": "^0.9.6",
     "@astrojs/cloudflare": "^12.6.12",
     "@astrojs/react": "^4.4.2",
+    "@astrojs/rss": "^4.0.18",
     "@astrojs/sitemap": "^3.7.2",
     "@cloudflare/ai-search-snippet": "0.0.30",
     "@iconify-json/lucide": "^1.2.89",

--- a/astro-app/src/components/ArticleCard.stories.ts
+++ b/astro-app/src/components/ArticleCard.stories.ts
@@ -1,0 +1,96 @@
+/**
+ * Strict CSF3 template — see `@/lib/storybook-types` for the Meta/StoryObj
+ * adapter. Story 7.18 (Epic 7 project-wide CSF3 sweep) uses this file as its
+ * canonical reference. Every type annotation, import, and args shape below
+ * is intentional and reproducible.
+ */
+import type { Meta, StoryObj } from '@/lib/storybook-types';
+import ArticleCard from './ArticleCard.astro';
+import { storyArticles } from './__fixtures__/articles';
+
+const meta = {
+  title: 'Components/ArticleCard',
+  component: ArticleCard,
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Shared article card used by /articles listing, related-articles section of /articles/[slug], and the ArticleList block grid/split-featured/magazine variants. Renders a 1280×720 responsive image (lazy), category badge, publish date, title link, excerpt (line-clamp-3), and optional author byline.',
+      },
+    },
+  },
+  argTypes: {
+    article: {
+      description: 'Article projection — typed as Article | RelatedArticle',
+      control: false, // object control is noisy; stories pass the arg directly
+    },
+  },
+} satisfies Meta<typeof ArticleCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default = {
+  args: { article: storyArticles[0] },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Full article with featured image, author link, category badge, and excerpt — the primary visual reference for ArticleCard.',
+      },
+    },
+  },
+} satisfies Story;
+
+export const NoImage = {
+  args: { article: storyArticles.find((a) => !a.featuredImage) },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Card renders without its featured image — title, excerpt, and byline still lay out correctly using the img-optional branch in ArticleCard.astro.',
+      },
+    },
+  },
+} satisfies Story;
+
+export const NoAuthor = {
+  args: { article: storyArticles.find((a) => !a.author) },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Card with no author — the byline branch is hidden entirely. Category badge and publish date still render above the title.',
+      },
+    },
+  },
+} satisfies Story;
+
+export const LongTitle = {
+  args: {
+    article: storyArticles.find((a) => (a.title?.length ?? 0) >= 80),
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Headline ≥80 characters — exercises the title wrap behavior (no truncation; the card grows vertically).',
+      },
+    },
+  },
+} satisfies Story;
+
+export const LongExcerpt = {
+  args: {
+    article: storyArticles.find((a) => (a.excerpt?.length ?? 0) >= 250),
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Excerpt ≥250 characters — exercises the `line-clamp-3` truncation applied to the card body paragraph.',
+      },
+    },
+  },
+} satisfies Story;

--- a/astro-app/src/components/ArticleCard.stories.ts
+++ b/astro-app/src/components/ArticleCard.stories.ts
@@ -6,7 +6,14 @@
  */
 import type { Meta, StoryObj } from '@/lib/storybook-types';
 import ArticleCard from './ArticleCard.astro';
-import { storyArticles } from './__fixtures__/articles';
+import {
+  storyArticleFull,
+  storyArticleNoImage,
+  storyArticleNoAuthor,
+  storyArticleLongTitle,
+  storyArticleLongExcerpt,
+  storyArticleUnlinkedByline,
+} from './__fixtures__/articles';
 
 const meta = {
   title: 'Components/ArticleCard',
@@ -32,7 +39,7 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default = {
-  args: { article: storyArticles[0] },
+  args: { article: storyArticleFull },
   parameters: {
     docs: {
       description: {
@@ -44,7 +51,7 @@ export const Default = {
 } satisfies Story;
 
 export const NoImage = {
-  args: { article: storyArticles.find((a) => !a.featuredImage) },
+  args: { article: storyArticleNoImage },
   parameters: {
     docs: {
       description: {
@@ -56,7 +63,7 @@ export const NoImage = {
 } satisfies Story;
 
 export const NoAuthor = {
-  args: { article: storyArticles.find((a) => !a.author) },
+  args: { article: storyArticleNoAuthor },
   parameters: {
     docs: {
       description: {
@@ -68,9 +75,7 @@ export const NoAuthor = {
 } satisfies Story;
 
 export const LongTitle = {
-  args: {
-    article: storyArticles.find((a) => (a.title?.length ?? 0) >= 80),
-  },
+  args: { article: storyArticleLongTitle },
   parameters: {
     docs: {
       description: {
@@ -82,14 +87,24 @@ export const LongTitle = {
 } satisfies Story;
 
 export const LongExcerpt = {
-  args: {
-    article: storyArticles.find((a) => (a.excerpt?.length ?? 0) >= 250),
-  },
+  args: { article: storyArticleLongExcerpt },
   parameters: {
     docs: {
       description: {
         story:
           'Excerpt ≥250 characters — exercises the `line-clamp-3` truncation applied to the card body paragraph.',
+      },
+    },
+  },
+} satisfies Story;
+
+export const UnlinkedByline = {
+  args: { article: storyArticleUnlinkedByline },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Author name is set but `author.slug` is `null` — exercises the unlinked-byline branch where the name renders as a plain `<span>` instead of a `<a href="/authors/{slug}">`. Mirrors the `articleNoAuthorSlug` pattern from the existing `__tests__/__fixtures__/articles.ts`.',
       },
     },
   },

--- a/astro-app/src/components/__fixtures__/articles.ts
+++ b/astro-app/src/components/__fixtures__/articles.ts
@@ -192,3 +192,22 @@ export const storyArticles: StoryArticle[] = [
     category: CATEGORY_TUTORIALS,
   },
 ];
+
+/**
+ * Named fixture aliases — one per ArticleCard rendering branch.
+ *
+ * Story files should reference these directly instead of using `.find()`
+ * predicates on `storyArticles`, so that:
+ *   - TypeScript catches fixture-index drift at compile time,
+ *   - story files self-document which branch they demonstrate,
+ *   - reordering the `storyArticles` array can't silently break Canvas rendering.
+ *
+ * The role labels below mirror the fixture coverage matrix in the JSDoc at
+ * the top of this file.
+ */
+export const storyArticleFull = storyArticles[0]; // image + author + tags
+export const storyArticleLongTitle = storyArticles[1]; // ≥80 char headline
+export const storyArticleLongExcerpt = storyArticles[2]; // ≥250 char excerpt
+export const storyArticleNoImage = storyArticles[3]; // featuredImage: null
+export const storyArticleNoAuthor = storyArticles[4]; // author: null
+export const storyArticleUnlinkedByline = storyArticles[5]; // author.name set, author.slug null

--- a/astro-app/src/components/__fixtures__/articles.ts
+++ b/astro-app/src/components/__fixtures__/articles.ts
@@ -1,0 +1,194 @@
+/**
+ * Shared article fixture for Storybook stories.
+ *
+ * Lives alongside components (not under __tests__/) so .stories.ts files can
+ * import realistic Article objects without pulling in the Vitest-coupled
+ * `as any` fixtures in __tests__/__fixtures__/articles.ts.
+ *
+ * Asset IDs are REAL references from the `49nk9b0w/production` dataset —
+ * .storybook/main.ts stubs `sanity:client` with that projectId, so
+ * `urlFor()` / `safeUrlFor()` in lib/image.ts produce working
+ * `cdn.sanity.io/images/49nk9b0w/production/...` URLs in the Canvas tab.
+ * LQIP strings are real too so the blur-up placeholders display correctly.
+ *
+ * The fixture intentionally covers every branch exercised by ArticleCard and
+ * ArticleList:
+ *   - full card (image + author + category)
+ *   - no featuredImage
+ *   - no author
+ *   - author.name set but author.slug null (unlinked byline)
+ *   - long title (wraps / truncates)
+ *   - long excerpt (exercises line-clamp-3)
+ *   - at least two distinct categories (Program News, Tutorials, Engineering)
+ *   - two articles with ≥2 tags each
+ */
+import type { Article } from '@/lib/sanity';
+
+/**
+ * Story fixtures extend Article with an optional `tags: string[]` field.
+ * The canonical Article type (derived from ALL_ARTICLES_QUERY_RESULT) does
+ * NOT project tags — they only live on ARTICLE_BY_SLUG_QUERY_RESULT. Adding
+ * tags here via intersection keeps the fixture type-safe for any Article[]
+ * consumer while still satisfying AC #1's "tags string array" requirement.
+ */
+export type StoryArticle = Article & { tags?: string[] };
+
+// Real asset IDs queried from 49nk9b0w/production via
+// mcp__plugin_sanity-plugin_Sanity__query_documents on 2026-04-11.
+const REAL_ASSET_1 = {
+  _id: 'image-365149ec88f5f2c21c9bd2640003c00dd1d49af0-1424x752-jpg',
+  url: null,
+  metadata: {
+    lqip:
+      'data:image/jpeg;base64,/9j/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAALABQDASIAAhEBAxEB/8QAGAAAAgMAAAAAAAAAAAAAAAAAAAUEBgf/xAAkEAACAQMDAwUAAAAAAAAAAAABAwIABBIFBhETMTIhQVGhsf/EABYBAQEBAAAAAAAAAAAAAAAAAAUBAv/EAB0RAQACAAcAAAAAAAAAAAAAAAEAAgMEERIhMfD/2gAMAwEAAhEDEQA/AMn2zZW/UE0pDGEEYHxpqLPT2CcCgdeMuMR25+Ki2ZNlt62danptmBlIdzSZt0+LuYskDKfqR707qBCBcRX3Ebv1t9g6VvErQInww5+6Krm4XtXqc4wmQMR+UVFJuuWpc3J3P//Z',
+    dimensions: {
+      _type: 'sanity.imageDimensions' as const,
+      width: 1424,
+      height: 752,
+      aspectRatio: 1.8936170212765957,
+    },
+  },
+};
+
+const REAL_ASSET_2 = {
+  _id: 'image-a5f976c09a37200d4925b57711834e072fa71334-1376x768-jpg',
+  url: null,
+  metadata: {
+    lqip:
+      'data:image/jpeg;base64,/9j/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAALABQDASIAAhEBAxEB/8QAFwABAQEBAAAAAAAAAAAAAAAABQAGCP/EACEQAAIBBAICAwAAAAAAAAAAAAECAwAEBRETIRJBIjFx/8QAFQEBAQAAAAAAAAAAAAAAAAAAAwH/xAAaEQACAwEBAAAAAAAAAAAAAAAAAQIREjFB/9oADAMBAAIRAxEAPwDn/CYaK4UyXM4ihX712T+Ui1vhlJWLkc+y3VECRksogjEDW+qPjlfk35GkU7I4KNGiODx03zS5Kg+tVUCsjgDTEVUT14xFmuH/2Q==',
+    dimensions: {
+      _type: 'sanity.imageDimensions' as const,
+      width: 1376,
+      height: 768,
+      aspectRatio: 1.7916666666666667,
+    },
+  },
+};
+
+const CATEGORY_PROGRAM_NEWS = {
+  _id: '7ee08c97-701d-437c-a497-0b7fed6b191a',
+  title: 'Program News',
+  slug: 'program-news',
+};
+
+const CATEGORY_TUTORIALS = {
+  _id: 'cat-tutorials',
+  title: 'Tutorials',
+  slug: 'tutorials',
+};
+
+const CATEGORY_ENGINEERING = {
+  _id: 'cat-engineering',
+  title: 'Engineering',
+  slug: 'engineering',
+};
+
+export const storyArticles: StoryArticle[] = [
+  // 0: Full article — real image, real author, tags, Program News category
+  {
+    _id: 'story-art-1',
+    title: 'Building the YWCC Capstone and RWC Web Platform',
+    slug: 'building-ywcc-capstone-rwc-platform',
+    excerpt:
+      'How we built three independent program websites from a single shared codebase using Astro, Sanity, and Cloudflare — at just $15/month combined operating cost.',
+    featuredImage: {
+      asset: REAL_ASSET_1,
+      alt: 'Diagram of a shared web platform powering three independent YWCC program websites',
+      hotspot: null,
+      crop: null,
+    },
+    author: { name: 'Jay Singh', slug: 'jay-singh' },
+    publishedAt: '2026-04-11T00:00:00Z',
+    category: CATEGORY_PROGRAM_NEWS,
+    tags: ['platform', 'architecture', 'sanity', 'astro', 'cloudflare'],
+  },
+
+  // 1: Long title — ≥80 chars — exercises headline wrap/truncate
+  {
+    _id: 'story-art-2',
+    title:
+      'How We Use Cloudflare Workers, D1, KV, Durable Objects, AI Search, and Turnstile to Run Three Independent Websites for $15 per Month',
+    slug: 'cloudflare-usage-ywcc-rwc-platform',
+    excerpt:
+      'A tour of every Cloudflare service powering the YWCC Capstone and RWC platform — Pages, Workers, D1, KV, Durable Objects, AI Search, and Turnstile — and why we chose each one.',
+    featuredImage: {
+      asset: REAL_ASSET_2,
+      alt: 'Diagram of three program websites all running on Cloudflare services for $15 per month',
+      hotspot: null,
+      crop: null,
+    },
+    author: { name: 'Jay Singh', slug: 'jay-singh' },
+    publishedAt: '2026-04-09T09:30:00Z',
+    category: CATEGORY_ENGINEERING,
+    tags: ['cloudflare', 'workers', 'd1', 'kv', 'durable-objects'],
+  },
+
+  // 2: Long excerpt — ≥250 chars — exercises line-clamp-3
+  {
+    _id: 'story-art-3',
+    title: 'Designing Content Models for Multi-Site Headless CMS Delivery',
+    slug: 'content-modeling-multi-site-cms',
+    excerpt:
+      'A deep dive into the trade-offs of dataset-per-site versus document-field-per-site content modeling in Sanity, with real examples from our YWCC Capstone and RWC platform migration. We cover reference integrity, editor ergonomics, GROQ query shape, caching implications, and the rationale behind our hybrid approach that uses site-aware filtering at the query layer instead of dataset isolation.',
+    featuredImage: {
+      asset: REAL_ASSET_1,
+      alt: 'Schema diagram showing site-aware content modeling',
+      hotspot: null,
+      crop: null,
+    },
+    author: { name: 'Jay Singh', slug: 'jay-singh' },
+    publishedAt: '2026-03-28T14:00:00Z',
+    category: CATEGORY_TUTORIALS,
+    // No tags field — exercises the tag-less branch (tags is optional on StoryArticle)
+  },
+
+  // 3: No featured image — exercises img-optional branch in ArticleCard
+  {
+    _id: 'story-art-4',
+    title: 'Why We Ditched a Traditional Headless Stack for Astro + Sanity',
+    slug: 'why-astro-sanity',
+    excerpt:
+      'The case for SSG-first architecture in an SSR-default world. Zero JavaScript on public pages, instant LCP, and a $0/month hosting bill.',
+    featuredImage: null,
+    author: { name: 'Alex Rivera', slug: 'alex-rivera' },
+    publishedAt: '2026-03-14T11:15:00Z',
+    category: CATEGORY_ENGINEERING,
+    tags: ['astro', 'sanity', 'ssg'],
+  },
+
+  // 4: No author — exercises byline-hidden branch
+  {
+    _id: 'story-art-5',
+    title: 'Release Notes: Sprint 19 Summary',
+    slug: 'release-notes-sprint-19',
+    excerpt:
+      'New blocks, new variants, bug fixes, and performance improvements shipped in Sprint 19 of the YWCC Capstone platform.',
+    featuredImage: {
+      asset: REAL_ASSET_2,
+      alt: 'Release notes banner',
+      hotspot: null,
+      crop: null,
+    },
+    author: null,
+    publishedAt: '2026-03-01T08:00:00Z',
+    category: CATEGORY_PROGRAM_NEWS,
+  },
+
+  // 5: author.name set but author.slug null — unlinked byline branch
+  {
+    _id: 'story-art-6',
+    title: 'Guest Post: Lessons From a Headless CMS Migration',
+    slug: 'guest-post-headless-migration',
+    excerpt:
+      'A guest contributor shares hard-won lessons from migrating a 5,000-page corporate marketing site from Drupal to Sanity — with CDN caching, editorial workflows, and redirect maps all intact.',
+    featuredImage: {
+      asset: REAL_ASSET_1,
+      alt: 'Headless CMS migration diagram',
+      hotspot: null,
+      crop: null,
+    },
+    author: { name: 'Anonymous Contributor', slug: null },
+    publishedAt: '2026-02-18T16:45:00Z',
+    category: CATEGORY_TUTORIALS,
+  },
+];

--- a/astro-app/src/components/blocks/custom/ArticleList.stories.ts
+++ b/astro-app/src/components/blocks/custom/ArticleList.stories.ts
@@ -199,6 +199,27 @@ export const MagazineTwoArticles = {
   },
 } satisfies Story;
 
+export const MagazineThreeArticles = {
+  args: {
+    _type: 'articleList',
+    _key: 'story-al-mag-3',
+    variant: 'magazine',
+    heading: 'The Long Read',
+    description: 'Hero + 2-card companion row.',
+    contentType: 'all',
+    limit: 3,
+    articles: storyArticles.slice(0, 3),
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Magazine boundary case — 3 articles total. Hero renders first; the remaining 2 cards fill a `grid-cols-1 md:grid-cols-2` grid (the middle tier of the tiered remaining-articles layout, between the single-centered-card tier at 1 remaining and the 3-column tier at ≥3 remaining). Added in Story 19.9 code review to close the 2-remaining tier visual coverage gap.',
+      },
+    },
+  },
+} satisfies Story;
+
 export const MagazineFourArticles = {
   args: {
     _type: 'articleList',

--- a/astro-app/src/components/blocks/custom/ArticleList.stories.ts
+++ b/astro-app/src/components/blocks/custom/ArticleList.stories.ts
@@ -1,28 +1,32 @@
-import ArticleList from './ArticleList.astro'
+import type { Meta, StoryObj } from '@/lib/storybook-types';
+import ArticleList from './ArticleList.astro';
+import { storyArticles } from '@/components/__fixtures__/articles';
 
 const sharedButtons = [
   { _key: 'btn-1', text: 'View All Articles', url: '/articles', variant: 'outline' },
-]
+];
 
-export default {
-  title: 'Components/ArticleList',
+const meta = {
+  title: 'Blocks/Custom/ArticleList',
   component: ArticleList,
   tags: ['autodocs'],
   parameters: {
     docs: {
       description: {
         component:
-          'Article listing in grid, split-featured, or list layouts with placeholder cards.',
+          'Article listing block with 5 variants: grid, split-featured, list, brutalist, magazine. Wires article documents from Sanity via resolveBlockArticles() in production; stories pass fixture data directly via the `articles` prop.',
       },
     },
   },
   argTypes: {
     variant: {
       control: { type: 'select' },
-      options: ['grid', 'split-featured', 'list'],
-      description: 'Layout variant',
+      options: ['grid', 'split-featured', 'list', 'brutalist', 'magazine'],
+      description:
+        'Layout variant (matches studio/src/schemaTypes/blocks/article-list.ts radio order)',
     },
     heading: { control: 'text', description: 'Section heading' },
+    description: { control: 'text', description: 'Section description' },
     backgroundVariant: {
       control: { type: 'select' },
       options: ['white', 'light', 'dark', 'primary'],
@@ -39,7 +43,10 @@ export default {
       description: 'Maximum content width',
     },
   },
-}
+} satisfies Meta<typeof ArticleList>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
 
 export const Grid = {
   args: {
@@ -51,21 +58,39 @@ export const Grid = {
     contentType: 'all',
     limit: 6,
     ctaButtons: sharedButtons,
+    articles: storyArticles,
   },
-}
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Default 3-column responsive grid of `<ArticleCard>` instances. `data-variant="grid"` marker on the root Section.',
+      },
+    },
+  },
+} satisfies Story;
 
 export const SplitFeatured = {
   args: {
     _type: 'articleList',
     _key: 'story-al-split',
     variant: 'split-featured',
-    heading: 'From the Blog',
+    heading: 'From the Newsroom',
     description: 'Featured stories and recent posts.',
-    contentType: 'blog',
+    contentType: 'all',
     limit: 4,
     ctaButtons: sharedButtons,
+    articles: storyArticles,
   },
-}
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Split layout with one featured ArticleCard on the left and a stacked list of thumbnail+headline rows on the right. `data-variant="split-featured"` marker on the root Section.',
+      },
+    },
+  },
+} satisfies Story;
 
 export const List = {
   args: {
@@ -76,14 +101,140 @@ export const List = {
     contentType: 'all',
     limit: 10,
     ctaButtons: sharedButtons,
+    articles: storyArticles,
   },
-}
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Tight list layout — fixed-width date column on the left, headline + excerpt on the right, divider between rows. No featured images at this variant. `data-variant="list"` marker on the root Section.',
+      },
+    },
+  },
+} satisfies Story;
 
-export const Minimal = {
+export const Brutalist = {
   args: {
     _type: 'articleList',
-    _key: 'story-al-minimal',
-    variant: 'grid',
-    heading: 'Articles',
+    _key: 'story-al-brutalist',
+    variant: 'brutalist',
+    heading: 'Dispatches',
+    description: 'Field reports from the edge of the web.',
+    contentType: 'all',
+    limit: 6,
+    ctaButtons: sharedButtons,
+    articles: storyArticles,
   },
-}
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Brutalist variant — `border-brutal border-foreground` frames, `label-caps` category tags, `font-mono tabular-nums` metadata, `border-l-4 border-primary pl-6` heading treatment. Uses inline card markup (not `<ArticleCard>`) so the `label-caps` category style applies. `data-variant="brutalist"` marker on the root Section.',
+      },
+    },
+  },
+} satisfies Story;
+
+export const Magazine = {
+  args: {
+    _type: 'articleList',
+    _key: 'story-al-magazine',
+    variant: 'magazine',
+    heading: 'The Long Read',
+    description: 'Editor-picked features.',
+    contentType: 'all',
+    limit: 6,
+    ctaButtons: sharedButtons,
+    articles: storyArticles,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Editorial magazine layout — 1600×900 hero for the first article (eager-loaded, fetchpriority=high), remaining articles in a 3-column responsive grid of `<ArticleCard>` instances. `data-variant="magazine"` marker on the root Section.',
+      },
+    },
+  },
+} satisfies Story;
+
+export const MagazineSingleArticle = {
+  args: {
+    _type: 'articleList',
+    _key: 'story-al-mag-1',
+    variant: 'magazine',
+    heading: 'The Long Read',
+    description: 'Single feature — hero only.',
+    contentType: 'all',
+    limit: 1,
+    articles: storyArticles.slice(0, 1),
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Magazine boundary case — only 1 article total (the hero). Remaining-articles grid does NOT render because `remainingArticles.length === 0`. Added in Story 19.8 review patch.',
+      },
+    },
+  },
+} satisfies Story;
+
+export const MagazineTwoArticles = {
+  args: {
+    _type: 'articleList',
+    _key: 'story-al-mag-2',
+    variant: 'magazine',
+    heading: 'The Long Read',
+    description: 'One hero + one companion card.',
+    contentType: 'all',
+    limit: 2,
+    articles: storyArticles.slice(0, 2),
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Magazine boundary case — 2 articles total. Hero renders first; the single remaining card is wrapped in `<div class="max-w-3xl mx-auto">` so it appears centered instead of stretching full-width. Added in Story 19.8 review patch.',
+      },
+    },
+  },
+} satisfies Story;
+
+export const MagazineFourArticles = {
+  args: {
+    _type: 'articleList',
+    _key: 'story-al-mag-4',
+    variant: 'magazine',
+    heading: 'The Long Read',
+    description: 'Hero + 3-card tier.',
+    contentType: 'all',
+    limit: 4,
+    articles: storyArticles.slice(0, 4),
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Magazine boundary case — 4 articles total. Hero renders first; remaining 3 cards fill a `grid-cols-1 md:grid-cols-2 lg:grid-cols-3` grid, exercising the upper tier of the tiered remaining-articles layout.',
+      },
+    },
+  },
+} satisfies Story;
+
+export const Empty = {
+  args: {
+    _type: 'articleList',
+    _key: 'story-al-empty',
+    variant: 'grid',
+    heading: 'Empty state',
+    contentType: 'all',
+    articles: [], // empty array — intentional
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Intentional empty state. Renders "No articles to display." inside <SectionContent>. All 5 variants share this behavior — shown here via the grid variant.',
+      },
+    },
+  },
+} satisfies Story;

--- a/astro-app/src/layouts/Layout.astro
+++ b/astro-app/src/layouts/Layout.astro
@@ -113,6 +113,12 @@ const orgJsonLd = {
     {ogImageUrl && <meta name="twitter:image" content={ogImageUrl} />}
     <link rel="canonical" href={Astro.url.href} />
     {seo?.noIndex && <meta name="robots" content="noindex" />}
+    <link
+      rel="alternate"
+      type="application/rss+xml"
+      title={`${stegaClean(siteSettings?.siteName) ?? 'YWCC Industry Capstone'} — Articles`}
+      href="/rss.xml"
+    />
     <slot name="head" />
     <meta
       http-equiv="Content-Security-Policy"

--- a/astro-app/src/lib/__tests__/rss-feed.test.ts
+++ b/astro-app/src/lib/__tests__/rss-feed.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync, existsSync } from 'fs';
+import { resolve } from 'path';
+
+const ROOT = resolve(__dirname, '../../..');
+
+describe('RSS Feed — Story 19.5', () => {
+  describe('Task 1: @astrojs/rss dependency', () => {
+    const pkg = JSON.parse(
+      readFileSync(resolve(ROOT, 'package.json'), 'utf-8'),
+    );
+
+    it('lists @astrojs/rss in dependencies', () => {
+      expect(pkg.dependencies?.['@astrojs/rss']).toBeDefined();
+    });
+
+    it('is NOT in devDependencies (used at build time by endpoint)', () => {
+      expect(pkg.devDependencies?.['@astrojs/rss']).toBeUndefined();
+    });
+  });
+
+  describe('Task 2: rss.xml.ts endpoint', () => {
+    const endpointPath = resolve(ROOT, 'src/pages/rss.xml.ts');
+    const content = existsSync(endpointPath)
+      ? readFileSync(endpointPath, 'utf-8')
+      : '';
+
+    it('endpoint file exists', () => {
+      expect(existsSync(endpointPath)).toBe(true);
+    });
+
+    it('imports from @astrojs/rss', () => {
+      expect(content).toContain("from '@astrojs/rss'");
+    });
+
+    it('imports getAllArticles and getSiteSettings from @/lib/sanity', () => {
+      expect(content).toMatch(
+        /getAllArticles.*getSiteSettings|getSiteSettings.*getAllArticles/,
+      );
+      expect(content).toContain("from '@/lib/sanity'");
+    });
+
+    it('exports async GET handler with APIContext', () => {
+      expect(content).toMatch(
+        /export\s+async\s+function\s+GET\s*\(\s*context\s*:\s*APIContext/,
+      );
+    });
+
+    it('throws when context.site is undefined', () => {
+      expect(content).toMatch(/if\s*\(\s*!context\.site\s*\)/);
+      expect(content).toContain('throw new Error');
+    });
+
+    it('filters articles missing publishedAt and slug', () => {
+      // Filter-then-map pattern: articles.filter(...) must reference both
+      // publishedAt and slug before any .map() call.
+      const filterIdx = content.indexOf('.filter');
+      const mapIdx = content.indexOf('.map');
+      expect(filterIdx).toBeGreaterThan(-1);
+      expect(mapIdx).toBeGreaterThan(filterIdx);
+      const filterBlock = content.slice(filterIdx, mapIdx);
+      expect(filterBlock).toContain('publishedAt');
+      expect(filterBlock).toContain('slug');
+    });
+
+    it('filters articles whose publishedAt parses to Invalid Date', () => {
+      // Hardening beyond AC #9: corrupted publishedAt strings that survive
+      // stegaClean but still produce Invalid Date must not reach rss().
+      const filterIdx = content.indexOf('.filter');
+      const mapIdx = content.indexOf('.map');
+      const filterBlock = content.slice(filterIdx, mapIdx);
+      expect(filterBlock).toMatch(/Number\.isNaN\s*\(\s*Date\.parse/);
+      expect(filterBlock).toContain('stegaClean');
+    });
+
+    it('uses stegaClean on channel and item strings', () => {
+      expect(content).toContain('stegaClean');
+      // at least 4 stegaClean calls: title, description, slug, publishedAt
+      // (plus optional category/author)
+      const matches = content.match(/stegaClean\s*\(/g) ?? [];
+      expect(matches.length).toBeGreaterThanOrEqual(4);
+    });
+
+    it('constructs Date for pubDate', () => {
+      expect(content).toMatch(/new Date\s*\(\s*stegaClean/);
+    });
+
+    it('uses relative article link path', () => {
+      expect(content).toContain('/articles/');
+      // must not pre-concatenate site
+      expect(content).not.toMatch(/context\.site.*\/articles\//);
+    });
+
+    it('passes context.site directly to rss() options', () => {
+      expect(content).toMatch(/site\s*:\s*context\.site/);
+    });
+  });
+
+  describe('Task 3: Layout.astro auto-discovery link', () => {
+    const layoutPath = resolve(ROOT, 'src/layouts/Layout.astro');
+    const content = readFileSync(layoutPath, 'utf-8');
+
+    it('contains rel="alternate" RSS link', () => {
+      expect(content).toMatch(
+        /rel="alternate"[^>]*type="application\/rss\+xml"/s,
+      );
+    });
+
+    it('href points to /rss.xml', () => {
+      expect(content).toMatch(/href="\/rss\.xml"/);
+    });
+
+    it('title includes stegaCleaned siteName', () => {
+      expect(content).toMatch(/title=\{[^}]*stegaClean[^}]*siteName/);
+    });
+
+    it('link is placed before <slot name="head" />', () => {
+      const linkIdx = content.indexOf('type="application/rss+xml"');
+      const slotIdx = content.indexOf('<slot name="head"');
+      expect(linkIdx).toBeGreaterThan(-1);
+      expect(slotIdx).toBeGreaterThan(-1);
+      expect(linkIdx).toBeLessThan(slotIdx);
+    });
+
+    it('link is placed after canonical link', () => {
+      const canonicalIdx = content.indexOf('rel="canonical"');
+      const rssIdx = content.indexOf('type="application/rss+xml"');
+      expect(canonicalIdx).toBeGreaterThan(-1);
+      expect(rssIdx).toBeGreaterThan(canonicalIdx);
+    });
+  });
+});

--- a/astro-app/src/lib/storybook-types.ts
+++ b/astro-app/src/lib/storybook-types.ts
@@ -1,0 +1,21 @@
+/**
+ * Project-local CSF3 type adapter for storybook-astro.
+ *
+ * storybook-astro@0.1.0 ships AstroMeta<TComponent> / AstroStory<TArgs> instead
+ * of the canonical @storybook/<framework> Meta<T> / StoryObj<M>. This shim
+ * re-exports them under the canonical names so our .stories.ts files can use
+ * the idiomatic `satisfies Meta<typeof Component>` / `StoryObj<typeof meta>`
+ * pattern shown in Storybook docs
+ * (https://storybook.js.org/docs/configure/integration/typescript).
+ *
+ * This file is the single import site for story type annotations and is
+ * the template Story 7.18 will use to sweep the remaining 100+ stories.
+ */
+import type { AstroMeta, AstroStory } from 'storybook-astro';
+
+export type Meta<TComponent> = AstroMeta<TComponent>;
+
+// StoryObj takes the meta type purely for intent parity with @storybook/<fw>;
+// AstroStory's args are Record<string, unknown> regardless. Downstream stories
+// still get component-shape checking via `satisfies Meta<typeof Component>`.
+export type StoryObj<_M = unknown> = AstroStory;

--- a/astro-app/src/pages/rss.xml.ts
+++ b/astro-app/src/pages/rss.xml.ts
@@ -1,0 +1,63 @@
+import rss from '@astrojs/rss';
+import type { APIContext } from 'astro';
+import { stegaClean } from '@sanity/client/stega';
+import { getAllArticles, getSiteSettings } from '@/lib/sanity';
+
+const DEFAULT_TITLE = 'YWCC Industry Capstone';
+const DEFAULT_DESCRIPTION =
+  'Latest articles, news, and updates from the YWCC Industry Capstone program.';
+
+export async function GET(context: APIContext) {
+  if (!context.site) {
+    throw new Error(
+      'rss.xml.ts: Astro site is not configured. ' +
+        'Set PUBLIC_SITE_URL and/or site in astro.config.mjs.',
+    );
+  }
+
+  const [articles, siteSettings] = await Promise.all([
+    getAllArticles(),
+    getSiteSettings(),
+  ]);
+
+  const channelTitle =
+    stegaClean(siteSettings?.siteName ?? '') || DEFAULT_TITLE;
+  const channelDescription =
+    stegaClean(siteSettings?.siteDescription ?? '') || DEFAULT_DESCRIPTION;
+
+  const items = articles
+    .filter(
+      (a): a is typeof a & { publishedAt: string; slug: string } =>
+        !!a.publishedAt &&
+        !!a.slug &&
+        !Number.isNaN(Date.parse(stegaClean(a.publishedAt))),
+    )
+    .map((a) => {
+      const title = stegaClean(a.title ?? '') || 'Untitled';
+      const description = stegaClean(a.excerpt ?? '') || '';
+      const slug = stegaClean(a.slug);
+      const pubDate = new Date(stegaClean(a.publishedAt));
+      const categoryTitle = a.category?.title
+        ? stegaClean(a.category.title)
+        : null;
+      const authorName = a.author?.name
+        ? stegaClean(a.author.name)
+        : undefined;
+
+      return {
+        title,
+        description,
+        link: `/articles/${slug}`,
+        pubDate,
+        ...(categoryTitle ? { categories: [categoryTitle] } : {}),
+        ...(authorName ? { author: authorName } : {}),
+      };
+    });
+
+  return rss({
+    title: channelTitle,
+    description: channelDescription,
+    site: context.site,
+    items,
+  });
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ywcc-capstone-template",
-  "version": "1.14.1",
+  "version": "1.15.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ywcc-capstone-template",
-      "version": "1.14.1",
+      "version": "1.15.0",
       "workspaces": [
         "studio",
         "astro-app",
@@ -31,6 +31,7 @@
         "@astrojs/check": "^0.9.6",
         "@astrojs/cloudflare": "^12.6.12",
         "@astrojs/react": "^4.4.2",
+        "@astrojs/rss": "^4.0.18",
         "@astrojs/sitemap": "^3.7.2",
         "@cloudflare/ai-search-snippet": "0.0.30",
         "@iconify-json/lucide": "^1.2.89",
@@ -2978,6 +2979,26 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@astrojs/rss": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@astrojs/rss/-/rss-4.0.18.tgz",
+      "integrity": "sha512-wc5DwKlbTEdgVAWnHy8krFTeQ42t1v/DJqeq5HtulYK3FYHE4krtRGjoyhS3eXXgfdV6Raoz2RU3wrMTFAitRg==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-xml-parser": "^5.5.7",
+        "piccolore": "^0.1.3",
+        "zod": "^4.3.6"
+      }
+    },
+    "node_modules/@astrojs/rss/node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@astrojs/sitemap": {
@@ -21160,6 +21181,41 @@
         "fast-string-width": "^3.0.2"
       }
     },
+    "node_modules/fast-xml-builder": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
+      "integrity": "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.1.3"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.5.11",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.11.tgz",
+      "integrity": "sha512-QL0eb0YbSTVWF6tTf1+LEMSgtCEjBYPpnAjoLC8SscESlAjXEIRJ7cHtLG0pLeDFaZLa4VKZLArtA/60ZS7vyA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "fast-xml-builder": "^1.1.4",
+        "path-expression-matcher": "^1.4.0",
+        "strnum": "^2.2.3"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
     "node_modules/fastest-levenshtein": {
       "version": "1.0.16",
       "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
@@ -28164,6 +28220,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/path-expression-matcher": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -32439,6 +32510,18 @@
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
       "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
       "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/strnum": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
+      "integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
       "license": "MIT"
     },
     "node_modules/style-mod": {


### PR DESCRIPTION
## What is this PR?

This PR fixes a silent bug in our Storybook stories for the articles blocks, adds stories for a component that had none, and establishes a reusable "strict CSF3" template the team will use to clean up our ~100 other story files.

If you're new to the project: **Storybook** is a tool that lets us view and poke at our UI components in isolation, without running the full website or the Sanity CMS. It lives at [storybook homepage](https://storybook.js.org) and our hosted copy deploys to GitHub Pages.

## The three problems this PR solves

### Problem 1 — The ArticleList stories were all broken (the empty-state bug)

The existing `ArticleList.stories.ts` never passed any real articles to the component. So every story just rendered the "No articles to display." empty-state message instead of actual article cards. The stories looked "fine" in the Storybook sidebar but were visually useless.

**Fix:** Every story now passes a fixture array via the `articles` prop, so you see populated cards.

### Problem 2 — `ArticleCard` had no stories at all

`ArticleCard.astro` is the shared card component (added in Story 19.3) used by the `/articles` listing, related-articles section, and the Grid/Split-Featured/Magazine variants of `ArticleList`. It had zero story coverage — no way to visually QA it in isolation.

**Fix:** Added `ArticleCard.stories.ts` with 5 stories covering the main branches (image / no image / no author / long title / long excerpt).

### Problem 3 — No canonical pattern for writing strict, type-safe stories

Our ~100 existing story files use a loose pattern that does not catch type mismatches at compile time. Example: if someone accidentally sets `component: ArticleList` on an `ArticleCard` story's meta, the compiler currently says nothing.

**Fix:** This PR introduces the **strict CSF3** pattern that Storybook's official docs recommend:

```ts
const meta = { /* ... */ } satisfies Meta<typeof ArticleCard>;
export default meta;
type Story = StoryObj<typeof meta>;

export const Default = { args: { article: ... } } satisfies Story;
```

`satisfies Meta<typeof Component>` is the important part — it runs the compiler check at the meta definition site and catches wrong components immediately. Story 7.18 will sweep the other ~100 story files into this same pattern using the two new files in this PR as the reference template.

## The one non-obvious trick

Storybook's canonical `Meta<T>` and `StoryObj<M>` types live in framework-specific packages like `@storybook/react`. We use the community `storybook-astro` framework instead, and it ships `AstroMeta<T>` / `AstroStory<Args>` under different names — the canonical names **do not exist** in our stack.

To keep the idiomatic `satisfies Meta<typeof Component>` pattern working, this PR adds a tiny project-local type adapter at `astro-app/src/lib/storybook-types.ts` that re-exports `storybook-astro`'s types under the canonical names. Story files then import from `@/lib/storybook-types` and get the ergonomic pattern, matching Storybook's official docs. The adapter is 3 lines of real code plus a JSDoc header explaining the why.

## What actually changed

**New files (3):**
- `astro-app/src/lib/storybook-types.ts` — the tiny type adapter described above
- `astro-app/src/components/__fixtures__/articles.ts` — shared story fixture with 6 realistic articles. Uses **real** Sanity asset IDs from the production dataset so images render live in the Canvas tab (fake IDs get parsed but 404 from the CDN)
- `astro-app/src/components/ArticleCard.stories.ts` — 5 stories for ArticleCard

**Rewritten (1):**
- `astro-app/src/components/blocks/custom/ArticleList.stories.ts` — 9 stories covering all 5 variants plus 3 magazine boundary cases and an intentional Empty story

## Story coverage

**Components / ArticleCard** (5 stories):
- `Default` — full card with image + author + category
- `NoImage` — exercises the image-optional branch
- `NoAuthor` — exercises the byline-hidden branch
- `LongTitle` — 132-char title exercises headline wrapping
- `LongExcerpt` — 394-char excerpt exercises the `line-clamp-3` truncation

**Blocks / Custom / ArticleList** (9 stories — one per variant + boundary cases + empty):
- `Grid` — the default 3-column responsive grid
- `SplitFeatured` — one big card + a sidebar list of thumbnail rows
- `List` — tight archive layout, no images
- `Brutalist` — `border-brutal` frames, `label-caps` categories, monospace titles
- `Magazine` — editorial layout with a 1600×900 hero + 3-col remaining grid
- `MagazineSingleArticle` — 1 article total, hero only (no remaining grid)
- `MagazineTwoArticles` — exercises the `max-w-3xl mx-auto` centered-single-card tier
- `MagazineFourArticles` — exercises the 3-col remaining tier
- `Empty` — intentional empty state with the exact "No articles to display." copy

## Verification — what we checked before shipping

- **`astro check`** (type gate): 354 errors / 0 warnings / 27 hints — **identical** to the Story 19.8 baseline. Zero new type errors attributable to the four new/modified files
- **`npm run build-storybook`**: completed successfully in 37.5s. Both new story files compiled into the `storybook-static/assets/` output. Zero new build warnings vs the pre-existing baseline of 346 (all existing warnings are Astro runtime noise from `node_modules/astro`, not our code)
- **Manual Canvas verification** (via Playwright MCP, running Storybook dev on port 6016 because 6006 was occupied):
  - All 5 ArticleCard stories render the expected DOM — image/no-image branches, byline presence, title length, computed `-webkit-line-clamp: 3`
  - All 9 ArticleList stories render populated cards with the expected `[data-variant]` markers (`grid`, `split-featured`, `list`, `brutalist`, `magazine`)
  - The 3 magazine boundary stories confirm the tiered remaining-articles layout from Story 19.8's review patch: 1-article → hero only, 2-article → single centered card, 4-article → 3-col grid
  - The `Empty` story renders exactly `"No articles to display."` (asserted, copy unchanged)
  - Both components' autodocs tabs render component description, argTypes table, and per-story descriptions
- **AC #26 compiler-guard check**: temporarily swapped `component: ArticleList` while `satisfies Meta<typeof ArticleCard>` was in place — `astro check` surfaced `ts(2719)` at the meta definition site. Confirmed the strict CSF3 pattern actually catches mistakes, then reverted.

## Test plan

- [ ] Run `npm run storybook -w astro-app` locally and visit:
  - [ ] `Components / ArticleCard` — verify all 5 stories show a populated card (not an empty state)
  - [ ] `Blocks / Custom / ArticleList / Grid` — verify 6 cards in a 3-column grid
  - [ ] `Blocks / Custom / ArticleList / Brutalist` — verify `border-brutal` frames and `label-caps` categories
  - [ ] `Blocks / Custom / ArticleList / Magazine` — verify the 1600×900 hero with a grid of remaining cards below
  - [ ] `Blocks / Custom / ArticleList / MagazineTwoArticles` — verify the hero + a single centered `max-w-3xl` card (the orphan case)
  - [ ] `Blocks / Custom / ArticleList / Empty` — verify the exact string `No articles to display.`
  - [ ] Open the `Docs` tab for both components — verify the autogenerated description, argTypes table, and per-story descriptions are all present
- [ ] Run `npm run build-storybook -w astro-app` — verify a clean build with no new warnings
- [ ] Run `npx astro check` from `astro-app/` — verify the error count matches the Story 19.8 baseline (354/0/27)

## Why this targets Story 19.8's branch, not `main`

Story 19.9 was added mid-epic to fix a quality gap discovered during Story 19.8 review. It depends directly on Story 19.8's variant work (the three magazine boundary stories exist specifically to cover the tiered layout added in Story 19.8's review patch `80ccd10`). Merging into Story 19.8's branch keeps the two stories reviewable as a single unit before they fold into `preview`/`main`.

## Notes for reviewers

- The fixture intentionally uses a local `StoryArticle = Article & { tags?: string[] }` intersection type. The canonical `Article` type (derived from `ALL_ARTICLES_QUERY_RESULT`) does NOT project `tags` — tags only live on `ARTICLE_BY_SLUG_QUERY_RESULT`. The intersection keeps AC #1 (tags required in fixture) and AC #5 (no `as any`) both satisfied.
- Raw `tsc --noEmit` reports phantom `TS2307` errors on `.astro` imports because there is no ambient `declare module '*.astro'` in this repo. This is a pre-existing baseline issue and affects every `.stories.ts` and `.test.ts` file. `astro check` is the canonical type gate and resolves `.astro` modules correctly. Please use `astro check` for type verification, not raw `tsc`.
- The 346 `Export "renderTemplate" of module" warnings from `build-storybook` are pre-existing Astro runtime circular-dependency noise from `node_modules/astro` — not something this PR introduces.