### PR TITLE
feat: establish 12-column grid system (Story 17-8)

### DIFF
--- a/astro-app/src/components/BlockWrapper.astro
+++ b/astro-app/src/components/BlockWrapper.astro
@@ -42,7 +42,7 @@ const spacingValue = spacingMap[sp] ?? '';
 ---
 
 <div
-  class:list={[bgClasses[bg], maxWidthClasses[mw], alignClasses[align]]}
+  class:list={['@container', bgClasses[bg], maxWidthClasses[mw], alignClasses[align]]}
   data-gtm-section={blockType}
   data-bg-theme={isDarkBg ? 'dark' : undefined}
   data-align={align !== 'left' ? align : undefined}

--- a/astro-app/src/components/EventCard.astro
+++ b/astro-app/src/components/EventCard.astro
@@ -32,7 +32,7 @@ const badgeClasses: Record<string, string> = {
 const badgeClass = cleanType ? badgeClasses[cleanType] ?? 'bg-muted text-muted-foreground' : null;
 ---
 
-<div class="flex flex-col gap-3 border border-border bg-card p-6">
+<div class="flex flex-col gap-3 border border-border bg-card p-6 shadow-sm">
   <div class="flex items-center justify-between gap-2">
     {formattedDate && (
       <time datetime={e.date ?? undefined} class="text-sm font-medium text-primary">

--- a/astro-app/src/components/Header.astro
+++ b/astro-app/src/components/Header.astro
@@ -59,7 +59,7 @@ const brandSecondary = nameParts.slice(1).join(' ');
     </LogoText>
   </Logo>
 
-  <NavigationMenu class="hidden md:flex" aria-label="Main navigation">
+  <NavigationMenu class="hidden xl:flex" aria-label="Main navigation">
     <NavigationMenuList>
       {(navigationItems || []).map((item) => {
         const hasChildren = item.children && item.children.length > 0;
@@ -116,8 +116,8 @@ const brandSecondary = nameParts.slice(1).join(' ');
   </NavigationMenu>
 
   <HeaderActions>
-    <Button href={ctaHref} class="hidden md:inline-flex" data-gtm-category="navigation" data-gtm-label="header-cta">{ctaText}</Button>
-    <div class="md:hidden">
+    <Button href={ctaHref} class="hidden xl:inline-flex" data-gtm-category="navigation" data-gtm-label="header-cta">{ctaText}</Button>
+    <div class="xl:hidden">
       <Sheet>
         <SheetTrigger variant="ghost" size="icon">
           <Icon name="menu" />

--- a/astro-app/src/components/SanityPageContent.astro
+++ b/astro-app/src/components/SanityPageContent.astro
@@ -48,7 +48,7 @@ const islandSyncTags = getSyncTags();
     )}
   </>
 ) : (
-  <div class="mx-auto max-w-7xl px-(--gutter) py-12 text-center">
+  <div class="mx-auto max-w-(--grid-max-width) px-(--grid-margin) py-12 text-center">
     <p class="text-muted-foreground">Page not found for slug: {slug}</p>
   </div>
 )}

--- a/astro-app/src/components/__tests__/ArticleList.test.ts
+++ b/astro-app/src/components/__tests__/ArticleList.test.ts
@@ -433,9 +433,9 @@ describe('ArticleList (Story 19.4)', () => {
         props: { ...articleListMagazine, articles: sampleArticles },
       });
       // AC #20: remaining articles in responsive grid after hero. With 3 articles
-      // total (2 remaining), the post-review tier logic now uses @md:grid-cols-2
-      // without @lg:grid-cols-3 — the 3-col class only activates with ≥3 remaining.
-      expect(html).toContain('@md:grid-cols-2');
+      // total (2 remaining), the post-review tier logic now uses @2xl:grid-cols-2
+      // without @5xl:grid-cols-3 — the 3-col class only activates with ≥3 remaining.
+      expect(html).toContain('@2xl:grid-cols-2');
       // Both non-hero articles rendered
       expect(html).toContain('Sanity Visual Editing Tips');
       expect(html).toContain('Why CSS Container Queries Matter');
@@ -454,11 +454,11 @@ describe('ArticleList (Story 19.4)', () => {
       expect(html).toContain('Sanity Visual Editing Tips');
       expect(html).toContain('max-w-3xl mx-auto');
       // Neither grid tier class is emitted for a single remaining item
-      expect(html).not.toContain('@md:grid-cols-2');
-      expect(html).not.toContain('@lg:grid-cols-3');
+      expect(html).not.toContain('@2xl:grid-cols-2');
+      expect(html).not.toContain('@5xl:grid-cols-3');
     });
 
-    test('with >=4 articles uses @lg:grid-cols-3 for the remaining-articles grid', async () => {
+    test('with >=4 articles uses @5xl:grid-cols-3 for the remaining-articles grid', async () => {
       // Post-review patch: the 3-col class only activates when ≥3 articles remain
       // (i.e., ≥4 total articles once the hero is extracted).
       const fourArticles = [
@@ -467,7 +467,7 @@ describe('ArticleList (Story 19.4)', () => {
           _id: 'article-4',
           title: 'Fourth Article for Grid Coverage',
           slug: 'fourth-article',
-          excerpt: 'A fourth article to exercise the @lg:grid-cols-3 tier.',
+          excerpt: 'A fourth article to exercise the @5xl:grid-cols-3 tier.',
           featuredImage: null,
           author: { name: 'Sam Taylor', slug: 'sam-taylor' },
           publishedAt: '2026-02-15T09:00:00Z',
@@ -479,7 +479,7 @@ describe('ArticleList (Story 19.4)', () => {
         props: { ...articleListMagazine, articles: fourArticles },
       });
       // 4 total → 3 remaining → full 3-col tier activated
-      expect(html).toContain('grid-cols-1 @md:grid-cols-2 @lg:grid-cols-3');
+      expect(html).toContain('grid-cols-1 @2xl:grid-cols-2 @5xl:grid-cols-3');
       expect(html).toContain('Fourth Article for Grid Coverage');
     });
 
@@ -492,7 +492,7 @@ describe('ArticleList (Story 19.4)', () => {
       expect(html).toContain('Astro 5 Released');
       // AC #21: no remaining-grid marker when there is only 1 article.
       // Neither the 3-col tier NOR the single-card contained layout renders.
-      expect(html).not.toContain('grid-cols-1 @md:grid-cols-2 @lg:grid-cols-3');
+      expect(html).not.toContain('grid-cols-1 @2xl:grid-cols-2 @5xl:grid-cols-3');
       expect(html).not.toContain('max-w-3xl mx-auto');
     });
 

--- a/astro-app/src/components/__tests__/ArticleList.test.ts
+++ b/astro-app/src/components/__tests__/ArticleList.test.ts
@@ -433,9 +433,9 @@ describe('ArticleList (Story 19.4)', () => {
         props: { ...articleListMagazine, articles: sampleArticles },
       });
       // AC #20: remaining articles in responsive grid after hero. With 3 articles
-      // total (2 remaining), the post-review tier logic now uses md:grid-cols-2
-      // without lg:grid-cols-3 — the 3-col class only activates with ≥3 remaining.
-      expect(html).toContain('md:grid-cols-2');
+      // total (2 remaining), the post-review tier logic now uses @md:grid-cols-2
+      // without @lg:grid-cols-3 — the 3-col class only activates with ≥3 remaining.
+      expect(html).toContain('@md:grid-cols-2');
       // Both non-hero articles rendered
       expect(html).toContain('Sanity Visual Editing Tips');
       expect(html).toContain('Why CSS Container Queries Matter');
@@ -454,11 +454,11 @@ describe('ArticleList (Story 19.4)', () => {
       expect(html).toContain('Sanity Visual Editing Tips');
       expect(html).toContain('max-w-3xl mx-auto');
       // Neither grid tier class is emitted for a single remaining item
-      expect(html).not.toContain('md:grid-cols-2');
-      expect(html).not.toContain('lg:grid-cols-3');
+      expect(html).not.toContain('@md:grid-cols-2');
+      expect(html).not.toContain('@lg:grid-cols-3');
     });
 
-    test('with >=4 articles uses lg:grid-cols-3 for the remaining-articles grid', async () => {
+    test('with >=4 articles uses @lg:grid-cols-3 for the remaining-articles grid', async () => {
       // Post-review patch: the 3-col class only activates when ≥3 articles remain
       // (i.e., ≥4 total articles once the hero is extracted).
       const fourArticles = [
@@ -467,7 +467,7 @@ describe('ArticleList (Story 19.4)', () => {
           _id: 'article-4',
           title: 'Fourth Article for Grid Coverage',
           slug: 'fourth-article',
-          excerpt: 'A fourth article to exercise the lg:grid-cols-3 tier.',
+          excerpt: 'A fourth article to exercise the @lg:grid-cols-3 tier.',
           featuredImage: null,
           author: { name: 'Sam Taylor', slug: 'sam-taylor' },
           publishedAt: '2026-02-15T09:00:00Z',
@@ -479,7 +479,7 @@ describe('ArticleList (Story 19.4)', () => {
         props: { ...articleListMagazine, articles: fourArticles },
       });
       // 4 total → 3 remaining → full 3-col tier activated
-      expect(html).toContain('grid-cols-1 md:grid-cols-2 lg:grid-cols-3');
+      expect(html).toContain('grid-cols-1 @md:grid-cols-2 @lg:grid-cols-3');
       expect(html).toContain('Fourth Article for Grid Coverage');
     });
 
@@ -492,7 +492,7 @@ describe('ArticleList (Story 19.4)', () => {
       expect(html).toContain('Astro 5 Released');
       // AC #21: no remaining-grid marker when there is only 1 article.
       // Neither the 3-col tier NOR the single-card contained layout renders.
-      expect(html).not.toContain('grid-cols-1 md:grid-cols-2 lg:grid-cols-3');
+      expect(html).not.toContain('grid-cols-1 @md:grid-cols-2 @lg:grid-cols-3');
       expect(html).not.toContain('max-w-3xl mx-auto');
     });
 

--- a/astro-app/src/components/__tests__/ColumnsBlock.test.ts
+++ b/astro-app/src/components/__tests__/ColumnsBlock.test.ts
@@ -39,7 +39,7 @@ describe('ColumnsBlock', () => {
       props: baseProps,
     });
 
-    expect(html).toContain('lg:grid-cols-2');
+    expect(html).toContain('@lg:grid-cols-2');
     expect(html).toContain('items-start');
   });
 
@@ -49,7 +49,7 @@ describe('ColumnsBlock', () => {
       props: { ...baseProps, _key: 'test-cols-wl', variant: 'wide-left' },
     });
 
-    expect(html).toContain('lg:grid-cols-[2fr_1fr]');
+    expect(html).toContain('@lg:grid-cols-[2fr_1fr]');
   });
 
   test('applies wide-right variant grid classes', async () => {
@@ -58,7 +58,7 @@ describe('ColumnsBlock', () => {
       props: { ...baseProps, _key: 'test-cols-wr', variant: 'wide-right' },
     });
 
-    expect(html).toContain('lg:grid-cols-[1fr_2fr]');
+    expect(html).toContain('@lg:grid-cols-[1fr_2fr]');
   });
 
   test('applies sidebar-left variant grid classes', async () => {
@@ -67,7 +67,7 @@ describe('ColumnsBlock', () => {
       props: { ...baseProps, _key: 'test-cols-sl', variant: 'sidebar-left' },
     });
 
-    expect(html).toContain('lg:grid-cols-[minmax(280px,1fr)_3fr]');
+    expect(html).toContain('@lg:grid-cols-[minmax(280px,1fr)_3fr]');
   });
 
   test('applies sidebar-right variant grid classes', async () => {
@@ -76,7 +76,7 @@ describe('ColumnsBlock', () => {
       props: { ...baseProps, _key: 'test-cols-sr', variant: 'sidebar-right' },
     });
 
-    expect(html).toContain('lg:grid-cols-[3fr_minmax(280px,1fr)]');
+    expect(html).toContain('@lg:grid-cols-[3fr_minmax(280px,1fr)]');
   });
 
   test('applies center vertical alignment', async () => {
@@ -103,8 +103,8 @@ describe('ColumnsBlock', () => {
       props: { ...baseProps, _key: 'test-cols-rev', reverseOnMobile: true },
     });
 
-    expect(html).toContain('order-2 lg:order-1');
-    expect(html).toContain('order-1 lg:order-2');
+    expect(html).toContain('order-2 @lg:order-1');
+    expect(html).toContain('order-1 @lg:order-2');
   });
 
   test('does not apply order classes when reverseOnMobile is false', async () => {
@@ -113,8 +113,8 @@ describe('ColumnsBlock', () => {
       props: baseProps,
     });
 
-    expect(html).not.toContain('order-2 lg:order-1');
-    expect(html).not.toContain('order-1 lg:order-2');
+    expect(html).not.toContain('order-2 @lg:order-1');
+    expect(html).not.toContain('order-1 @lg:order-2');
   });
 
   test('defaults to equal variant when variant is undefined', async () => {
@@ -123,7 +123,7 @@ describe('ColumnsBlock', () => {
       props: { ...baseProps, _key: 'test-cols-def', variant: undefined },
     });
 
-    expect(html).toContain('lg:grid-cols-2');
+    expect(html).toContain('@lg:grid-cols-2');
     expect(html).toContain('items-start');
   });
 
@@ -134,6 +134,6 @@ describe('ColumnsBlock', () => {
     });
 
     expect(html).toContain('gap-8');
-    expect(html).toContain('lg:gap-16');
+    expect(html).toContain('@lg:gap-16');
   });
 });

--- a/astro-app/src/components/__tests__/ColumnsBlock.test.ts
+++ b/astro-app/src/components/__tests__/ColumnsBlock.test.ts
@@ -39,7 +39,7 @@ describe('ColumnsBlock', () => {
       props: baseProps,
     });
 
-    expect(html).toContain('@lg:grid-cols-2');
+    expect(html).toContain('@4xl:grid-cols-2');
     expect(html).toContain('items-start');
   });
 
@@ -49,7 +49,7 @@ describe('ColumnsBlock', () => {
       props: { ...baseProps, _key: 'test-cols-wl', variant: 'wide-left' },
     });
 
-    expect(html).toContain('@lg:grid-cols-[2fr_1fr]');
+    expect(html).toContain('@4xl:grid-cols-[2fr_1fr]');
   });
 
   test('applies wide-right variant grid classes', async () => {
@@ -58,7 +58,7 @@ describe('ColumnsBlock', () => {
       props: { ...baseProps, _key: 'test-cols-wr', variant: 'wide-right' },
     });
 
-    expect(html).toContain('@lg:grid-cols-[1fr_2fr]');
+    expect(html).toContain('@4xl:grid-cols-[1fr_2fr]');
   });
 
   test('applies sidebar-left variant grid classes', async () => {
@@ -67,7 +67,7 @@ describe('ColumnsBlock', () => {
       props: { ...baseProps, _key: 'test-cols-sl', variant: 'sidebar-left' },
     });
 
-    expect(html).toContain('@lg:grid-cols-[minmax(280px,1fr)_3fr]');
+    expect(html).toContain('@4xl:grid-cols-[minmax(280px,1fr)_3fr]');
   });
 
   test('applies sidebar-right variant grid classes', async () => {
@@ -76,7 +76,7 @@ describe('ColumnsBlock', () => {
       props: { ...baseProps, _key: 'test-cols-sr', variant: 'sidebar-right' },
     });
 
-    expect(html).toContain('@lg:grid-cols-[3fr_minmax(280px,1fr)]');
+    expect(html).toContain('@4xl:grid-cols-[3fr_minmax(280px,1fr)]');
   });
 
   test('applies center vertical alignment', async () => {
@@ -103,8 +103,8 @@ describe('ColumnsBlock', () => {
       props: { ...baseProps, _key: 'test-cols-rev', reverseOnMobile: true },
     });
 
-    expect(html).toContain('order-2 @lg:order-1');
-    expect(html).toContain('order-1 @lg:order-2');
+    expect(html).toContain('order-2 @4xl:order-1');
+    expect(html).toContain('order-1 @4xl:order-2');
   });
 
   test('does not apply order classes when reverseOnMobile is false', async () => {
@@ -113,8 +113,8 @@ describe('ColumnsBlock', () => {
       props: baseProps,
     });
 
-    expect(html).not.toContain('order-2 @lg:order-1');
-    expect(html).not.toContain('order-1 @lg:order-2');
+    expect(html).not.toContain('order-2 @4xl:order-1');
+    expect(html).not.toContain('order-1 @4xl:order-2');
   });
 
   test('defaults to equal variant when variant is undefined', async () => {
@@ -123,7 +123,7 @@ describe('ColumnsBlock', () => {
       props: { ...baseProps, _key: 'test-cols-def', variant: undefined },
     });
 
-    expect(html).toContain('@lg:grid-cols-2');
+    expect(html).toContain('@4xl:grid-cols-2');
     expect(html).toContain('items-start');
   });
 
@@ -134,6 +134,6 @@ describe('ColumnsBlock', () => {
     });
 
     expect(html).toContain('gap-8');
-    expect(html).toContain('@lg:gap-16');
+    expect(html).toContain('@4xl:gap-16');
   });
 });

--- a/astro-app/src/components/__tests__/CountdownTimer.test.ts
+++ b/astro-app/src/components/__tests__/CountdownTimer.test.ts
@@ -1,0 +1,102 @@
+import { experimental_AstroContainer as AstroContainer } from 'astro/container';
+import { describe, test, expect } from 'vitest';
+import CountdownTimer from '../blocks/custom/CountdownTimer.astro';
+import {
+  countdownInline,
+  countdownHero,
+  countdownBanner,
+  countdownBrutalist,
+  countdownMinimal,
+} from './__fixtures__/countdown-timer';
+
+describe('CountdownTimer', () => {
+  test('renders inline variant with heading and description', async () => {
+    const container = await AstroContainer.create();
+    const html = await container.renderToString(CountdownTimer, { props: countdownInline });
+
+    expect(html).toContain('Event Countdown');
+    expect(html).toContain('Time remaining until launch');
+    expect(html).toContain('data-countdown="2027-01-01T00:00:00Z"');
+    expect(html).toContain('data-completed-message="We have launched!"');
+  });
+
+  test('renders hero variant with container query classes', async () => {
+    const container = await AstroContainer.create();
+    const html = await container.renderToString(CountdownTimer, { props: countdownHero });
+
+    expect(html).toContain('The Big Launch');
+    expect(html).toContain('Join us for the main event');
+    expect(html).toContain('@3xl:gap-8');
+    expect(html).toContain('@3xl:text-8xl');
+  });
+
+  test('renders banner variant with compact layout', async () => {
+    const container = await AstroContainer.create();
+    const html = await container.renderToString(CountdownTimer, { props: countdownBanner });
+
+    expect(html).toContain('Sale Ends Soon');
+    expect(html).toContain('flex-row');
+  });
+
+  test('renders brutalist variant with container query classes', async () => {
+    const container = await AstroContainer.create();
+    const html = await container.renderToString(CountdownTimer, { props: countdownBrutalist });
+
+    expect(html).toContain('Deadline Approaching');
+    expect(html).toContain('Submit your entry before time runs out');
+    expect(html).toContain('@3xl:gap-6');
+    expect(html).toContain('@3xl:text-7xl');
+    expect(html).toContain('border-brutal');
+    expect(html).toContain('font-mono');
+  });
+
+  test('renders placeholder time units', async () => {
+    const container = await AstroContainer.create();
+    const html = await container.renderToString(CountdownTimer, { props: countdownInline });
+
+    expect(html).toContain('Days');
+    expect(html).toContain('Hours');
+    expect(html).toContain('Min');
+    expect(html).toContain('Sec');
+  });
+
+  test('generates JSON-LD Event structured data', async () => {
+    const container = await AstroContainer.create();
+    const html = await container.renderToString(CountdownTimer, { props: countdownInline });
+
+    const jsonLdMatch = html.match(/<script type="application\/ld\+json">(.*?)<\/script>/s);
+    expect(jsonLdMatch).not.toBeNull();
+
+    const jsonLd = JSON.parse(jsonLdMatch![1]);
+    expect(jsonLd['@type']).toBe('Event');
+    expect(jsonLd.name).toBe('Event Countdown');
+    expect(jsonLd.startDate).toBe('2027-01-01T00:00:00Z');
+    expect(jsonLd.description).toBe('Time remaining until launch');
+    expect(jsonLd.eventStatus).toBe('https://schema.org/EventScheduled');
+  });
+
+  test('defaults to inline variant for unknown variant value', async () => {
+    const container = await AstroContainer.create();
+    const html = await container.renderToString(CountdownTimer, {
+      props: { ...countdownInline, variant: 'unknown-variant' as any },
+    });
+
+    expect(html).toContain('Event Countdown');
+    expect(html).toContain('data-countdown');
+  });
+
+  test('handles minimal data without crashing', async () => {
+    const container = await AstroContainer.create();
+    const html = await container.renderToString(CountdownTimer, { props: countdownMinimal });
+
+    expect(html).toBeDefined();
+    expect(html).toContain('data-countdown="2027-01-01T00:00:00Z"');
+  });
+
+  test('omits heading when not provided', async () => {
+    const container = await AstroContainer.create();
+    const html = await container.renderToString(CountdownTimer, { props: countdownMinimal });
+
+    expect(html).not.toContain('<h2');
+  });
+});

--- a/astro-app/src/components/__tests__/ImageGallery.test.ts
+++ b/astro-app/src/components/__tests__/ImageGallery.test.ts
@@ -18,7 +18,7 @@ describe('ImageGallery', () => {
     const container = await AstroContainer.create();
     const html = await container.renderToString(ImageGallery, { props: imageGalleryFull });
 
-    expect(html).toContain('lg:grid-cols-3');
+    expect(html).toContain('@lg:grid-cols-3');
   });
 
   test('renders masonry variant with heading', async () => {

--- a/astro-app/src/components/__tests__/ImageGallery.test.ts
+++ b/astro-app/src/components/__tests__/ImageGallery.test.ts
@@ -18,7 +18,7 @@ describe('ImageGallery', () => {
     const container = await AstroContainer.create();
     const html = await container.renderToString(ImageGallery, { props: imageGalleryFull });
 
-    expect(html).toContain('@lg:grid-cols-3');
+    expect(html).toContain('@5xl:grid-cols-3');
   });
 
   test('renders masonry variant with heading', async () => {

--- a/astro-app/src/components/__tests__/LogoCloud.test.ts
+++ b/astro-app/src/components/__tests__/LogoCloud.test.ts
@@ -99,7 +99,7 @@ describe('LogoCloud', () => {
       props: { ...logoCloudFull, variant: 'nonexistent' },
     });
 
-    expect(html).toContain('grid-cols-2');
-    expect(html).toContain('lg:grid-cols-8');
+    expect(html).toContain('auto-fit');
+    expect(html).toContain('gap-px');
   });
 });

--- a/astro-app/src/components/__tests__/SponsorSteps.test.ts
+++ b/astro-app/src/components/__tests__/SponsorSteps.test.ts
@@ -71,7 +71,7 @@ describe('SponsorSteps', () => {
       props: { ...sponsorStepsFull, variant: 'split' },
     });
 
-    expect(html).toContain('sm:grid-cols-[repeat(auto-fit,minmax(260px,1fr))]');
+    expect(html).toContain('grid-cols-1 @sm:grid-cols-2 @3xl:grid-cols-3');
     expect(html).not.toContain('h-px flex-1');
   });
 

--- a/astro-app/src/components/__tests__/SponsorSteps.test.ts
+++ b/astro-app/src/components/__tests__/SponsorSteps.test.ts
@@ -55,14 +55,14 @@ describe('SponsorSteps', () => {
     expect(html).toBeDefined();
   });
 
-  test('steps variant keeps connecting-line classes', async () => {
+  test('steps variant uses responsive grid layout', async () => {
     const container = await AstroContainer.create();
     const html = await container.renderToString(SponsorSteps, {
       props: { ...sponsorStepsFull, variant: 'steps' },
     });
 
-    expect(html).toContain('bg-border');
-    expect(html).toContain('h-px flex-1');
+    expect(html).toContain('grid-cols-1 @2xl:grid-cols-2 @5xl:grid-cols-3');
+    expect(html).not.toContain('h-px flex-1');
   });
 
   test('split variant renders grid and omits connecting-line classes', async () => {
@@ -75,13 +75,13 @@ describe('SponsorSteps', () => {
     expect(html).not.toContain('h-px flex-1');
   });
 
-  test('spread variant renders spread container classes', async () => {
+  test('spread variant uses responsive grid layout', async () => {
     const container = await AstroContainer.create();
     const html = await container.renderToString(SponsorSteps, {
       props: { ...sponsorStepsFull, variant: 'spread' },
     });
 
-    expect(html).toContain('@5xl:justify-between');
+    expect(html).toContain('grid-cols-1 @2xl:grid-cols-2 @5xl:grid-cols-3');
   });
 
   test('unknown variant falls back to steps layout', async () => {
@@ -90,6 +90,6 @@ describe('SponsorSteps', () => {
       props: { ...sponsorStepsFull, variant: 'legacy-variant' },
     });
 
-    expect(html).toContain('bg-border');
+    expect(html).toContain('grid-cols-1 @2xl:grid-cols-2 @5xl:grid-cols-3');
   });
 });

--- a/astro-app/src/components/__tests__/SponsorSteps.test.ts
+++ b/astro-app/src/components/__tests__/SponsorSteps.test.ts
@@ -71,7 +71,7 @@ describe('SponsorSteps', () => {
       props: { ...sponsorStepsFull, variant: 'split' },
     });
 
-    expect(html).toContain('grid-cols-1 @sm:grid-cols-2 @3xl:grid-cols-3');
+    expect(html).toContain('grid-cols-1 @2xl:grid-cols-2 @5xl:grid-cols-3');
     expect(html).not.toContain('h-px flex-1');
   });
 

--- a/astro-app/src/components/__tests__/StatsRow.test.ts
+++ b/astro-app/src/components/__tests__/StatsRow.test.ts
@@ -104,6 +104,35 @@ describe('StatsRow', () => {
     expect(html).toContain('text-primary-foreground');
   });
 
+  test('brutalist variant uses container query text sizing', async () => {
+    const container = await AstroContainer.create();
+    const html = await container.renderToString(StatsRow, {
+      props: { ...statsFull, variant: 'brutalist' },
+    });
+
+    // Container-query breakpoints, not viewport — consistent with grid variant
+    expect(html).toContain('@3xl:text-7xl');
+    expect(html).toContain('@5xl:text-8xl');
+    expect(html).not.toContain('@md:text-7xl');
+    expect(html).not.toContain('@lg:text-8xl');
+  });
+
+  test('renders QuantitativeValue JSON-LD for stats', async () => {
+    const container = await AstroContainer.create();
+    const html = await container.renderToString(StatsRow, {
+      props: statsFull,
+    });
+
+    const jsonLdMatches = [...html.matchAll(/<script type="application\/ld\+json">(.*?)<\/script>/gs)];
+    expect(jsonLdMatches.length).toBeGreaterThan(0);
+
+    const schema = JSON.parse(jsonLdMatches[0][1]);
+    expect(schema['@context']).toBe('https://schema.org');
+    expect(schema['@type']).toBe('QuantitativeValue');
+    expect(schema.name).toBe('Members');
+    expect(schema.value).toBe('500');
+  });
+
   test('unknown variant falls back to grid layout', async () => {
     const container = await AstroContainer.create();
     const html = await container.renderToString(StatsRow, {

--- a/astro-app/src/components/__tests__/StatsRow.test.ts
+++ b/astro-app/src/components/__tests__/StatsRow.test.ts
@@ -41,9 +41,9 @@ describe('StatsRow', () => {
       props: { ...statsFull, variant: 'grid' },
     });
 
-    // 4 stats → grid-cols-2 @md:grid-cols-4 (container queries, not viewport)
+    // 4 stats → grid-cols-2 @6xl:grid-cols-4 (container queries, not viewport)
     expect(html).toContain('grid-cols-2');
-    expect(html).toContain('@md:grid-cols-4');
+    expect(html).toContain('@6xl:grid-cols-4');
   });
 
   test('split variant renders a single-column stat stack', async () => {
@@ -111,6 +111,6 @@ describe('StatsRow', () => {
     });
 
     expect(html).toContain('grid-cols-2');
-    expect(html).toContain('@md:grid-cols-4');
+    expect(html).toContain('@6xl:grid-cols-4');
   });
 });

--- a/astro-app/src/components/__tests__/Testimonials.test.ts
+++ b/astro-app/src/components/__tests__/Testimonials.test.ts
@@ -144,7 +144,7 @@ describe('Testimonials', () => {
       props: { ...testimonialsFull, variant: 'legacy-variant' },
     });
 
-    expect(html).toContain('md:grid-cols-2 lg:grid-cols-3');
+    expect(html).toContain('@md:grid-cols-2 @lg:grid-cols-3');
   });
 
   test('renders YouTube video facade with video ID', async () => {

--- a/astro-app/src/components/__tests__/Testimonials.test.ts
+++ b/astro-app/src/components/__tests__/Testimonials.test.ts
@@ -144,7 +144,7 @@ describe('Testimonials', () => {
       props: { ...testimonialsFull, variant: 'legacy-variant' },
     });
 
-    expect(html).toContain('@md:grid-cols-2 @lg:grid-cols-3');
+    expect(html).toContain('@2xl:grid-cols-2 @5xl:grid-cols-3');
   });
 
   test('renders YouTube video facade with video ID', async () => {

--- a/astro-app/src/components/__tests__/VariantLayout.test.ts
+++ b/astro-app/src/components/__tests__/VariantLayout.test.ts
@@ -73,8 +73,8 @@ describe('VariantLayout', () => {
       slots: { content: '<div>Grid item</div>' },
     });
 
-    // SectionGrid renders with "grid w-full gap-6" classes
-    expect(html).toMatch(/class="[^"]*grid w-full gap-6[^"]*"/);
+    // SectionGrid renders with "grid w-full gap-(--grid-gutter)" classes
+    expect(html).toMatch(/class="[^"]*grid w-full gap-\(--grid-gutter\)[^"]*"/);
     expect(html).toContain('<div>Grid item</div>');
   });
 

--- a/astro-app/src/components/__tests__/__fixtures__/countdown-timer.ts
+++ b/astro-app/src/components/__tests__/__fixtures__/countdown-timer.ts
@@ -1,0 +1,58 @@
+import type { CountdownTimerBlock } from '@/lib/types';
+
+const base = {
+  _type: 'countdownTimer' as const,
+  _key: 'test-countdown',
+  backgroundVariant: null,
+  spacing: 'default' as const,
+  maxWidth: 'default' as const,
+};
+
+export const countdownInline: CountdownTimerBlock = {
+  ...base,
+  heading: 'Event Countdown',
+  description: 'Time remaining until launch',
+  targetDate: '2027-01-01T00:00:00Z',
+  completedMessage: 'We have launched!',
+  variant: 'inline',
+};
+
+export const countdownHero: CountdownTimerBlock = {
+  ...base,
+  _key: 'test-countdown-hero',
+  heading: 'The Big Launch',
+  description: 'Join us for the main event',
+  targetDate: '2027-06-15T18:00:00Z',
+  completedMessage: 'The event has begun!',
+  variant: 'hero',
+};
+
+export const countdownBanner: CountdownTimerBlock = {
+  ...base,
+  _key: 'test-countdown-banner',
+  heading: 'Sale Ends Soon',
+  description: null,
+  targetDate: '2027-03-01T00:00:00Z',
+  completedMessage: null,
+  variant: 'banner',
+};
+
+export const countdownBrutalist: CountdownTimerBlock = {
+  ...base,
+  _key: 'test-countdown-brutalist',
+  heading: 'Deadline Approaching',
+  description: 'Submit your entry before time runs out',
+  targetDate: '2027-09-01T12:00:00Z',
+  completedMessage: null,
+  variant: 'brutalist',
+};
+
+export const countdownMinimal: CountdownTimerBlock = {
+  ...base,
+  _key: 'test-countdown-minimal',
+  heading: null,
+  description: null,
+  targetDate: '2027-01-01T00:00:00Z',
+  completedMessage: null,
+  variant: null,
+};

--- a/astro-app/src/components/blocks/custom/ArticleList.astro
+++ b/astro-app/src/components/blocks/custom/ArticleList.astro
@@ -453,8 +453,8 @@ const remainingArticles = articles.slice(1);
           <SectionGrid
             class={
               remainingArticles.length === 2
-                ? 'grid-cols-1 md:grid-cols-2'
-                : 'grid-cols-1 md:grid-cols-2 lg:grid-cols-3'
+                ? 'grid-cols-1 @md:grid-cols-2'
+                : 'grid-cols-1 @md:grid-cols-2 @lg:grid-cols-3'
             }
           >
             {remainingArticles.map((article) => <ArticleCard article={article} />)}

--- a/astro-app/src/components/blocks/custom/ArticleList.astro
+++ b/astro-app/src/components/blocks/custom/ArticleList.astro
@@ -453,8 +453,8 @@ const remainingArticles = articles.slice(1);
           <SectionGrid
             class={
               remainingArticles.length === 2
-                ? 'grid-cols-1 @md:grid-cols-2'
-                : 'grid-cols-1 @md:grid-cols-2 @lg:grid-cols-3'
+                ? 'grid-cols-1 @2xl:grid-cols-2'
+                : 'grid-cols-1 @2xl:grid-cols-2 @5xl:grid-cols-3'
             }
           >
             {remainingArticles.map((article) => <ArticleCard article={article} />)}

--- a/astro-app/src/components/blocks/custom/ArticleList.stories.ts
+++ b/astro-app/src/components/blocks/custom/ArticleList.stories.ts
@@ -214,7 +214,7 @@ export const MagazineThreeArticles = {
     docs: {
       description: {
         story:
-          'Magazine boundary case — 3 articles total. Hero renders first; the remaining 2 cards fill a `grid-cols-1 md:grid-cols-2` grid (the middle tier of the tiered remaining-articles layout, between the single-centered-card tier at 1 remaining and the 3-column tier at ≥3 remaining). Added in Story 19.9 code review to close the 2-remaining tier visual coverage gap.',
+          'Magazine boundary case — 3 articles total. Hero renders first; the remaining 2 cards fill a `grid-cols-1 @2xl:grid-cols-2` grid (the middle tier of the tiered remaining-articles layout, between the single-centered-card tier at 1 remaining and the 3-column tier at ≥3 remaining). Added in Story 19.9 code review to close the 2-remaining tier visual coverage gap.',
       },
     },
   },
@@ -235,7 +235,7 @@ export const MagazineFourArticles = {
     docs: {
       description: {
         story:
-          'Magazine boundary case — 4 articles total. Hero renders first; remaining 3 cards fill a `grid-cols-1 md:grid-cols-2 lg:grid-cols-3` grid, exercising the upper tier of the tiered remaining-articles layout.',
+          'Magazine boundary case — 4 articles total. Hero renders first; remaining 3 cards fill a `grid-cols-1 @2xl:grid-cols-2 @5xl:grid-cols-3` grid, exercising the upper tier of the tiered remaining-articles layout.',
       },
     },
   },

--- a/astro-app/src/components/blocks/custom/ColumnsBlock.astro
+++ b/astro-app/src/components/blocks/custom/ColumnsBlock.astro
@@ -28,12 +28,12 @@ const {
 const variant = stegaClean(rawVariant ?? 'equal');
 const verticalAlign = stegaClean(rawVerticalAlign ?? 'top');
 
-const gridClass = variant === 'equal' ? 'grid-cols-1 lg:grid-cols-2'
-  : variant === 'wide-left' ? 'grid-cols-1 lg:grid-cols-[2fr_1fr]'
-  : variant === 'wide-right' ? 'grid-cols-1 lg:grid-cols-[1fr_2fr]'
-  : variant === 'sidebar-left' ? 'grid-cols-1 lg:grid-cols-[minmax(280px,1fr)_3fr]'
-  : variant === 'sidebar-right' ? 'grid-cols-1 lg:grid-cols-[3fr_minmax(280px,1fr)]'
-  : 'grid-cols-1 lg:grid-cols-2';
+const gridClass = variant === 'equal' ? 'grid-cols-1 @lg:grid-cols-2'
+  : variant === 'wide-left' ? 'grid-cols-1 @lg:grid-cols-[2fr_1fr]'
+  : variant === 'wide-right' ? 'grid-cols-1 @lg:grid-cols-[1fr_2fr]'
+  : variant === 'sidebar-left' ? 'grid-cols-1 @lg:grid-cols-[minmax(280px,1fr)_3fr]'
+  : variant === 'sidebar-right' ? 'grid-cols-1 @lg:grid-cols-[3fr_minmax(280px,1fr)]'
+  : 'grid-cols-1 @lg:grid-cols-2';
 
 const alignClass = verticalAlign === 'center' ? 'items-center'
   : verticalAlign === 'stretch' ? 'items-stretch'
@@ -42,8 +42,8 @@ const shouldReverse = stegaClean(reverseOnMobile) === true;
 ---
 
 {(leftBlocks.length > 0 || rightBlocks.length > 0) && (
-<div class:list={['grid gap-8 lg:gap-16', gridClass, alignClass]}>
-  <div class:list={[shouldReverse && 'order-2 lg:order-1']}>
+<div class:list={['grid gap-8 @lg:gap-16', gridClass, alignClass]}>
+  <div class:list={[shouldReverse && 'order-2 @lg:order-1']}>
     <BlockRenderer
       blocks={leftBlocks}
       sponsors={sponsors}
@@ -53,7 +53,7 @@ const shouldReverse = stegaClean(reverseOnMobile) === true;
       articles={articles}
     />
   </div>
-  <div class:list={[shouldReverse && 'order-1 lg:order-2']}>
+  <div class:list={[shouldReverse && 'order-1 @lg:order-2']}>
     <BlockRenderer
       blocks={rightBlocks}
       sponsors={sponsors}

--- a/astro-app/src/components/blocks/custom/ColumnsBlock.astro
+++ b/astro-app/src/components/blocks/custom/ColumnsBlock.astro
@@ -2,6 +2,7 @@
 import type { Sponsor, Project, Testimonial, SanityEvent, Article } from '@/lib/sanity';
 import type { ColumnsBlockBlock } from '@/lib/types';
 import BlockRenderer from '@/components/BlockRenderer.astro';
+import { Section, SectionContent } from '@/components/ui/section';
 import { stegaClean } from '@sanity/client/stega';
 
 interface Props extends ColumnsBlockBlock {
@@ -28,12 +29,12 @@ const {
 const variant = stegaClean(rawVariant ?? 'equal');
 const verticalAlign = stegaClean(rawVerticalAlign ?? 'top');
 
-const gridClass = variant === 'equal' ? 'grid-cols-1 @lg:grid-cols-2'
-  : variant === 'wide-left' ? 'grid-cols-1 @lg:grid-cols-[2fr_1fr]'
-  : variant === 'wide-right' ? 'grid-cols-1 @lg:grid-cols-[1fr_2fr]'
-  : variant === 'sidebar-left' ? 'grid-cols-1 @lg:grid-cols-[minmax(280px,1fr)_3fr]'
-  : variant === 'sidebar-right' ? 'grid-cols-1 @lg:grid-cols-[3fr_minmax(280px,1fr)]'
-  : 'grid-cols-1 @lg:grid-cols-2';
+const gridClass = variant === 'equal' ? 'grid-cols-1 @4xl:grid-cols-2'
+  : variant === 'wide-left' ? 'grid-cols-1 @4xl:grid-cols-[2fr_1fr]'
+  : variant === 'wide-right' ? 'grid-cols-1 @4xl:grid-cols-[1fr_2fr]'
+  : variant === 'sidebar-left' ? 'grid-cols-1 @4xl:grid-cols-[minmax(280px,1fr)_3fr]'
+  : variant === 'sidebar-right' ? 'grid-cols-1 @4xl:grid-cols-[3fr_minmax(280px,1fr)]'
+  : 'grid-cols-1 @4xl:grid-cols-2';
 
 const alignClass = verticalAlign === 'center' ? 'items-center'
   : verticalAlign === 'stretch' ? 'items-stretch'
@@ -42,26 +43,37 @@ const shouldReverse = stegaClean(reverseOnMobile) === true;
 ---
 
 {(leftBlocks.length > 0 || rightBlocks.length > 0) && (
-<div class:list={['grid gap-8 @lg:gap-16', gridClass, alignClass]}>
-  <div class:list={[shouldReverse && 'order-2 @lg:order-1']}>
-    <BlockRenderer
-      blocks={leftBlocks}
-      sponsors={sponsors}
-      projects={projects}
-      testimonials={testimonials}
-      events={events}
-      articles={articles}
-    />
+<Section>
+  <div class:list={['grid gap-8 @4xl:gap-16', gridClass, alignClass]} data-columns-grid>
+    <div class:list={[shouldReverse && 'order-2 @4xl:order-1']}>
+      <BlockRenderer
+        blocks={leftBlocks}
+        sponsors={sponsors}
+        projects={projects}
+        testimonials={testimonials}
+        events={events}
+        articles={articles}
+      />
+    </div>
+    <div class:list={[shouldReverse && 'order-1 @4xl:order-2']}>
+      <BlockRenderer
+        blocks={rightBlocks}
+        sponsors={sponsors}
+        projects={projects}
+        testimonials={testimonials}
+        events={events}
+        articles={articles}
+      />
+    </div>
   </div>
-  <div class:list={[shouldReverse && 'order-1 @lg:order-2']}>
-    <BlockRenderer
-      blocks={rightBlocks}
-      sponsors={sponsors}
-      projects={projects}
-      testimonials={testimonials}
-      events={events}
-      articles={articles}
-    />
-  </div>
-</div>
+</Section>
 )}
+
+<style is:global>
+  /* Inner blocks inside ColumnsBlock should not add their own section padding —
+     the outer Section already provides containment. */
+  [data-columns-grid] [data-slot="section"] {
+    --section-px: 0px;
+    --section-py: 0px;
+  }
+</style>

--- a/astro-app/src/components/blocks/custom/CountdownTimer.astro
+++ b/astro-app/src/components/blocks/custom/CountdownTimer.astro
@@ -74,12 +74,12 @@ const placeholderUnits = [
       {description && (
         <p class="text-xl leading-relaxed text-muted-foreground">{description}</p>
       )}
-      <div class="flex items-center gap-6 md:gap-8 justify-center" data-countdown={targetDate} data-completed-message={completedMessage}>
+      <div class="flex items-center gap-6 @md:gap-8 justify-center" data-countdown={targetDate} data-completed-message={completedMessage}>
         {placeholderUnits.map((unit, i) => (
           <Fragment>
             {i > 0 && <span class="text-4xl font-bold text-muted-foreground">:</span>}
             <div class="flex flex-col items-center">
-              <span class="text-6xl md:text-8xl font-bold tabular-nums">{unit.value}</span>
+              <span class="text-6xl @md:text-8xl font-bold tabular-nums">{unit.value}</span>
               <span class="text-sm uppercase tracking-wide text-muted-foreground mt-2">{unit.label}</span>
             </div>
           </Fragment>
@@ -119,13 +119,13 @@ const placeholderUnits = [
       {description && (
         <p class="text-lg leading-relaxed text-muted-foreground">{description}</p>
       )}
-      <div class="flex items-start gap-4 md:gap-6 justify-center" data-countdown={targetDate} data-completed-message={completedMessage}>
+      <div class="flex items-start gap-4 @md:gap-6 justify-center" data-countdown={targetDate} data-completed-message={completedMessage}>
         {placeholderUnits.map((unit, i) => (
           <Fragment>
-            {i > 0 && <span class="text-4xl md:text-6xl font-bold text-primary font-mono self-center mt-2">:</span>}
+            {i > 0 && <span class="text-4xl @md:text-6xl font-bold text-primary font-mono self-center mt-2">:</span>}
             <div class="flex flex-col items-center">
-              <div class="border-brutal border-foreground/30 px-4 py-3 md:px-6 md:py-4">
-                <span class="text-5xl md:text-7xl font-bold font-mono tabular-nums leading-none">{unit.value}</span>
+              <div class="border-brutal border-foreground/30 px-4 py-3 @md:px-6 @md:py-4">
+                <span class="text-5xl @md:text-7xl font-bold font-mono tabular-nums leading-none">{unit.value}</span>
               </div>
               <span class="label-caps text-muted-foreground text-[10px] mt-2">{unit.label}</span>
             </div>

--- a/astro-app/src/components/blocks/custom/CountdownTimer.astro
+++ b/astro-app/src/components/blocks/custom/CountdownTimer.astro
@@ -74,12 +74,12 @@ const placeholderUnits = [
       {description && (
         <p class="text-xl leading-relaxed text-muted-foreground">{description}</p>
       )}
-      <div class="flex items-center gap-6 @md:gap-8 justify-center" data-countdown={targetDate} data-completed-message={completedMessage}>
+      <div class="flex items-center gap-6 @3xl:gap-8 justify-center" data-countdown={targetDate} data-completed-message={completedMessage}>
         {placeholderUnits.map((unit, i) => (
           <Fragment>
             {i > 0 && <span class="text-4xl font-bold text-muted-foreground">:</span>}
             <div class="flex flex-col items-center">
-              <span class="text-6xl @md:text-8xl font-bold tabular-nums">{unit.value}</span>
+              <span class="text-6xl @3xl:text-8xl font-bold tabular-nums">{unit.value}</span>
               <span class="text-sm uppercase tracking-wide text-muted-foreground mt-2">{unit.label}</span>
             </div>
           </Fragment>
@@ -119,13 +119,13 @@ const placeholderUnits = [
       {description && (
         <p class="text-lg leading-relaxed text-muted-foreground">{description}</p>
       )}
-      <div class="flex items-start gap-4 @md:gap-6 justify-center" data-countdown={targetDate} data-completed-message={completedMessage}>
+      <div class="flex items-start gap-4 @3xl:gap-6 justify-center" data-countdown={targetDate} data-completed-message={completedMessage}>
         {placeholderUnits.map((unit, i) => (
           <Fragment>
-            {i > 0 && <span class="text-4xl @md:text-6xl font-bold text-primary font-mono self-center mt-2">:</span>}
+            {i > 0 && <span class="text-4xl @3xl:text-6xl font-bold text-primary font-mono self-center mt-2">:</span>}
             <div class="flex flex-col items-center">
-              <div class="border-brutal border-foreground/30 px-4 py-3 @md:px-6 @md:py-4">
-                <span class="text-5xl @md:text-7xl font-bold font-mono tabular-nums leading-none">{unit.value}</span>
+              <div class="border-brutal border-foreground/30 px-4 py-3 @3xl:px-6 @3xl:py-4">
+                <span class="text-5xl @3xl:text-7xl font-bold font-mono tabular-nums leading-none">{unit.value}</span>
               </div>
               <span class="label-caps text-muted-foreground text-[10px] mt-2">{unit.label}</span>
             </div>

--- a/astro-app/src/components/blocks/custom/EventList.astro
+++ b/astro-app/src/components/blocks/custom/EventList.astro
@@ -88,7 +88,7 @@ function statusBadge(status: string): { text: string; cls: string } {
 
     <SectionContent>
       {events.length > 0 ? (
-        <div class="grid gap-6 @md:grid-cols-2 @lg:grid-cols-3">
+        <div class="grid gap-6 @2xl:grid-cols-2 @5xl:grid-cols-3">
           {events.map((e) => (
             <EventCard event={e} />
           ))}

--- a/astro-app/src/components/blocks/custom/EventList.astro
+++ b/astro-app/src/components/blocks/custom/EventList.astro
@@ -88,7 +88,7 @@ function statusBadge(status: string): { text: string; cls: string } {
 
     <SectionContent>
       {events.length > 0 ? (
-        <div class="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+        <div class="grid gap-6 @md:grid-cols-2 @lg:grid-cols-3">
           {events.map((e) => (
             <EventCard event={e} />
           ))}

--- a/astro-app/src/components/blocks/custom/FeatureGrid.astro
+++ b/astro-app/src/components/blocks/custom/FeatureGrid.astro
@@ -26,10 +26,10 @@ const cols = columns || 3;
 const gridSize = cols === 2 ? 'lg' : cols === 4 ? 'sm' : 'default';
 const gridClass =
   gridSize === 'lg'
-    ? 'grid-cols-1 @lg:grid-cols-2'
+    ? 'grid-cols-1 @4xl:grid-cols-2'
     : gridSize === 'sm'
-      ? 'grid-cols-2 @sm:grid-cols-3 @3xl:grid-cols-4'
-      : 'grid-cols-1 @sm:grid-cols-2 @3xl:grid-cols-3';
+      ? 'grid-cols-2 @2xl:grid-cols-3 @5xl:grid-cols-4'
+      : 'grid-cols-1 @2xl:grid-cols-2 @5xl:grid-cols-3';
 ---
 
 {cleanVariant === 'grid' ? (

--- a/astro-app/src/components/blocks/custom/FeatureGrid.astro
+++ b/astro-app/src/components/blocks/custom/FeatureGrid.astro
@@ -26,10 +26,10 @@ const cols = columns || 3;
 const gridSize = cols === 2 ? 'lg' : cols === 4 ? 'sm' : 'default';
 const gridClass =
   gridSize === 'lg'
-    ? 'grid-cols-1 sm:grid-cols-[repeat(auto-fit,minmax(400px,1fr))]'
+    ? 'grid-cols-1 @lg:grid-cols-2'
     : gridSize === 'sm'
-      ? 'grid-cols-[repeat(auto-fit,minmax(200px,1fr))]'
-      : 'grid-cols-1 sm:grid-cols-[repeat(auto-fit,minmax(260px,1fr))]';
+      ? 'grid-cols-2 @sm:grid-cols-3 @3xl:grid-cols-4'
+      : 'grid-cols-1 @sm:grid-cols-2 @3xl:grid-cols-3';
 ---
 
 {cleanVariant === 'grid' ? (

--- a/astro-app/src/components/blocks/custom/ImageGallery.astro
+++ b/astro-app/src/components/blocks/custom/ImageGallery.astro
@@ -38,7 +38,7 @@ const galleryJsonLd = galleryImages.length > 0 ? {
       </SectionContent>
     )}
     <SectionContent>
-      <div class="grid gap-6 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
+      <div class="grid gap-6 grid-cols-1 @sm:grid-cols-2 @lg:grid-cols-3">
         {(images ?? []).map((item) => (
           <figure>
             {item.image?.asset && (

--- a/astro-app/src/components/blocks/custom/ImageGallery.astro
+++ b/astro-app/src/components/blocks/custom/ImageGallery.astro
@@ -38,7 +38,7 @@ const galleryJsonLd = galleryImages.length > 0 ? {
       </SectionContent>
     )}
     <SectionContent>
-      <div class="grid gap-6 grid-cols-1 @sm:grid-cols-2 @lg:grid-cols-3">
+      <div class="grid gap-6 grid-cols-1 @2xl:grid-cols-2 @5xl:grid-cols-3">
         {(images ?? []).map((item) => (
           <figure>
             {item.image?.asset && (

--- a/astro-app/src/components/blocks/custom/LogoCloud.astro
+++ b/astro-app/src/components/blocks/custom/LogoCloud.astro
@@ -45,7 +45,7 @@ function groupByTier(list: Sponsor[]) {
       </div>
     )}
 
-    <ul class="grid grid-cols-2 sm:grid-cols-4 lg:grid-cols-8 gap-px bg-border list-none">
+    <ul class="grid grid-cols-[repeat(auto-fit,minmax(120px,1fr))] gap-px list-none">
       {sponsors?.map((sponsor) => {
         const logoUrl = safeUrlFor(sponsor.logo)?.width(120).url() ?? null;
         const content = (
@@ -190,7 +190,7 @@ function groupByTier(list: Sponsor[]) {
         <h2 class="text-4xl md:text-5xl font-bold tracking-[-0.03em] leading-[1.05]">{heading}</h2>
       </SectionContent>
     )}
-    <ul class="grid grid-cols-2 sm:grid-cols-4 lg:grid-cols-6 gap-px bg-border mx-auto max-w-6xl list-none">
+    <ul class="grid grid-cols-[repeat(auto-fit,minmax(150px,1fr))] gap-px list-none">
       {(sponsors ?? []).map((sponsor) => {
         const tier = stegaClean(sponsor.tier) || 'silver';
         const isPlatinum = tier === 'platinum';

--- a/astro-app/src/components/blocks/custom/SponsorSteps.astro
+++ b/astro-app/src/components/blocks/custom/SponsorSteps.astro
@@ -11,7 +11,6 @@ import {
   SectionProse,
   SectionSplit,
   SectionGrid,
-  SectionSpread,
 } from '@/components/ui/section';
 import {
   Tile,
@@ -71,18 +70,15 @@ const howToJsonLd = (items ?? []).length > 0 ? {
           ))
         }
       </SectionActions>
-      <SectionSplit class="gap-8">
+      <SectionGrid>
         {
           (items ?? []).map(({ title, description, list }, i) => (
-            <Tile class="items-stretch gap-4">
-              <div class="flex items-center gap-3">
-                <TileMedia variant="icon" class="size-10 text-base font-semibold">{i + 1}</TileMedia>
-                <div class="h-px flex-1 bg-border"></div>
-              </div>
-              <TileContent class="p-0">
-                <TileTitle class="not-first:mt-2">{title}</TileTitle>
+            <Tile>
+              <TileMedia variant="icon">{i + 1}</TileMedia>
+              <TileContent>
+                <TileTitle>{title}</TileTitle>
                 <TileDescription>{description}</TileDescription>
-                <List class="text-foreground not-first:mt-4">
+                <List class="text-foreground">
                   {list?.map((item) => (
                     <ListItem>
                       <CircleCheck />
@@ -94,7 +90,7 @@ const howToJsonLd = (items ?? []).length > 0 ? {
             </Tile>
           ))
         }
-      </SectionSplit>
+      </SectionGrid>
     </SectionContent>
   </Section>
 )}
@@ -175,7 +171,7 @@ const howToJsonLd = (items ?? []).length > 0 ? {
         }
       </SectionActions>
     </SectionContent>
-    <SectionSpread>
+    <SectionGrid>
       {
         (items ?? []).map(({ title, description, list }, i) => (
           <Tile>
@@ -195,6 +191,6 @@ const howToJsonLd = (items ?? []).length > 0 ? {
           </Tile>
         ))
       }
-    </SectionSpread>
+    </SectionGrid>
   </Section>
 )}

--- a/astro-app/src/components/blocks/custom/SponsorshipTiers.astro
+++ b/astro-app/src/components/blocks/custom/SponsorshipTiers.astro
@@ -48,7 +48,7 @@ const tierBarColors: Record<string, string> = {
       {description && (
         <p class="text-muted-foreground leading-relaxed max-w-2xl">{description}</p>
       )}
-      <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 items-start">
+      <div class="grid grid-cols-1 @md:grid-cols-2 @lg:grid-cols-3 gap-6 items-start">
         {tiersList.map((tier) => {
           const isHighlighted = tier.highlighted === true;
           return (
@@ -110,7 +110,7 @@ const tierBarColors: Record<string, string> = {
       {description && (
         <p class="text-muted-foreground leading-relaxed max-w-2xl">{description}</p>
       )}
-      <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 items-start">
+      <div class="grid grid-cols-1 @md:grid-cols-2 @lg:grid-cols-3 gap-6 items-start">
         {tiersList.map((tier) => {
           const isHighlighted = tier.highlighted === true;
           const tierName = stegaClean(tier.name)?.toLowerCase() || 'silver';

--- a/astro-app/src/components/blocks/custom/SponsorshipTiers.astro
+++ b/astro-app/src/components/blocks/custom/SponsorshipTiers.astro
@@ -48,7 +48,7 @@ const tierBarColors: Record<string, string> = {
       {description && (
         <p class="text-muted-foreground leading-relaxed max-w-2xl">{description}</p>
       )}
-      <div class="grid grid-cols-1 @md:grid-cols-2 @lg:grid-cols-3 gap-6 items-start">
+      <div class="grid grid-cols-1 @2xl:grid-cols-2 @5xl:grid-cols-3 gap-6 items-start">
         {tiersList.map((tier) => {
           const isHighlighted = tier.highlighted === true;
           return (
@@ -110,7 +110,7 @@ const tierBarColors: Record<string, string> = {
       {description && (
         <p class="text-muted-foreground leading-relaxed max-w-2xl">{description}</p>
       )}
-      <div class="grid grid-cols-1 @md:grid-cols-2 @lg:grid-cols-3 gap-6 items-start">
+      <div class="grid grid-cols-1 @2xl:grid-cols-2 @5xl:grid-cols-3 gap-6 items-start">
         {tiersList.map((tier) => {
           const isHighlighted = tier.highlighted === true;
           const tierName = stegaClean(tier.name)?.toLowerCase() || 'silver';

--- a/astro-app/src/components/blocks/custom/StatsRow.astro
+++ b/astro-app/src/components/blocks/custom/StatsRow.astro
@@ -121,7 +121,7 @@ const gridColsClass = statCount <= 1 ? 'grid-cols-1'
     <div class:list={['grid gap-8 @3xl:gap-10 @5xl:gap-12', gridColsClass]}>
       {(stats ?? []).map((stat) => (
         <div class="border-t-4 border-primary pt-4">
-          <div class="font-mono tabular-nums text-5xl @md:text-7xl @lg:text-8xl font-bold tracking-[-0.04em] leading-none mb-3">
+          <div class="font-mono tabular-nums text-5xl @3xl:text-7xl @5xl:text-8xl font-bold tracking-[-0.04em] leading-none mb-3">
             {stat.value}
           </div>
           <div class={`label-caps text-muted-foreground`}>

--- a/astro-app/src/components/blocks/custom/StatsRow.astro
+++ b/astro-app/src/components/blocks/custom/StatsRow.astro
@@ -52,10 +52,10 @@ const gridColsClass = statCount <= 1 ? 'grid-cols-1'
     {heading && (
       <h2 class="text-2xl md:text-3xl font-bold tracking-[-0.03em] text-center mb-8">{heading}</h2>
     )}
-    <div class:list={['grid gap-8 @md:gap-12', gridColsClass]}>
+    <div class:list={['grid gap-8 @sm:gap-10 @lg:gap-12', gridColsClass]}>
       {(stats ?? []).map((stat) => (
         <div class="text-center">
-          <div class="text-4xl @md:text-6xl font-bold tracking-[-0.04em] leading-none mb-3">
+          <div class="text-4xl @sm:text-5xl @lg:text-6xl font-bold tracking-[-0.04em] leading-none mb-3">
             {stat.value}
           </div>
           <div class={`label-caps text-muted-foreground`}>
@@ -118,7 +118,7 @@ const gridColsClass = statCount <= 1 ? 'grid-cols-1'
     {heading && (
       <h2 class="text-2xl md:text-3xl font-bold tracking-[-0.03em] text-center mb-8">{heading}</h2>
     )}
-    <div class:list={['grid gap-8 @md:gap-12', gridColsClass]}>
+    <div class:list={['grid gap-8 @sm:gap-10 @lg:gap-12', gridColsClass]}>
       {(stats ?? []).map((stat) => (
         <div class="border-t-4 border-primary pt-4">
           <div class="font-mono tabular-nums text-5xl @md:text-7xl @lg:text-8xl font-bold tracking-[-0.04em] leading-none mb-3">

--- a/astro-app/src/components/blocks/custom/StatsRow.astro
+++ b/astro-app/src/components/blocks/custom/StatsRow.astro
@@ -37,8 +37,8 @@ const cleanVariant = rawVariant === 'grid' || rawVariant === 'split' || rawVaria
 const statCount = (stats ?? []).length;
 const gridColsClass = statCount <= 1 ? 'grid-cols-1'
   : statCount === 2 ? 'grid-cols-2'
-  : statCount === 3 ? 'grid-cols-1 @sm:grid-cols-3'
-  : 'grid-cols-2 @md:grid-cols-4';
+  : statCount === 3 ? 'grid-cols-1 @2xl:grid-cols-3'
+  : 'grid-cols-2 @6xl:grid-cols-4';
 ---
 
 {statsJsonLd.length > 0 && statsJsonLd.map(s => <JsonLd schema={s} />)}
@@ -52,10 +52,10 @@ const gridColsClass = statCount <= 1 ? 'grid-cols-1'
     {heading && (
       <h2 class="text-2xl md:text-3xl font-bold tracking-[-0.03em] text-center mb-8">{heading}</h2>
     )}
-    <div class:list={['grid gap-8 @sm:gap-10 @lg:gap-12', gridColsClass]}>
+    <div class:list={['grid gap-8 @3xl:gap-10 @5xl:gap-12', gridColsClass]}>
       {(stats ?? []).map((stat) => (
         <div class="text-center">
-          <div class="text-4xl @sm:text-5xl @lg:text-6xl font-bold tracking-[-0.04em] leading-none mb-3">
+          <div class="text-4xl @3xl:text-5xl @5xl:text-6xl font-bold tracking-[-0.04em] leading-none mb-3">
             {stat.value}
           </div>
           <div class={`label-caps text-muted-foreground`}>
@@ -118,7 +118,7 @@ const gridColsClass = statCount <= 1 ? 'grid-cols-1'
     {heading && (
       <h2 class="text-2xl md:text-3xl font-bold tracking-[-0.03em] text-center mb-8">{heading}</h2>
     )}
-    <div class:list={['grid gap-8 @sm:gap-10 @lg:gap-12', gridColsClass]}>
+    <div class:list={['grid gap-8 @3xl:gap-10 @5xl:gap-12', gridColsClass]}>
       {(stats ?? []).map((stat) => (
         <div class="border-t-4 border-primary pt-4">
           <div class="font-mono tabular-nums text-5xl @md:text-7xl @lg:text-8xl font-bold tracking-[-0.04em] leading-none mb-3">

--- a/astro-app/src/components/blocks/custom/Testimonials.astro
+++ b/astro-app/src/components/blocks/custom/Testimonials.astro
@@ -82,7 +82,7 @@ if (isByProject) {
                 {group.title}
               </a>
             </h3>
-            <div class="grid gap-6 @md:grid-cols-2 @lg:grid-cols-3">
+            <div class="grid gap-6 @2xl:grid-cols-2 @5xl:grid-cols-3">
               {group.testimonials.map((t) => (
                 <TestimonialCard testimonial={t} />
               ))}
@@ -93,7 +93,7 @@ if (isByProject) {
     ) : (
       <SectionContent>
         {testimonials.length > 0 ? (
-          <div class="grid gap-6 @md:grid-cols-2 @lg:grid-cols-3">
+          <div class="grid gap-6 @2xl:grid-cols-2 @5xl:grid-cols-3">
             {testimonials.map((t) => (
               <TestimonialCard testimonial={t} />
             ))}

--- a/astro-app/src/components/blocks/custom/Testimonials.astro
+++ b/astro-app/src/components/blocks/custom/Testimonials.astro
@@ -82,7 +82,7 @@ if (isByProject) {
                 {group.title}
               </a>
             </h3>
-            <div class="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+            <div class="grid gap-6 @md:grid-cols-2 @lg:grid-cols-3">
               {group.testimonials.map((t) => (
                 <TestimonialCard testimonial={t} />
               ))}
@@ -93,7 +93,7 @@ if (isByProject) {
     ) : (
       <SectionContent>
         {testimonials.length > 0 ? (
-          <div class="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+          <div class="grid gap-6 @md:grid-cols-2 @lg:grid-cols-3">
             {testimonials.map((t) => (
               <TestimonialCard testimonial={t} />
             ))}

--- a/astro-app/src/components/ui/banner/banner.astro
+++ b/astro-app/src/components/ui/banner/banner.astro
@@ -69,7 +69,7 @@ const slot = await Astro.slots.render("default")
   }
 
   [data-slot="banner"] {
-    --banner-width: var(--container, var(--breakpoint-xl));
+    --banner-width: var(--container, var(--grid-max-width));
     --banner-px: max(
       var(--grid-margin),
       calc((100cqw - var(--banner-width)) / 2)

--- a/astro-app/src/components/ui/banner/banner.astro
+++ b/astro-app/src/components/ui/banner/banner.astro
@@ -71,7 +71,7 @@ const slot = await Astro.slots.render("default")
   [data-slot="banner"] {
     --banner-width: var(--container, var(--breakpoint-xl));
     --banner-px: max(
-      var(--gutter, 24px),
+      var(--grid-margin),
       calc((100cqw - var(--banner-width)) / 2)
     );
   }

--- a/astro-app/src/components/ui/banner/banner.astro
+++ b/astro-app/src/components/ui/banner/banner.astro
@@ -16,7 +16,7 @@ const variants = cva(
         default: "bg-foreground text-background w-full",
         floating: [
           "bg-foreground text-background shadow-sm",
-          "w-[calc(100%-2*var(--gutter,24px))] max-w-(--banner-width)",
+          "w-[calc(100%-2*var(--gutter))] max-w-(--banner-width)",
           "border-border my-2 overflow-hidden border",
         ],
       },

--- a/astro-app/src/components/ui/footer/footer-grid.astro
+++ b/astro-app/src/components/ui/footer/footer-grid.astro
@@ -14,7 +14,7 @@ const slot = await Astro.slots.render("default")
   slot?.trim().length > 0 && (
     <div
       class={cn(
-        "grid grid-cols-2 @lg:grid-cols-4 gap-(--grid-gutter)",
+        "grid grid-cols-2 @4xl:grid-cols-4 gap-(--grid-gutter)",
         className
       )}
       {...props}

--- a/astro-app/src/components/ui/footer/footer-grid.astro
+++ b/astro-app/src/components/ui/footer/footer-grid.astro
@@ -14,7 +14,7 @@ const slot = await Astro.slots.render("default")
   slot?.trim().length > 0 && (
     <div
       class={cn(
-        "grid grid-cols-[repeat(auto-fit,minmax(200px,250px))] gap-8",
+        "grid grid-cols-2 @lg:grid-cols-4 gap-(--grid-gutter)",
         className
       )}
       {...props}

--- a/astro-app/src/components/ui/footer/footer-split.astro
+++ b/astro-app/src/components/ui/footer/footer-split.astro
@@ -14,7 +14,7 @@ const slot = await Astro.slots.render("default")
   slot?.trim().length > 0 && (
     <div
       class={cn(
-        "grid size-full grid-cols-1 gap-16 *:w-full @5xl:grid-cols-[1fr_3fr]",
+        "grid size-full grid-cols-1 gap-(--grid-gutter) *:w-full @5xl:grid-cols-[1fr_3fr]",
         className
       )}
       data-slot="footer-split"

--- a/astro-app/src/components/ui/footer/footer.astro
+++ b/astro-app/src/components/ui/footer/footer.astro
@@ -50,7 +50,7 @@ const slot = await Astro.slots.render("default")
     --footer-width: var(--container, var(--breakpoint-xl));
     --footer-py: calc(var(--spacing) * 12);
     --footer-px: max(
-      var(--gutter, 24px),
+      var(--grid-margin),
       calc((100cqw - var(--footer-width)) / 2)
     );
   }

--- a/astro-app/src/components/ui/footer/footer.astro
+++ b/astro-app/src/components/ui/footer/footer.astro
@@ -47,7 +47,7 @@ const slot = await Astro.slots.render("default")
 
 <style is:global>
   [data-slot="footer"] {
-    --footer-width: var(--container, var(--breakpoint-xl));
+    --footer-width: var(--container, var(--grid-max-width));
     --footer-py: calc(var(--spacing) * 12);
     --footer-px: max(
       var(--grid-margin),

--- a/astro-app/src/components/ui/footer/footer.astro
+++ b/astro-app/src/components/ui/footer/footer.astro
@@ -16,7 +16,7 @@ const variants = cva(
         default: "bg-background w-full",
         floating: [
           "bg-background border shadow-sm",
-          "w-[calc(100%-2*var(--gutter,24px))] max-w-(--footer-width)",
+          "w-[calc(100%-2*var(--gutter))] max-w-(--footer-width)",
           "my-(--footer-py) overflow-hidden first:mt-2",
         ],
       },

--- a/astro-app/src/components/ui/header/header.astro
+++ b/astro-app/src/components/ui/header/header.astro
@@ -49,7 +49,7 @@ const slot = await Astro.slots.render("default")
   [data-slot="header"] {
     --header-width: var(--container, var(--breakpoint-xl));
     --header-px: max(
-      var(--gutter, 24px),
+      var(--grid-margin),
       calc((100cqw - var(--header-width)) / 2)
     );
   }

--- a/astro-app/src/components/ui/header/header.astro
+++ b/astro-app/src/components/ui/header/header.astro
@@ -47,7 +47,7 @@ const slot = await Astro.slots.render("default")
 
 <style is:global>
   [data-slot="header"] {
-    --header-width: var(--container, var(--breakpoint-xl));
+    --header-width: var(--container, var(--grid-max-width));
     --header-px: max(
       var(--grid-margin),
       calc((100cqw - var(--header-width)) / 2)

--- a/astro-app/src/components/ui/header/header.astro
+++ b/astro-app/src/components/ui/header/header.astro
@@ -15,7 +15,7 @@ const variants = cva(
       variant: {
         default: "bg-background sticky w-full",
         floating: [
-          "w-[calc(100%-2*var(--gutter,24px))] max-w-(--header-width)",
+          "w-[calc(100%-2*var(--gutter))] max-w-(--header-width)",
           "top-2 mt-2 h-[calc(var(--header-height)-var(--spacing)*2)] overflow-hidden",
           "bg-background border-border sticky border",
         ],

--- a/astro-app/src/components/ui/section/section-grid.astro
+++ b/astro-app/src/components/ui/section/section-grid.astro
@@ -12,9 +12,9 @@ const variants = cva("grid w-full gap-(--grid-gutter)", {
       default: "",
     },
     size: {
-      sm: "grid-cols-2 @sm:grid-cols-3 @3xl:grid-cols-4",
-      default: "grid-cols-1 @sm:grid-cols-2 @3xl:grid-cols-3",
-      lg: "grid-cols-1 @lg:grid-cols-2",
+      sm: "grid-cols-2 @2xl:grid-cols-3 @5xl:grid-cols-4",
+      default: "grid-cols-1 @2xl:grid-cols-2 @5xl:grid-cols-3",
+      lg: "grid-cols-1 @4xl:grid-cols-2",
     },
   },
   defaultVariants: {

--- a/astro-app/src/components/ui/section/section-grid.astro
+++ b/astro-app/src/components/ui/section/section-grid.astro
@@ -6,15 +6,15 @@ import { cn } from "@/lib/utils"
 
 interface Props extends HTMLAttributes<"div">, VariantProps<typeof variants> {}
 
-const variants = cva("grid w-full gap-6", {
+const variants = cva("grid w-full gap-(--grid-gutter)", {
   variants: {
     frame: {
       default: "",
     },
     size: {
-      sm: "grid-cols-[repeat(auto-fit,minmax(200px,1fr))]",
-      default: "grid-cols-1 sm:grid-cols-[repeat(auto-fit,minmax(260px,1fr))]",
-      lg: "grid-cols-1 sm:grid-cols-[repeat(auto-fit,minmax(400px,1fr))]",
+      sm: "grid-cols-2 @sm:grid-cols-3 @3xl:grid-cols-4",
+      default: "grid-cols-1 @sm:grid-cols-2 @3xl:grid-cols-3",
+      lg: "grid-cols-1 @lg:grid-cols-2",
     },
   },
   defaultVariants: {

--- a/astro-app/src/components/ui/section/section-split.astro
+++ b/astro-app/src/components/ui/section/section-split.astro
@@ -3,9 +3,21 @@ import type { HTMLAttributes } from "astro/types"
 
 import { cn } from "@/lib/utils"
 
-interface Props extends HTMLAttributes<"div"> {}
+interface Props extends HTMLAttributes<"div"> {
+  ratio?: '5:7' | '7:5' | '6:6' | '4:8' | '8:4';
+}
 
-const { class: className, ...props } = Astro.props
+const ratioMap: Record<string, string> = {
+  '5:7': '@lg:grid-cols-[5fr_7fr]',
+  '7:5': '@lg:grid-cols-[7fr_5fr]',
+  '6:6': '@lg:grid-cols-2',
+  '4:8': '@lg:grid-cols-[4fr_8fr]',
+  '8:4': '@lg:grid-cols-[8fr_4fr]',
+};
+
+const { class: className, ratio = '5:7', ...props } = Astro.props
+
+const ratioCols = ratioMap[ratio] ?? ratioMap['5:7'];
 
 const slot = await Astro.slots.render("default")
 ---
@@ -14,7 +26,8 @@ const slot = await Astro.slots.render("default")
   slot?.trim().length > 0 && (
     <div
       class={cn(
-        "grid size-full grid-cols-1 gap-16 @lg:grid-cols-2",
+        "grid size-full grid-cols-1 gap-(--grid-gutter)",
+        ratioCols,
         className
       )}
       data-slot="section-split"

--- a/astro-app/src/components/ui/section/section-split.astro
+++ b/astro-app/src/components/ui/section/section-split.astro
@@ -8,11 +8,11 @@ interface Props extends HTMLAttributes<"div"> {
 }
 
 const ratioMap: Record<string, string> = {
-  '5:7': '@lg:grid-cols-[5fr_7fr]',
-  '7:5': '@lg:grid-cols-[7fr_5fr]',
-  '6:6': '@lg:grid-cols-2',
-  '4:8': '@lg:grid-cols-[4fr_8fr]',
-  '8:4': '@lg:grid-cols-[8fr_4fr]',
+  '5:7': '@4xl:grid-cols-[5fr_7fr]',
+  '7:5': '@4xl:grid-cols-[7fr_5fr]',
+  '6:6': '@4xl:grid-cols-2',
+  '4:8': '@4xl:grid-cols-[4fr_8fr]',
+  '8:4': '@4xl:grid-cols-[8fr_4fr]',
 };
 
 const { class: className, ratio = '5:7', ...props } = Astro.props

--- a/astro-app/src/components/ui/section/section.astro
+++ b/astro-app/src/components/ui/section/section.astro
@@ -50,10 +50,10 @@ const slot = await Astro.slots.render("default")
 
 <style is:global>
   [data-slot="section"] {
-    --section-width: var(--container, var(--breakpoint-xl));
+    --section-width: var(--container, var(--grid-max-width));
     --section-py: var(--block-section-py, calc(var(--spacing) * 12));
     --section-px: max(
-      var(--gutter, 24px),
+      var(--grid-margin),
       calc((100cqw - var(--section-width)) / 2)
     );
   }

--- a/astro-app/src/components/ui/section/section.astro
+++ b/astro-app/src/components/ui/section/section.astro
@@ -18,7 +18,7 @@ const variants = cva(
         default: "bg-background w-full",
         floating: [
           "bg-background border shadow-md",
-          "w-[calc(100%-2*var(--gutter,24px))] max-w-(--section-width)",
+          "w-[calc(100%-2*var(--gutter))] max-w-(--section-width)",
           "my-(--section-py) overflow-hidden",
         ],
       },

--- a/astro-app/src/layouts/PortalLayout.astro
+++ b/astro-app/src/layouts/PortalLayout.astro
@@ -196,7 +196,7 @@ const avatarLetter = email.charAt(0).toUpperCase();
       </aside>
 
       {/* Main content area — constrained width */}
-      <div class="flex-1 p-6 lg:p-8 lg:max-w-[var(--breakpoint-xl)]">
+      <div class="flex-1 p-6 lg:p-8 lg:max-w-(--grid-max-width)">
         <slot />
       </div>
     </div>

--- a/astro-app/src/layouts/SidebarLayout.astro
+++ b/astro-app/src/layouts/SidebarLayout.astro
@@ -23,7 +23,7 @@ const hasSidebar = Astro.slots.has('sidebar');
 <Layout title={title} seo={seo} hideNav={hideNav} ogType={ogType}>
   <slot name="header" />
   {hasSidebar ? (
-    <div class="mx-auto w-full max-w-[var(--breakpoint-xl)] px-(--gutter) pb-12 flex flex-col lg:grid lg:gap-8 lg:pb-16" style={`--sidebar-width: ${sidebarWidth};`} data-sidebar-layout>
+    <div class="mx-auto w-full max-w-(--grid-max-width) px-(--gutter) pb-12 flex flex-col lg:grid lg:gap-8 lg:pb-16" style={`--sidebar-width: ${sidebarWidth};`} data-sidebar-layout>
       <div>
         <slot />
       </div>

--- a/astro-app/src/layouts/SidebarLayout.astro
+++ b/astro-app/src/layouts/SidebarLayout.astro
@@ -23,7 +23,7 @@ const hasSidebar = Astro.slots.has('sidebar');
 <Layout title={title} seo={seo} hideNav={hideNav} ogType={ogType}>
   <slot name="header" />
   {hasSidebar ? (
-    <div class="mx-auto w-full max-w-(--grid-max-width) px-(--gutter) pb-12 flex flex-col lg:grid lg:gap-8 lg:pb-16" style={`--sidebar-width: ${sidebarWidth};`} data-sidebar-layout>
+    <div class="@container w-full pb-12 flex flex-col lg:grid lg:gap-8 lg:pb-16" style={`--sidebar-width: ${sidebarWidth};`} data-sidebar-layout>
       <div>
         <slot />
       </div>
@@ -41,6 +41,12 @@ const hasSidebar = Astro.slots.has('sidebar');
 
 <style is:global>
   [data-sidebar-layout] {
+    --sidebar-px: max(
+      var(--grid-margin),
+      calc((100cqw - var(--grid-max-width)) / 2)
+    );
+    padding-left: var(--sidebar-px);
+    padding-right: var(--sidebar-px);
     grid-template-columns: 1fr var(--sidebar-width);
   }
 </style>

--- a/astro-app/src/pages/[...slug].astro
+++ b/astro-app/src/pages/[...slug].astro
@@ -67,7 +67,7 @@ const preloadSrcset = heroImage?.asset
 >
   {visualEditingEnabled ? (
     <SanityPageContent server:defer slug={slug as string}>
-      <div slot="fallback" class="mx-auto max-w-7xl px-(--gutter) py-12">
+      <div slot="fallback" class="mx-auto max-w-(--grid-max-width) px-(--grid-margin) py-12">
         <div class="animate-pulse space-y-8">
           <div class="h-10 bg-muted rounded w-2/5"></div>
           <div class="h-64 bg-muted rounded"></div>

--- a/astro-app/src/pages/events/index.astro
+++ b/astro-app/src/pages/events/index.astro
@@ -40,7 +40,7 @@ const pageSeo = listingPage?.seo ?? { metaDescription: 'Browse upcoming and past
 
       <div id="events-list">
         {events.length > 0 ? (
-          <div class="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+          <div class="grid gap-6 @2xl:grid-cols-2 @5xl:grid-cols-3">
             {events.map((e) => (
               <EventCard event={e} />
             ))}

--- a/astro-app/src/pages/index.astro
+++ b/astro-app/src/pages/index.astro
@@ -41,7 +41,7 @@ const preloadSrcset = heroImage?.asset
 <Layout title={page?.title ?? undefined} seo={page?.seo} preloadImage={preloadImageUrl} preloadImageSrcset={preloadSrcset} preloadImageSizes="100vw">
   {visualEditingEnabled ? (
     <SanityPageContent server:defer slug="home">
-      <div slot="fallback" class="mx-auto max-w-7xl px-(--gutter) py-12">
+      <div slot="fallback" class="mx-auto max-w-(--grid-max-width) px-(--grid-margin) py-12">
         <div class="animate-pulse space-y-8">
           <div class="h-10 bg-muted rounded w-2/5"></div>
           <div class="h-64 bg-muted rounded"></div>

--- a/astro-app/src/pages/projects/index.astro
+++ b/astro-app/src/pages/projects/index.astro
@@ -40,7 +40,7 @@ const pageSeo = listingPage?.seo ?? { metaDescription: 'Explore capstone project
     </SectionContent>
   </Section>
 
-  <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+  <div class="grid grid-cols-1 @2xl:grid-cols-2 gap-6">
     {projects.map((project) => (
       <ProjectCard project={project} />
     ))}

--- a/astro-app/src/styles/global.css
+++ b/astro-app/src/styles/global.css
@@ -179,10 +179,16 @@
 }
 
 :root {
+  /* 12-column grid tokens */
+  --grid-columns: 12;
+  --grid-gutter: 24px;
+  --grid-margin: var(--grid-gutter);
+  --grid-max-width: var(--breakpoint-xl);
+
   /* Gutter system — single source of truth for edge/container padding.
      Responsive: 16px (mobile) → 24px (sm 640px) → 32px (lg 1024px).
-     Referenced by section, header, footer, banner via var(--gutter, 24px)
-     and by templates via px-(--gutter). */
+     Referenced by section, header, footer, banner via var(--grid-margin)
+     and by templates via px-(--grid-margin). */
   --gutter: 1rem;
   --radius: 0;
   --background: #ffffff;
@@ -296,9 +302,35 @@
 
 @media (min-width: 1024px) {
   :root {
+    --grid-gutter: 32px;
     --gutter: 2rem;
   }
 }
+
+/* === 12-COLUMN GRID SYSTEM === *
+ * Formal grid foundation for Swiss design discipline.
+ * All layouts expressed as column spans of this 12-column grid.
+ *
+ * Tokens:
+ *   --grid-columns   Number of columns (12)
+ *   --grid-gutter    Gap between columns (24px mobile, 32px desktop)
+ *   --grid-margin    Outer page margin (= gutter)
+ *   --grid-max-width Maximum content width (1280px from Tailwind v4)
+ *
+ * Column Span Reference (12-column grid):
+ *   Full width:    col-span-12  (12/12)
+ *   Major content: col-span-8   (8/12) — prose, main content
+ *   Minor sidebar: col-span-4   (4/12) — sidebar, aside
+ *   Two-thirds:    col-span-8   (8/12) — split major
+ *   One-third:     col-span-4   (4/12) — split minor
+ *   Half:          col-span-6   (6/12) — equal split
+ *   Quarter:       col-span-3   (3/12) — card grids (4-up)
+ *   Third:         col-span-4   (4/12) — card grids (3-up)
+ *   Sixth:         col-span-2   (2/12) — icon grids, logo clouds
+ *
+ * Tailwind v4 provides grid-cols-12 and col-span-* natively.
+ * Container queries (@lg:, @3xl:, @5xl:) used for internal layout.
+ */
 
 @layer base {
   * {

--- a/astro-app/src/styles/global.css
+++ b/astro-app/src/styles/global.css
@@ -185,10 +185,9 @@
   --grid-margin: var(--grid-gutter);
   --grid-max-width: var(--breakpoint-xl);
 
-  /* Gutter system — single source of truth for edge/container padding.
+  /* Gutter system — edge/container padding for floating variants.
      Responsive: 16px (mobile) → 24px (sm 640px) → 32px (lg 1024px).
-     Referenced by section, header, footer, banner via var(--grid-margin)
-     and by templates via px-(--grid-margin). */
+     Referenced by section, header, footer, banner floating variant width calc. */
   --gutter: 1rem;
   --radius: 0;
   --background: #ffffff;


### PR DESCRIPTION
## Summary

This PR sets up a formal **12-column grid system** across the entire site. Think of it like graph paper behind every page — it makes sure all our layouts line up consistently.

### What changed and why

- **New grid tokens in CSS** — We added four new CSS variables (`--grid-columns`, `--grid-gutter`, `--grid-margin`, `--grid-max-width`) that act as the single source of truth for how wide content can be and how much space goes between columns. Before this, different parts of the site used different values (some hardcoded `max-w-7xl`, others used `--breakpoint-xl`). Now they all point to the same tokens.

- **Card grids no longer use `auto-fit`** — Components like `SectionGrid` and `footer-grid` used CSS `auto-fit` which lets the browser decide how many columns to show. This is unpredictable — you might get 2 columns one moment and 3 the next. We replaced this with explicit column counts at specific breakpoints (e.g., 1 column on mobile, 2 on tablet, 3 on desktop).

- **Container queries instead of viewport breakpoints** — 10 block components (ArticleList, EventList, ImageGallery, etc.) used `md:grid-cols-2` which checks the *browser window* width. This breaks inside narrow containers like ColumnsBlock sidebars — the window is wide but the column is narrow. We switched to `@md:grid-cols-2` which checks the *container* width instead. Now blocks adapt correctly no matter where they're placed.

- **Asymmetric split layouts** — `SectionSplit` previously defaulted to a 50/50 split. We changed the default to 5:7 (a ratio based on the 12-column grid) and added a `ratio` prop so blocks can choose from `5:7`, `7:5`, `6:6`, `4:8`, or `8:4`.

- **Header nav fix for iPads** — The desktop navigation menu was overflowing at 1024px (iPad landscape). We raised the breakpoint from `md:` (768px) to `xl:` (1280px) so iPads show the hamburger menu instead of cramming all nav items into a narrow space.

- **LogoCloud adaptive grid** — The logo grid used to hard-code 8 columns, which left an empty gray cell when there were only 7 sponsors. Now it uses `auto-fit` so logos fill whatever space is available without gaps.

- **StatsRow tablet sizing** — Stat numbers used to jump from `text-4xl` straight to `text-6xl`. We added an intermediate `text-5xl` step for tablets so the numbers don't look oversized on mid-sized screens.

### Files touched (33 files)

| Area | Files | What changed |
|------|-------|-------------|
| Grid tokens | `global.css` | New `--grid-*` CSS custom properties |
| Layout primitives | `section.astro`, `section-grid.astro`, `section-split.astro`, `header.astro`, `footer.astro`, `footer-grid.astro`, `footer-split.astro`, `banner.astro` | Reference new grid tokens instead of old `--gutter`/`--breakpoint-xl` |
| Block wrapper | `BlockWrapper.astro` | Added `@container` so container queries work for blocks without their own `<Section>` |
| Header nav | `Header.astro` | Nav breakpoint `md:` → `xl:` |
| Templates/Pages | `SidebarLayout.astro`, `PortalLayout.astro`, `SanityPageContent.astro`, `index.astro`, `[...slug].astro` | `max-w-7xl` → `--grid-max-width` |
| Block components | `ColumnsBlock`, `ArticleList`, `EventList`, `ImageGallery`, `SponsorshipTiers`, `Testimonials`, `LogoCloud`, `FeatureGrid`, `CountdownTimer`, `StatsRow` | Viewport → container query migration |
| Tests | 7 test files | Updated CSS class assertions to match new `@lg:`/`@md:` patterns |

## Test plan

- [x] `npm run build -w astro-app` — build succeeds
- [x] `npm run test:unit` — 103 files, 1737 tests pass, 0 failures
- [x] Visual verification at mobile (375px), tablet portrait (768px), tablet landscape (1024px), desktop (1440px)
- [x] ColumnsBlock showcase page renders correctly at all viewports
- [x] No horizontal overflow at any viewport
- [ ] Verify on actual iPad device if available
- [ ] Spot-check sponsor detail pages, event index, project index

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added selectable split-section ratios and improved section container sizing responsiveness.

* **Style**
  * Introduced a 12‑column grid system and CSS variables for standardized spacing and max-widths.
  * Updated responsive breakpoints and layout utilities across headers, footers, banners, sections, and content grids.
  * Minor visual polish: subtle card shadow and refined layout containment.

* **Tests**
  * Updated many tests to match revised responsive/grid classes and added CountdownTimer test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->