### PR TITLE
fix: resolve code review findings for image gallery

### DIFF
--- a/astro-app/src/components/Header.astro
+++ b/astro-app/src/components/Header.astro
@@ -78,7 +78,7 @@ const isActive = (href: string) =>
       >
         <Icon name="search" class="h-4 w-4" />
         <span class="label-caps text-[10px]">Search</span>
-        <kbd class="border-2 border-foreground/20 px-1.5 py-0.5 text-[10px] font-mono text-foreground/40 leading-none">⌘K</kbd>
+        <kbd class="border-2 border-foreground/20 px-1.5 pt-1 pb-0.5 text-[10px] font-mono text-foreground/40 leading-none">⌘K</kbd>
       </button>
 
       {/* CTA button — Swiss structural accent */}
@@ -197,7 +197,7 @@ const isActive = (href: string) =>
                       'inline-flex h-11 items-center bg-transparent px-4 py-0 text-[11px] font-bold uppercase tracking-[0.15em] rounded-none',
                       isActive(item.href || '')
                         ? 'text-primary'
-                        : 'text-foreground/50',
+                        : 'text-foreground',
                     ]}
                     href={item.href}
                     data-gtm-category="navigation"
@@ -228,7 +228,7 @@ const isActive = (href: string) =>
                     'inline-flex h-11 items-center bg-transparent px-4 py-0 text-[11px] font-bold uppercase tracking-[0.15em] no-underline transition-colors hover:text-primary rounded-none',
                     isActive(item.href || '')
                       ? 'text-primary'
-                      : 'text-foreground/50',
+                      : 'text-foreground',
                   ]}
                   variant="trigger"
                   href={item.href}
@@ -251,7 +251,7 @@ const isActive = (href: string) =>
         'inline-flex h-11 items-center px-4 text-[10px] font-mono uppercase tracking-[0.12em] no-underline transition-colors hover:text-foreground border-b-[3px] -mb-[3px]',
         isActive('/contact')
           ? 'text-primary border-primary'
-          : 'border-transparent text-foreground/40',
+          : 'border-transparent text-foreground',
       ]}
       data-gtm-category="navigation"
       data-gtm-label="Contact"

--- a/astro-app/src/components/__tests__/ImageGallery.test.ts
+++ b/astro-app/src/components/__tests__/ImageGallery.test.ts
@@ -78,8 +78,9 @@ describe('ImageGallery', () => {
     const container = await AstroContainer.create();
     const html = await container.renderToString(ImageGallery, { props: imageGalleryWithFeatured });
 
-    expect(html).toContain('All Years');
+    expect(html).toContain('Year');
     expect(html).toContain('data-filter-type="year"');
+    expect(html).toContain('data-filter-value="all"');
     expect(html).toContain('data-filter-value="2024"');
     expect(html).toContain('data-filter-value="2025"');
     expect(html).toContain('data-filter-value="2026"');
@@ -89,8 +90,9 @@ describe('ImageGallery', () => {
     const container = await AstroContainer.create();
     const html = await container.renderToString(ImageGallery, { props: imageGalleryWithFeatured });
 
-    expect(html).toContain('All Categories');
+    expect(html).toContain('Category');
     expect(html).toContain('data-filter-type="category"');
+    expect(html).toContain('data-filter-value="all"');
     expect(html).toContain('AI/ML');
     expect(html).toContain('Web Apps');
     expect(html).toContain('Mobile');
@@ -204,8 +206,8 @@ describe('ImageGallery', () => {
     const masonryWithFilters = { ...imageGalleryWithFeatured, variant: 'masonry' as const };
     const html = await container.renderToString(ImageGallery, { props: masonryWithFilters });
 
-    expect(html).toContain('All Years');
-    expect(html).toContain('All Categories');
+    expect(html).toContain('Year');
+    expect(html).toContain('Category');
     expect(html).toContain('gallery-filter-pill');
   });
 

--- a/astro-app/src/components/__tests__/ImageGallery.test.ts
+++ b/astro-app/src/components/__tests__/ImageGallery.test.ts
@@ -1,5 +1,5 @@
 import { experimental_AstroContainer as AstroContainer } from 'astro/container';
-import { describe, test, expect } from 'vitest';
+import { describe, test, expect, vi } from 'vitest';
 import ImageGallery from '../blocks/custom/ImageGallery.astro';
 import {
   imageGalleryFull,
@@ -8,6 +8,13 @@ import {
   imageGallerySingle,
   imageGalleryMinimal,
 } from './__fixtures__/image-gallery';
+
+// Mock getSiteSettings to avoid Sanity API dependency
+vi.mock('@/lib/sanity', () => ({
+  getSiteSettings: vi.fn().mockResolvedValue({
+    title: 'YWCC Industry Capstone',
+  }),
+}));
 
 describe('ImageGallery', () => {
   test('renders heading and captions in grid variant', async () => {
@@ -167,5 +174,46 @@ describe('ImageGallery', () => {
 
     expect(html).toContain('background-image: url(data:image/jpeg;base64');
     expect(html).toContain('background-size: cover');
+  });
+
+  test('renders JSON-LD with creator Organization from siteSettings', async () => {
+    const container = await AstroContainer.create();
+    const html = await container.renderToString(ImageGallery, { props: imageGalleryFull });
+
+    const jsonLdMatch = html.match(/<script type="application\/ld\+json">(.*?)<\/script>/s);
+    expect(jsonLdMatch).not.toBeNull();
+
+    const jsonLd = JSON.parse(jsonLdMatch![1]);
+    expect(jsonLd.creator).toBeDefined();
+    expect(jsonLd.creator['@type']).toBe('Organization');
+    expect(jsonLd.creator.name).toBe('YWCC Industry Capstone');
+  });
+
+  test('renders featured images inside pswp-gallery container', async () => {
+    const container = await AstroContainer.create();
+    const html = await container.renderToString(ImageGallery, { props: imageGalleryWithFeatured });
+
+    // Featured row should be inside pswp-gallery, not a sibling
+    const pswpGalleryMatch = html.match(/class="pswp-gallery[^"]*"[^>]*>([\s\S]*)/);
+    expect(pswpGalleryMatch).not.toBeNull();
+    expect(pswpGalleryMatch![1]).toContain('gallery-featured');
+  });
+
+  test('masonry variant renders filter pills when year/category data exists', async () => {
+    const container = await AstroContainer.create();
+    const masonryWithFilters = { ...imageGalleryWithFeatured, variant: 'masonry' as const };
+    const html = await container.renderToString(ImageGallery, { props: masonryWithFilters });
+
+    expect(html).toContain('All Years');
+    expect(html).toContain('All Categories');
+    expect(html).toContain('gallery-filter-pill');
+  });
+
+  test('single variant includes 1200w and 1600w in srcset', async () => {
+    const container = await AstroContainer.create();
+    const html = await container.renderToString(ImageGallery, { props: imageGallerySingle });
+
+    expect(html).toContain('1200w');
+    expect(html).toContain('1600w');
   });
 });

--- a/astro-app/src/components/__tests__/json-ld-blocks.test.ts
+++ b/astro-app/src/components/__tests__/json-ld-blocks.test.ts
@@ -1,6 +1,13 @@
 import { experimental_AstroContainer as AstroContainer } from 'astro/container';
 import { describe, test, expect, vi, beforeEach } from 'vitest';
 
+// Mock getSiteSettings to avoid Sanity API dependency
+vi.mock('@/lib/sanity', () => ({
+  getSiteSettings: vi.fn().mockResolvedValue({
+    title: 'YWCC Industry Capstone',
+  }),
+}));
+
 // Mock image utilities before imports
 vi.mock('@/lib/image', () => ({
   urlFor: (img: unknown) => ({

--- a/astro-app/src/components/blocks/custom/ImageGallery.astro
+++ b/astro-app/src/components/blocks/custom/ImageGallery.astro
@@ -9,9 +9,11 @@ import { JsonLd } from '@/components/ui/json-ld';
 interface Props extends ImageGalleryBlock {
   class?: string;
   id?: string;
+  /** When true, renders content without the Section/SectionContent wrapper (for embedding in a page's own Section) */
+  bare?: boolean;
 }
 
-const { heading, description, images, variant: rawVariant, _key: blockKey } = Astro.props;
+const { heading, description, images, variant: rawVariant, _key: blockKey, bare = false } = Astro.props;
 const variant = stegaClean(rawVariant) ?? 'grid';
 
 const CATEGORY_LABELS: Record<string, string> = {
@@ -87,7 +89,7 @@ const hasFilters = years.length > 0 || categories.length > 0;
 
 {galleryJsonLd && <JsonLd schema={galleryJsonLd} />}
 
-{variant === 'grid' && (
+{variant === 'grid' && !bare && (
   <Section data-animate>
     {heading && (
       <SectionContent class="max-w-3xl">
@@ -96,22 +98,24 @@ const hasFilters = years.length > 0 || categories.length > 0;
       </SectionContent>
     )}
     <SectionContent>
-      {/* Filter pills */}
+      {/* Filter bar — Swiss geometric style */}
       {hasFilters && (
-        <div class="gallery-filters flex flex-wrap gap-2 mb-8" data-gallery-target={galleryId}>
+        <div class="gallery-filters space-y-3 mb-8 border-b border-border pb-6" data-gallery-target={galleryId}>
           {years.length > 0 && (
-            <div class="flex flex-wrap gap-2">
-              <button type="button" class="gallery-filter-pill active bg-primary text-primary-foreground px-4 py-1.5 rounded-full text-sm font-medium transition-colors" data-filter-type="year" data-filter-value="all">All Years</button>
+            <div class="flex flex-wrap items-center gap-2">
+              <span class="label-caps text-muted-foreground mr-1">Year</span>
+              <button type="button" class="gallery-filter-pill label-caps border border-border px-3 py-1 transition-colors data-[state=active]:bg-primary data-[state=active]:text-primary-foreground data-[state=active]:border-primary hover:bg-muted hover:border-foreground" data-state="active" aria-pressed="true" data-filter-type="year" data-filter-value="all">All</button>
               {years.map(year => (
-                <button type="button" class="gallery-filter-pill bg-muted text-muted-foreground px-4 py-1.5 rounded-full text-sm font-medium transition-colors hover:bg-muted/80" data-filter-type="year" data-filter-value={String(year)}>{year}</button>
+                <button type="button" class="gallery-filter-pill label-caps border border-border px-3 py-1 transition-colors data-[state=active]:bg-primary data-[state=active]:text-primary-foreground data-[state=active]:border-primary hover:bg-muted hover:border-foreground" aria-pressed="false" data-filter-type="year" data-filter-value={String(year)}>{year}</button>
               ))}
             </div>
           )}
           {categories.length > 0 && (
-            <div class="flex flex-wrap gap-2">
-              <button type="button" class="gallery-filter-pill active bg-primary text-primary-foreground px-4 py-1.5 rounded-full text-sm font-medium transition-colors" data-filter-type="category" data-filter-value="all">All Categories</button>
+            <div class="flex flex-wrap items-center gap-2">
+              <span class="label-caps text-muted-foreground mr-1">Category</span>
+              <button type="button" class="gallery-filter-pill label-caps border border-border px-3 py-1 transition-colors data-[state=active]:bg-primary data-[state=active]:text-primary-foreground data-[state=active]:border-primary hover:bg-muted hover:border-foreground" data-state="active" aria-pressed="true" data-filter-type="category" data-filter-value="all">All</button>
               {categories.map(cat => (
-                <button type="button" class="gallery-filter-pill bg-muted text-muted-foreground px-4 py-1.5 rounded-full text-sm font-medium transition-colors hover:bg-muted/80" data-filter-type="category" data-filter-value={cat}>{CATEGORY_LABELS[cat] || cat}</button>
+                <button type="button" class="gallery-filter-pill label-caps border border-border px-3 py-1 transition-colors data-[state=active]:bg-primary data-[state=active]:text-primary-foreground data-[state=active]:border-primary hover:bg-muted hover:border-foreground" aria-pressed="false" data-filter-type="category" data-filter-value={cat}>{CATEGORY_LABELS[cat] || cat}</button>
               ))}
             </div>
           )}
@@ -186,6 +190,71 @@ const hasFilters = years.length > 0 || categories.length > 0;
   </Section>
 )}
 
+{variant === 'grid' && bare && (
+  <Fragment>
+    {heading && (
+      <div>
+        <h2 class="text-4xl md:text-5xl font-[750] tracking-[-0.03em] leading-[1.05]">{heading}</h2>
+        {description && <p class="mt-4 text-lg text-muted-foreground">{description}</p>}
+      </div>
+    )}
+
+    {/* Filter bar — Swiss geometric style */}
+    {hasFilters && (
+      <div class="gallery-filters space-y-3 border-b border-border pb-6" data-gallery-target={galleryId}>
+        {years.length > 0 && (
+          <div class="flex flex-wrap items-center gap-2">
+            <span class="label-caps text-muted-foreground mr-1">Year</span>
+            <button type="button" class="gallery-filter-pill label-caps border border-border px-3 py-1 transition-colors data-[state=active]:bg-primary data-[state=active]:text-primary-foreground data-[state=active]:border-primary hover:bg-muted hover:border-foreground" data-state="active" aria-pressed="true" data-filter-type="year" data-filter-value="all">All</button>
+            {years.map(year => (
+              <button type="button" class="gallery-filter-pill label-caps border border-border px-3 py-1 transition-colors data-[state=active]:bg-primary data-[state=active]:text-primary-foreground data-[state=active]:border-primary hover:bg-muted hover:border-foreground" aria-pressed="false" data-filter-type="year" data-filter-value={String(year)}>{year}</button>
+            ))}
+          </div>
+        )}
+        {categories.length > 0 && (
+          <div class="flex flex-wrap items-center gap-2">
+            <span class="label-caps text-muted-foreground mr-1">Category</span>
+            <button type="button" class="gallery-filter-pill label-caps border border-border px-3 py-1 transition-colors data-[state=active]:bg-primary data-[state=active]:text-primary-foreground data-[state=active]:border-primary hover:bg-muted hover:border-foreground" data-state="active" aria-pressed="true" data-filter-type="category" data-filter-value="all">All</button>
+            {categories.map(cat => (
+              <button type="button" class="gallery-filter-pill label-caps border border-border px-3 py-1 transition-colors data-[state=active]:bg-primary data-[state=active]:text-primary-foreground data-[state=active]:border-primary hover:bg-muted hover:border-foreground" aria-pressed="false" data-filter-type="category" data-filter-value={cat}>{CATEGORY_LABELS[cat] || cat}</button>
+            ))}
+          </div>
+        )}
+      </div>
+    )}
+
+    {/* Gallery container */}
+    <div id={galleryId} class="pswp-gallery">
+      {featuredItems.length > 0 && (
+        <div class="gallery-featured grid gap-6 grid-cols-1 @3xl:grid-cols-2 mb-8">
+          {featuredItems.map((item) => (
+            <figure data-year={item.year ? String(item.year) : undefined} data-category={stegaClean(item.category) || undefined}>
+              {item.image?.asset && (
+                <a href={urlFor(item.image).width(1600).url()} data-pswp-width={item.fullWidth} data-pswp-height={item.fullHeight} target="_blank" class="block transition-transform duration-200 hover:scale-[1.02] hover:shadow-lg cursor-zoom-in">
+                  <img src={urlFor(item.image).width(1200).height(800).fit('crop').url()} srcset={`${urlFor(item.image).width(400).height(267).fit('crop').url()} 400w, ${urlFor(item.image).width(600).height(400).fit('crop').url()} 600w, ${urlFor(item.image).width(800).height(533).fit('crop').url()} 800w`} sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 50vw" alt={item.image.alt || ''} width={1200} height={800} class="aspect-[3/2] w-full object-cover" loading="lazy" style={lqipStyle(item.image.asset.metadata?.lqip)} />
+                </a>
+              )}
+              {item.caption && <figcaption class="mt-2 text-sm text-muted-foreground">{item.caption}</figcaption>}
+            </figure>
+          ))}
+        </div>
+      )}
+      <div class="grid gap-6 grid-cols-1 @2xl:grid-cols-2 @5xl:grid-cols-3">
+        {regularItems.map((item) => (
+          <figure data-year={item.year ? String(item.year) : undefined} data-category={stegaClean(item.category) || undefined}>
+            {item.image?.asset && (
+              <a href={urlFor(item.image).width(1600).url()} data-pswp-width={item.fullWidth} data-pswp-height={item.fullHeight} target="_blank" class="block transition-transform duration-200 hover:scale-[1.02] hover:shadow-lg cursor-zoom-in">
+                <img src={urlFor(item.image).width(800).height(600).fit('crop').url()} srcset={`${urlFor(item.image).width(400).height(300).fit('crop').url()} 400w, ${urlFor(item.image).width(600).height(450).fit('crop').url()} 600w, ${urlFor(item.image).width(800).height(600).fit('crop').url()} 800w`} sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw" alt={item.image.alt || ''} width={800} height={600} class="aspect-video w-full object-cover" loading="lazy" style={lqipStyle(item.image.asset.metadata?.lqip)} />
+              </a>
+            )}
+            {item.caption && <figcaption class="mt-2 text-sm text-muted-foreground">{item.caption}</figcaption>}
+          </figure>
+        ))}
+      </div>
+    </div>
+  </Fragment>
+)}
+
 {variant === 'masonry' && (
   <Section data-animate>
     {heading && (
@@ -196,20 +265,22 @@ const hasFilters = years.length > 0 || categories.length > 0;
     )}
     {hasFilters && (
       <SectionContent>
-        <div class="gallery-filters flex flex-wrap gap-2 mb-8" data-gallery-target={galleryId}>
+        <div class="gallery-filters space-y-3 mb-8 border-b border-border pb-6" data-gallery-target={galleryId}>
           {years.length > 0 && (
-            <div class="flex flex-wrap gap-2">
-              <button type="button" class="gallery-filter-pill active bg-primary text-primary-foreground px-4 py-1.5 rounded-full text-sm font-medium transition-colors" data-filter-type="year" data-filter-value="all">All Years</button>
+            <div class="flex flex-wrap items-center gap-2">
+              <span class="label-caps text-muted-foreground mr-1">Year</span>
+              <button type="button" class="gallery-filter-pill label-caps border border-border px-3 py-1 transition-colors data-[state=active]:bg-primary data-[state=active]:text-primary-foreground data-[state=active]:border-primary hover:bg-muted hover:border-foreground" data-state="active" aria-pressed="true" data-filter-type="year" data-filter-value="all">All</button>
               {years.map(year => (
-                <button type="button" class="gallery-filter-pill bg-muted text-muted-foreground px-4 py-1.5 rounded-full text-sm font-medium transition-colors hover:bg-muted/80" data-filter-type="year" data-filter-value={String(year)}>{year}</button>
+                <button type="button" class="gallery-filter-pill label-caps border border-border px-3 py-1 transition-colors data-[state=active]:bg-primary data-[state=active]:text-primary-foreground data-[state=active]:border-primary hover:bg-muted hover:border-foreground" aria-pressed="false" data-filter-type="year" data-filter-value={String(year)}>{year}</button>
               ))}
             </div>
           )}
           {categories.length > 0 && (
-            <div class="flex flex-wrap gap-2">
-              <button type="button" class="gallery-filter-pill active bg-primary text-primary-foreground px-4 py-1.5 rounded-full text-sm font-medium transition-colors" data-filter-type="category" data-filter-value="all">All Categories</button>
+            <div class="flex flex-wrap items-center gap-2">
+              <span class="label-caps text-muted-foreground mr-1">Category</span>
+              <button type="button" class="gallery-filter-pill label-caps border border-border px-3 py-1 transition-colors data-[state=active]:bg-primary data-[state=active]:text-primary-foreground data-[state=active]:border-primary hover:bg-muted hover:border-foreground" data-state="active" aria-pressed="true" data-filter-type="category" data-filter-value="all">All</button>
               {categories.map(cat => (
-                <button type="button" class="gallery-filter-pill bg-muted text-muted-foreground px-4 py-1.5 rounded-full text-sm font-medium transition-colors hover:bg-muted/80" data-filter-type="category" data-filter-value={cat}>{CATEGORY_LABELS[cat] || cat}</button>
+                <button type="button" class="gallery-filter-pill label-caps border border-border px-3 py-1 transition-colors data-[state=active]:bg-primary data-[state=active]:text-primary-foreground data-[state=active]:border-primary hover:bg-muted hover:border-foreground" aria-pressed="false" data-filter-type="category" data-filter-value={cat}>{CATEGORY_LABELS[cat] || cat}</button>
               ))}
             </div>
           )}
@@ -288,20 +359,22 @@ const hasFilters = years.length > 0 || categories.length > 0;
       )}
       <SectionContent>
         {hasFilters && (
-          <div class="gallery-filters flex flex-wrap gap-2 mb-8" data-gallery-target={galleryId}>
+          <div class="gallery-filters space-y-3 mb-8 border-b border-border pb-6" data-gallery-target={galleryId}>
             {years.length > 0 && (
-              <div class="flex flex-wrap gap-2">
-                <button type="button" class="gallery-filter-pill active bg-primary text-primary-foreground px-4 py-1.5 rounded-full text-sm font-medium transition-colors" data-filter-type="year" data-filter-value="all">All Years</button>
+              <div class="flex flex-wrap items-center gap-2">
+                <span class="label-caps text-muted-foreground mr-1">Year</span>
+                <button type="button" class="gallery-filter-pill label-caps border border-border px-3 py-1 transition-colors data-[state=active]:bg-primary data-[state=active]:text-primary-foreground data-[state=active]:border-primary hover:bg-muted hover:border-foreground" data-state="active" aria-pressed="true" data-filter-type="year" data-filter-value="all">All</button>
                 {years.map(year => (
-                  <button type="button" class="gallery-filter-pill bg-muted text-muted-foreground px-4 py-1.5 rounded-full text-sm font-medium transition-colors hover:bg-muted/80" data-filter-type="year" data-filter-value={String(year)}>{year}</button>
+                  <button type="button" class="gallery-filter-pill label-caps border border-border px-3 py-1 transition-colors data-[state=active]:bg-primary data-[state=active]:text-primary-foreground data-[state=active]:border-primary hover:bg-muted hover:border-foreground" aria-pressed="false" data-filter-type="year" data-filter-value={String(year)}>{year}</button>
                 ))}
               </div>
             )}
             {categories.length > 0 && (
-              <div class="flex flex-wrap gap-2">
-                <button type="button" class="gallery-filter-pill active bg-primary text-primary-foreground px-4 py-1.5 rounded-full text-sm font-medium transition-colors" data-filter-type="category" data-filter-value="all">All Categories</button>
+              <div class="flex flex-wrap items-center gap-2">
+                <span class="label-caps text-muted-foreground mr-1">Category</span>
+                <button type="button" class="gallery-filter-pill label-caps border border-border px-3 py-1 transition-colors data-[state=active]:bg-primary data-[state=active]:text-primary-foreground data-[state=active]:border-primary hover:bg-muted hover:border-foreground" data-state="active" aria-pressed="true" data-filter-type="category" data-filter-value="all">All</button>
                 {categories.map(cat => (
-                  <button type="button" class="gallery-filter-pill bg-muted text-muted-foreground px-4 py-1.5 rounded-full text-sm font-medium transition-colors hover:bg-muted/80" data-filter-type="category" data-filter-value={cat}>{CATEGORY_LABELS[cat] || cat}</button>
+                  <button type="button" class="gallery-filter-pill label-caps border border-border px-3 py-1 transition-colors data-[state=active]:bg-primary data-[state=active]:text-primary-foreground data-[state=active]:border-primary hover:bg-muted hover:border-foreground" aria-pressed="false" data-filter-type="category" data-filter-value={cat}>{CATEGORY_LABELS[cat] || cat}</button>
                 ))}
               </div>
             )}
@@ -480,13 +553,13 @@ const hasFilters = years.length > 0 || categories.length > 0;
           activeCategory = filterValue;
         }
 
-        // Update active pill styling within the same filter group
+        // Update active pill styling via data-state attribute (Swiss design pattern)
         filterBar.querySelectorAll(`.gallery-filter-pill[data-filter-type="${filterType}"]`).forEach(p => {
-          p.classList.remove('active', 'bg-primary', 'text-primary-foreground');
-          p.classList.add('bg-muted', 'text-muted-foreground');
+          p.removeAttribute('data-state');
+          p.setAttribute('aria-pressed', 'false');
         });
-        pill.classList.add('active', 'bg-primary', 'text-primary-foreground');
-        pill.classList.remove('bg-muted', 'text-muted-foreground');
+        pill.setAttribute('data-state', 'active');
+        pill.setAttribute('aria-pressed', 'true');
 
         applyFilters();
       });

--- a/astro-app/src/components/blocks/custom/ImageGallery.astro
+++ b/astro-app/src/components/blocks/custom/ImageGallery.astro
@@ -2,6 +2,7 @@
 import type { ImageGalleryBlock } from '@/lib/types';
 import { stegaClean } from '@sanity/client/stega';
 import { urlFor, safeUrlFor, lqipStyle } from '@/lib/image';
+import { getSiteSettings } from '@/lib/sanity';
 import { Section, SectionContent, SectionMasonry } from '@/components/ui/section';
 import { JsonLd } from '@/components/ui/json-ld';
 
@@ -37,24 +38,45 @@ const regularItems = galleryItems.filter(item => item.featured !== true);
 const years = [...new Set(galleryItems.map(i => i.year).filter((y): y is number => y != null))].sort();
 const categories = [...new Set(galleryItems.map(i => stegaClean(i.category)).filter((c): c is string => c != null))].sort();
 
-// JSON-LD structured data
-const galleryImages = galleryItems.filter(img => img.image?.asset).map(img => ({
-  "@type": "ImageObject" as const,
-  "contentUrl": safeUrlFor(img.image)?.width(1200).url(),
-  ...(img.caption && { "name": stegaClean(img.caption) }),
-  ...(img.image?.alt && { "description": stegaClean(img.image.alt) }),
-  "width": img.fullWidth,
-  "height": img.fullHeight,
-  "thumbnailUrl": safeUrlFor(img.image)?.width(400).url(),
-}));
+// JSON-LD structured data — filter out items where safeUrlFor returns null
+const galleryImages = galleryItems
+  .filter(img => img.image?.asset)
+  .map(img => {
+    const contentUrl = safeUrlFor(img.image)?.width(1200).url();
+    const thumbnailUrl = safeUrlFor(img.image)?.width(400).url();
+    if (!contentUrl) return null;
+    return {
+      "@type": "ImageObject" as const,
+      "contentUrl": contentUrl,
+      ...(img.caption && { "name": stegaClean(img.caption) }),
+      ...(img.image?.alt && { "description": stegaClean(img.image.alt) }),
+      "width": img.fullWidth,
+      "height": img.fullHeight,
+      ...(thumbnailUrl && { "thumbnailUrl": thumbnailUrl }),
+    };
+  })
+  .filter((img): img is NonNullable<typeof img> => img !== null);
 
 const earliestYear = years.length > 0 ? Math.min(...years) : null;
+
+// Fetch siteSettings for JSON-LD creator (cached at module level)
+let creatorOrg: { "@type": "Organization"; "name": string } | null = null;
+try {
+  const siteSettings = await getSiteSettings();
+  const siteName = stegaClean(siteSettings.title);
+  if (siteName) {
+    creatorOrg = { "@type": "Organization", "name": siteName };
+  }
+} catch {
+  // siteSettings unavailable — omit creator
+}
 
 const galleryJsonLd = galleryImages.length > 0 ? {
   "@type": "ImageGallery",
   ...(heading && { "name": stegaClean(heading) }),
   ...(description && { "description": stegaClean(description) }),
   ...(earliestYear && { "dateCreated": new Date(earliestYear, 0, 1).toISOString() }),
+  ...(creatorOrg && { "creator": creatorOrg }),
   "image": galleryImages,
 } : null;
 
@@ -96,10 +118,43 @@ const hasFilters = years.length > 0 || categories.length > 0;
         </div>
       )}
 
-      {/* Featured hero row */}
-      {featuredItems.length > 0 && (
-        <div class="gallery-featured grid gap-6 grid-cols-1 @3xl:grid-cols-2 mb-8">
-          {featuredItems.map((item) => (
+      {/* Gallery container — featured + regular inside one pswp-gallery */}
+      <div id={galleryId} class="pswp-gallery">
+        {/* Featured hero row */}
+        {featuredItems.length > 0 && (
+          <div class="gallery-featured grid gap-6 grid-cols-1 @3xl:grid-cols-2 mb-8">
+            {featuredItems.map((item) => (
+              <figure data-year={item.year ? String(item.year) : undefined} data-category={stegaClean(item.category) || undefined}>
+                {item.image?.asset && (
+                  <a
+                    href={urlFor(item.image).width(1600).url()}
+                    data-pswp-width={item.fullWidth}
+                    data-pswp-height={item.fullHeight}
+                    target="_blank"
+                    class="block transition-transform duration-200 hover:scale-[1.02] hover:shadow-lg cursor-zoom-in"
+                  >
+                    <img
+                      src={urlFor(item.image).width(1200).height(800).fit('crop').url()}
+                      srcset={`${urlFor(item.image).width(400).height(267).fit('crop').url()} 400w, ${urlFor(item.image).width(600).height(400).fit('crop').url()} 600w, ${urlFor(item.image).width(800).height(533).fit('crop').url()} 800w`}
+                      sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 50vw"
+                      alt={item.image.alt || ''}
+                      width={1200}
+                      height={800}
+                      class="aspect-[3/2] w-full object-cover"
+                      loading="lazy"
+                      style={lqipStyle(item.image.asset.metadata?.lqip)}
+                    />
+                  </a>
+                )}
+                {item.caption && <figcaption class="mt-2 text-sm text-muted-foreground">{item.caption}</figcaption>}
+              </figure>
+            ))}
+          </div>
+        )}
+
+        {/* Main grid */}
+        <div class="grid gap-6 grid-cols-1 @2xl:grid-cols-2 @5xl:grid-cols-3">
+          {regularItems.map((item) => (
             <figure data-year={item.year ? String(item.year) : undefined} data-category={stegaClean(item.category) || undefined}>
               {item.image?.asset && (
                 <a
@@ -110,13 +165,13 @@ const hasFilters = years.length > 0 || categories.length > 0;
                   class="block transition-transform duration-200 hover:scale-[1.02] hover:shadow-lg cursor-zoom-in"
                 >
                   <img
-                    src={urlFor(item.image).width(1200).height(800).fit('crop').url()}
-                    srcset={`${urlFor(item.image).width(400).height(267).fit('crop').url()} 400w, ${urlFor(item.image).width(600).height(400).fit('crop').url()} 600w, ${urlFor(item.image).width(800).height(533).fit('crop').url()} 800w`}
-                    sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 50vw"
+                    src={urlFor(item.image).width(800).height(600).fit('crop').url()}
+                    srcset={`${urlFor(item.image).width(400).height(300).fit('crop').url()} 400w, ${urlFor(item.image).width(600).height(450).fit('crop').url()} 600w, ${urlFor(item.image).width(800).height(600).fit('crop').url()} 800w`}
+                    sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
                     alt={item.image.alt || ''}
-                    width={1200}
-                    height={800}
-                    class="aspect-[3/2] w-full object-cover"
+                    width={800}
+                    height={600}
+                    class="aspect-video w-full object-cover"
                     loading="lazy"
                     style={lqipStyle(item.image.asset.metadata?.lqip)}
                   />
@@ -126,36 +181,6 @@ const hasFilters = years.length > 0 || categories.length > 0;
             </figure>
           ))}
         </div>
-      )}
-
-      {/* Main grid */}
-      <div id={galleryId} class="pswp-gallery grid gap-6 grid-cols-1 @2xl:grid-cols-2 @5xl:grid-cols-3">
-        {regularItems.map((item) => (
-          <figure data-year={item.year ? String(item.year) : undefined} data-category={stegaClean(item.category) || undefined}>
-            {item.image?.asset && (
-              <a
-                href={urlFor(item.image).width(1600).url()}
-                data-pswp-width={item.fullWidth}
-                data-pswp-height={item.fullHeight}
-                target="_blank"
-                class="block transition-transform duration-200 hover:scale-[1.02] hover:shadow-lg cursor-zoom-in"
-              >
-                <img
-                  src={urlFor(item.image).width(800).height(600).fit('crop').url()}
-                  srcset={`${urlFor(item.image).width(400).height(300).fit('crop').url()} 400w, ${urlFor(item.image).width(600).height(450).fit('crop').url()} 600w, ${urlFor(item.image).width(800).height(600).fit('crop').url()} 800w`}
-                  sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
-                  alt={item.image.alt || ''}
-                  width={800}
-                  height={600}
-                  class="aspect-video w-full object-cover"
-                  loading="lazy"
-                  style={lqipStyle(item.image.asset.metadata?.lqip)}
-                />
-              </a>
-            )}
-            {item.caption && <figcaption class="mt-2 text-sm text-muted-foreground">{item.caption}</figcaption>}
-          </figure>
-        ))}
       </div>
     </SectionContent>
   </Section>
@@ -169,9 +194,58 @@ const hasFilters = years.length > 0 || categories.length > 0;
         {description && <p class="mt-4 text-lg text-muted-foreground">{description}</p>}
       </SectionContent>
     )}
+    {hasFilters && (
+      <SectionContent>
+        <div class="gallery-filters flex flex-wrap gap-2 mb-8" data-gallery-target={galleryId}>
+          {years.length > 0 && (
+            <div class="flex flex-wrap gap-2">
+              <button type="button" class="gallery-filter-pill active bg-primary text-primary-foreground px-4 py-1.5 rounded-full text-sm font-medium transition-colors" data-filter-type="year" data-filter-value="all">All Years</button>
+              {years.map(year => (
+                <button type="button" class="gallery-filter-pill bg-muted text-muted-foreground px-4 py-1.5 rounded-full text-sm font-medium transition-colors hover:bg-muted/80" data-filter-type="year" data-filter-value={String(year)}>{year}</button>
+              ))}
+            </div>
+          )}
+          {categories.length > 0 && (
+            <div class="flex flex-wrap gap-2">
+              <button type="button" class="gallery-filter-pill active bg-primary text-primary-foreground px-4 py-1.5 rounded-full text-sm font-medium transition-colors" data-filter-type="category" data-filter-value="all">All Categories</button>
+              {categories.map(cat => (
+                <button type="button" class="gallery-filter-pill bg-muted text-muted-foreground px-4 py-1.5 rounded-full text-sm font-medium transition-colors hover:bg-muted/80" data-filter-type="category" data-filter-value={cat}>{CATEGORY_LABELS[cat] || cat}</button>
+              ))}
+            </div>
+          )}
+        </div>
+      </SectionContent>
+    )}
     <SectionMasonry>
       <div id={galleryId} class="pswp-gallery contents">
-        {galleryItems.map((item) => (
+        {/* Featured hero row in masonry */}
+        {featuredItems.length > 0 && featuredItems.map((item) => (
+          <figure class="col-span-full" data-year={item.year ? String(item.year) : undefined} data-category={stegaClean(item.category) || undefined}>
+            {item.image?.asset && (
+              <a
+                href={urlFor(item.image).width(1600).url()}
+                data-pswp-width={item.fullWidth}
+                data-pswp-height={item.fullHeight}
+                target="_blank"
+                class="block transition-transform duration-200 hover:scale-[1.02] hover:shadow-lg cursor-zoom-in"
+              >
+                <img
+                  src={urlFor(item.image).width(1200).height(800).fit('crop').url()}
+                  srcset={`${urlFor(item.image).width(400).height(267).fit('crop').url()} 400w, ${urlFor(item.image).width(600).height(400).fit('crop').url()} 600w, ${urlFor(item.image).width(800).height(533).fit('crop').url()} 800w`}
+                  sizes="(max-width: 640px) 100vw, 50vw"
+                  alt={item.image.alt || ''}
+                  width={1200}
+                  height={800}
+                  class="aspect-[3/2] w-full object-cover"
+                  loading="lazy"
+                  style={lqipStyle(item.image.asset.metadata?.lqip)}
+                />
+              </a>
+            )}
+            {item.caption && <figcaption class="mt-2 text-sm text-muted-foreground">{item.caption}</figcaption>}
+          </figure>
+        ))}
+        {regularItems.map((item) => (
           <figure data-year={item.year ? String(item.year) : undefined} data-category={stegaClean(item.category) || undefined}>
             {item.image?.asset && (
               <a
@@ -213,6 +287,26 @@ const hasFilters = years.length > 0 || categories.length > 0;
         </SectionContent>
       )}
       <SectionContent>
+        {hasFilters && (
+          <div class="gallery-filters flex flex-wrap gap-2 mb-8" data-gallery-target={galleryId}>
+            {years.length > 0 && (
+              <div class="flex flex-wrap gap-2">
+                <button type="button" class="gallery-filter-pill active bg-primary text-primary-foreground px-4 py-1.5 rounded-full text-sm font-medium transition-colors" data-filter-type="year" data-filter-value="all">All Years</button>
+                {years.map(year => (
+                  <button type="button" class="gallery-filter-pill bg-muted text-muted-foreground px-4 py-1.5 rounded-full text-sm font-medium transition-colors hover:bg-muted/80" data-filter-type="year" data-filter-value={String(year)}>{year}</button>
+                ))}
+              </div>
+            )}
+            {categories.length > 0 && (
+              <div class="flex flex-wrap gap-2">
+                <button type="button" class="gallery-filter-pill active bg-primary text-primary-foreground px-4 py-1.5 rounded-full text-sm font-medium transition-colors" data-filter-type="category" data-filter-value="all">All Categories</button>
+                {categories.map(cat => (
+                  <button type="button" class="gallery-filter-pill bg-muted text-muted-foreground px-4 py-1.5 rounded-full text-sm font-medium transition-colors hover:bg-muted/80" data-filter-type="category" data-filter-value={cat}>{CATEGORY_LABELS[cat] || cat}</button>
+                ))}
+              </div>
+            )}
+          </div>
+        )}
         <div id={galleryId} class="pswp-gallery">
           <figure>
             {item.image?.asset && (
@@ -225,7 +319,7 @@ const hasFilters = years.length > 0 || categories.length > 0;
               >
                 <img
                   src={urlFor(item.image).width(1600).url()}
-                  srcset={`${urlFor(item.image).width(400).url()} 400w, ${urlFor(item.image).width(600).url()} 600w, ${urlFor(item.image).width(800).url()} 800w`}
+                  srcset={`${urlFor(item.image).width(400).url()} 400w, ${urlFor(item.image).width(600).url()} 600w, ${urlFor(item.image).width(800).url()} 800w, ${urlFor(item.image).width(1200).url()} 1200w, ${urlFor(item.image).width(1600).url()} 1600w`}
                   sizes="100vw"
                   alt={item.image.alt || ''}
                   width={item.image.asset.metadata?.dimensions?.width || 1600}
@@ -248,71 +342,99 @@ const hasFilters = years.length > 0 || categories.length > 0;
   import PhotoSwipeLightbox from 'photoswipe/lightbox';
   import 'photoswipe/style.css';
 
-  const lightbox = new PhotoSwipeLightbox({
-    gallery: '.pswp-gallery',
-    children: 'a',
-    pswpModule: () => import('photoswipe'),
-  });
+  let lightbox: InstanceType<typeof PhotoSwipeLightbox> | null = null;
 
-  // Caption overlay
-  lightbox.on('uiRegister', () => {
-    lightbox.pswp!.ui.registerElement({
-      name: 'caption',
-      order: 9,
-      isButton: false,
-      appendTo: 'root',
-      html: '',
-      onInit: (el) => {
-        el.style.cssText = 'position:absolute;bottom:0;left:0;right:0;padding:16px 24px;background:linear-gradient(transparent,rgba(0,0,0,.6));color:#fff;font-size:14px;text-align:center;pointer-events:none;';
-        lightbox.pswp!.on('change', () => {
-          const slide = lightbox.pswp!.currSlide?.data.element;
-          const caption = slide?.closest('figure')?.querySelector('figcaption')?.textContent || '';
-          el.textContent = caption;
-          el.style.display = caption ? '' : 'none';
-        });
-      },
+  function initLightbox() {
+    if (lightbox) {
+      lightbox.destroy();
+      lightbox = null;
+    }
+
+    lightbox = new PhotoSwipeLightbox({
+      gallery: '.pswp-gallery',
+      children: 'a:not([hidden])',
+      pswpModule: () => import('photoswipe'),
     });
 
-    // Share button
-    lightbox.pswp!.ui.registerElement({
-      name: 'share-button',
-      order: 8,
-      isButton: true,
-      tagName: 'button',
-      html: '<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 12v8a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-8"/><polyline points="16 6 12 2 8 6"/><line x1="12" y1="2" x2="12" y2="15"/></svg>',
-      onClick: (_event, el) => {
-        navigator.clipboard.writeText(window.location.href).then(() => {
+    // Caption overlay
+    lightbox.on('uiRegister', () => {
+      lightbox!.pswp!.ui.registerElement({
+        name: 'caption',
+        order: 9,
+        isButton: false,
+        appendTo: 'root',
+        html: '',
+        onInit: (el) => {
+          el.style.cssText = 'position:absolute;bottom:0;left:0;right:0;padding:16px 24px;background:linear-gradient(transparent,rgba(0,0,0,.6));color:#fff;font-size:14px;text-align:center;pointer-events:none;';
+          lightbox!.pswp!.on('change', () => {
+            const slide = lightbox!.pswp!.currSlide?.data.element;
+            const caption = slide?.closest('figure')?.querySelector('figcaption')?.textContent || '';
+            el.textContent = caption;
+            el.style.display = caption ? '' : 'none';
+          });
+        },
+      });
+
+      // Share button
+      lightbox!.pswp!.ui.registerElement({
+        name: 'share-button',
+        order: 8,
+        isButton: true,
+        tagName: 'button',
+        html: '<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 12v8a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-8"/><polyline points="16 6 12 2 8 6"/><line x1="12" y1="2" x2="12" y2="15"/></svg>',
+        onClick: (_event, el) => {
+          if (!navigator.clipboard) {
+            el.innerHTML = '<span style="font-size:12px;color:#fff;">Copy failed</span>';
+            setTimeout(() => { el.innerHTML = '<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 12v8a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-8"/><polyline points="16 6 12 2 8 6"/><line x1="12" y1="2" x2="12" y2="15"/></svg>'; }, 2000);
+            return;
+          }
           const originalHtml = el.innerHTML;
-          el.innerHTML = '<span style="font-size:12px;color:#fff;">Copied!</span>';
-          setTimeout(() => { el.innerHTML = originalHtml; }, 2000);
-        });
-      },
+          navigator.clipboard.writeText(window.location.href).then(() => {
+            el.innerHTML = '<span style="font-size:12px;color:#fff;">Copied!</span>';
+            setTimeout(() => { el.innerHTML = originalHtml; }, 2000);
+          }).catch(() => {
+            el.innerHTML = '<span style="font-size:12px;color:#fff;">Copy failed</span>';
+            setTimeout(() => { el.innerHTML = originalHtml; }, 2000);
+          });
+        },
+      });
     });
-  });
 
-  // Deep linking: update URL on slide change
-  lightbox.on('change', () => {
-    const index = lightbox.pswp!.currIndex;
-    const url = new URL(window.location.href);
-    url.searchParams.set('img', String(index + 1));
-    history.replaceState(null, '', url.toString());
-  });
+    // Set ?img= on first open (before any change event fires)
+    lightbox.on('afterInit', () => {
+      const index = lightbox!.pswp!.currIndex;
+      const url = new URL(window.location.href);
+      url.searchParams.set('img', String(index + 1));
+      history.replaceState(null, '', url.toString());
+    });
 
-  // Clear ?img= param when lightbox closes
-  lightbox.on('close', () => {
-    const url = new URL(window.location.href);
-    url.searchParams.delete('img');
-    history.replaceState(null, '', url.toString());
-  });
+    // Deep linking: update URL on slide change
+    lightbox.on('change', () => {
+      const index = lightbox!.pswp!.currIndex;
+      const url = new URL(window.location.href);
+      url.searchParams.set('img', String(index + 1));
+      history.replaceState(null, '', url.toString());
+    });
 
-  lightbox.init();
+    // Clear ?img= param when lightbox closes
+    lightbox.on('close', () => {
+      const url = new URL(window.location.href);
+      url.searchParams.delete('img');
+      history.replaceState(null, '', url.toString());
+    });
 
-  // Deep linking: open to ?img=N on page load
+    lightbox.init();
+  }
+
+  initLightbox();
+
+  // Deep linking: open to ?img=N on page load (with bounds check)
   const params = new URLSearchParams(window.location.search);
   const imgParam = params.get('img');
-  if (imgParam) {
+  if (imgParam && lightbox) {
     const imgIndex = parseInt(imgParam, 10) - 1;
-    if (imgIndex >= 0) {
+    const totalItems = document.querySelectorAll('.pswp-gallery a').length;
+    if (imgIndex >= 0 && imgIndex < totalItems) {
       lightbox.loadAndOpen(imgIndex);
     }
   }
@@ -323,24 +445,28 @@ const hasFilters = years.length > 0 || categories.length > 0;
     if (!targetId) return;
 
     const gallery = document.getElementById(targetId);
-    const featuredContainer = gallery?.previousElementSibling?.classList.contains('gallery-featured')
-      ? gallery.previousElementSibling
-      : null;
+    if (!gallery) return;
 
     let activeYear = 'all';
     let activeCategory = 'all';
 
     function applyFilters() {
-      const containers = [gallery, featuredContainer].filter(Boolean) as Element[];
-      containers.forEach(container => {
-        container.querySelectorAll('figure').forEach(fig => {
-          const figYear = fig.getAttribute('data-year') || '';
-          const figCategory = fig.getAttribute('data-category') || '';
-          const yearMatch = activeYear === 'all' || figYear === activeYear;
-          const categoryMatch = activeCategory === 'all' || figCategory === activeCategory;
-          (fig as HTMLElement).style.display = (yearMatch && categoryMatch) ? '' : 'none';
-        });
+      gallery!.querySelectorAll('figure').forEach(fig => {
+        const figYear = fig.getAttribute('data-year') || '';
+        const figCategory = fig.getAttribute('data-category') || '';
+        const yearMatch = activeYear === 'all' || figYear === activeYear;
+        const categoryMatch = activeCategory === 'all' || figCategory === activeCategory;
+        const visible = yearMatch && categoryMatch;
+        (fig as HTMLElement).style.display = visible ? '' : 'none';
+        // Hide/show anchor for PhotoSwipe filtering
+        const anchor = fig.querySelector('a');
+        if (anchor) {
+          anchor.toggleAttribute('hidden', !visible);
+        }
       });
+
+      // Reinitialize PhotoSwipe to update its item list after filtering
+      initLightbox();
     }
 
     filterBar.querySelectorAll('.gallery-filter-pill').forEach(pill => {

--- a/astro-app/src/components/blocks/custom/ImageGallery.astro
+++ b/astro-app/src/components/blocks/custom/ImageGallery.astro
@@ -5,6 +5,7 @@ import { urlFor, safeUrlFor, lqipStyle } from '@/lib/image';
 import { getSiteSettings } from '@/lib/sanity';
 import { Section, SectionContent, SectionMasonry } from '@/components/ui/section';
 import { JsonLd } from '@/components/ui/json-ld';
+import GalleryFilterBar from './_partials/GalleryFilterBar.astro';
 
 interface Props extends ImageGalleryBlock {
   class?: string;
@@ -16,6 +17,7 @@ interface Props extends ImageGalleryBlock {
 const { heading, description, images, variant: rawVariant, _key: blockKey, bare = false } = Astro.props;
 const variant = stegaClean(rawVariant) ?? 'grid';
 
+/** @sync studio/src/schemaTypes/objects/gallery-image.ts — GALLERY_CATEGORY_OPTIONS is the source of truth */
 const CATEGORY_LABELS: Record<string, string> = {
   'web-apps': 'Web Apps',
   'mobile': 'Mobile',
@@ -98,29 +100,7 @@ const hasFilters = years.length > 0 || categories.length > 0;
       </SectionContent>
     )}
     <SectionContent>
-      {/* Filter bar — Swiss geometric style */}
-      {hasFilters && (
-        <div class="gallery-filters space-y-3 mb-8 border-b border-border pb-6" data-gallery-target={galleryId}>
-          {years.length > 0 && (
-            <div class="flex flex-wrap items-center gap-2">
-              <span class="label-caps text-muted-foreground mr-1">Year</span>
-              <button type="button" class="gallery-filter-pill label-caps border border-border px-3 py-1 transition-colors data-[state=active]:bg-primary data-[state=active]:text-primary-foreground data-[state=active]:border-primary hover:bg-muted hover:border-foreground" data-state="active" aria-pressed="true" data-filter-type="year" data-filter-value="all">All</button>
-              {years.map(year => (
-                <button type="button" class="gallery-filter-pill label-caps border border-border px-3 py-1 transition-colors data-[state=active]:bg-primary data-[state=active]:text-primary-foreground data-[state=active]:border-primary hover:bg-muted hover:border-foreground" aria-pressed="false" data-filter-type="year" data-filter-value={String(year)}>{year}</button>
-              ))}
-            </div>
-          )}
-          {categories.length > 0 && (
-            <div class="flex flex-wrap items-center gap-2">
-              <span class="label-caps text-muted-foreground mr-1">Category</span>
-              <button type="button" class="gallery-filter-pill label-caps border border-border px-3 py-1 transition-colors data-[state=active]:bg-primary data-[state=active]:text-primary-foreground data-[state=active]:border-primary hover:bg-muted hover:border-foreground" data-state="active" aria-pressed="true" data-filter-type="category" data-filter-value="all">All</button>
-              {categories.map(cat => (
-                <button type="button" class="gallery-filter-pill label-caps border border-border px-3 py-1 transition-colors data-[state=active]:bg-primary data-[state=active]:text-primary-foreground data-[state=active]:border-primary hover:bg-muted hover:border-foreground" aria-pressed="false" data-filter-type="category" data-filter-value={cat}>{CATEGORY_LABELS[cat] || cat}</button>
-              ))}
-            </div>
-          )}
-        </div>
-      )}
+      {hasFilters && <GalleryFilterBar galleryId={galleryId} years={years} categories={categories} categoryLabels={CATEGORY_LABELS} class="mb-8" />}
 
       {/* Gallery container — featured + regular inside one pswp-gallery */}
       <div id={galleryId} class="pswp-gallery">
@@ -199,29 +179,7 @@ const hasFilters = years.length > 0 || categories.length > 0;
       </div>
     )}
 
-    {/* Filter bar — Swiss geometric style */}
-    {hasFilters && (
-      <div class="gallery-filters space-y-3 border-b border-border pb-6" data-gallery-target={galleryId}>
-        {years.length > 0 && (
-          <div class="flex flex-wrap items-center gap-2">
-            <span class="label-caps text-muted-foreground mr-1">Year</span>
-            <button type="button" class="gallery-filter-pill label-caps border border-border px-3 py-1 transition-colors data-[state=active]:bg-primary data-[state=active]:text-primary-foreground data-[state=active]:border-primary hover:bg-muted hover:border-foreground" data-state="active" aria-pressed="true" data-filter-type="year" data-filter-value="all">All</button>
-            {years.map(year => (
-              <button type="button" class="gallery-filter-pill label-caps border border-border px-3 py-1 transition-colors data-[state=active]:bg-primary data-[state=active]:text-primary-foreground data-[state=active]:border-primary hover:bg-muted hover:border-foreground" aria-pressed="false" data-filter-type="year" data-filter-value={String(year)}>{year}</button>
-            ))}
-          </div>
-        )}
-        {categories.length > 0 && (
-          <div class="flex flex-wrap items-center gap-2">
-            <span class="label-caps text-muted-foreground mr-1">Category</span>
-            <button type="button" class="gallery-filter-pill label-caps border border-border px-3 py-1 transition-colors data-[state=active]:bg-primary data-[state=active]:text-primary-foreground data-[state=active]:border-primary hover:bg-muted hover:border-foreground" data-state="active" aria-pressed="true" data-filter-type="category" data-filter-value="all">All</button>
-            {categories.map(cat => (
-              <button type="button" class="gallery-filter-pill label-caps border border-border px-3 py-1 transition-colors data-[state=active]:bg-primary data-[state=active]:text-primary-foreground data-[state=active]:border-primary hover:bg-muted hover:border-foreground" aria-pressed="false" data-filter-type="category" data-filter-value={cat}>{CATEGORY_LABELS[cat] || cat}</button>
-            ))}
-          </div>
-        )}
-      </div>
-    )}
+    {hasFilters && <GalleryFilterBar galleryId={galleryId} years={years} categories={categories} categoryLabels={CATEGORY_LABELS} />}
 
     {/* Gallery container */}
     <div id={galleryId} class="pswp-gallery">
@@ -265,26 +223,7 @@ const hasFilters = years.length > 0 || categories.length > 0;
     )}
     {hasFilters && (
       <SectionContent>
-        <div class="gallery-filters space-y-3 mb-8 border-b border-border pb-6" data-gallery-target={galleryId}>
-          {years.length > 0 && (
-            <div class="flex flex-wrap items-center gap-2">
-              <span class="label-caps text-muted-foreground mr-1">Year</span>
-              <button type="button" class="gallery-filter-pill label-caps border border-border px-3 py-1 transition-colors data-[state=active]:bg-primary data-[state=active]:text-primary-foreground data-[state=active]:border-primary hover:bg-muted hover:border-foreground" data-state="active" aria-pressed="true" data-filter-type="year" data-filter-value="all">All</button>
-              {years.map(year => (
-                <button type="button" class="gallery-filter-pill label-caps border border-border px-3 py-1 transition-colors data-[state=active]:bg-primary data-[state=active]:text-primary-foreground data-[state=active]:border-primary hover:bg-muted hover:border-foreground" aria-pressed="false" data-filter-type="year" data-filter-value={String(year)}>{year}</button>
-              ))}
-            </div>
-          )}
-          {categories.length > 0 && (
-            <div class="flex flex-wrap items-center gap-2">
-              <span class="label-caps text-muted-foreground mr-1">Category</span>
-              <button type="button" class="gallery-filter-pill label-caps border border-border px-3 py-1 transition-colors data-[state=active]:bg-primary data-[state=active]:text-primary-foreground data-[state=active]:border-primary hover:bg-muted hover:border-foreground" data-state="active" aria-pressed="true" data-filter-type="category" data-filter-value="all">All</button>
-              {categories.map(cat => (
-                <button type="button" class="gallery-filter-pill label-caps border border-border px-3 py-1 transition-colors data-[state=active]:bg-primary data-[state=active]:text-primary-foreground data-[state=active]:border-primary hover:bg-muted hover:border-foreground" aria-pressed="false" data-filter-type="category" data-filter-value={cat}>{CATEGORY_LABELS[cat] || cat}</button>
-              ))}
-            </div>
-          )}
-        </div>
+        <GalleryFilterBar galleryId={galleryId} years={years} categories={categories} categoryLabels={CATEGORY_LABELS} class="mb-8" />
       </SectionContent>
     )}
     <SectionMasonry>
@@ -358,28 +297,7 @@ const hasFilters = years.length > 0 || categories.length > 0;
         </SectionContent>
       )}
       <SectionContent>
-        {hasFilters && (
-          <div class="gallery-filters space-y-3 mb-8 border-b border-border pb-6" data-gallery-target={galleryId}>
-            {years.length > 0 && (
-              <div class="flex flex-wrap items-center gap-2">
-                <span class="label-caps text-muted-foreground mr-1">Year</span>
-                <button type="button" class="gallery-filter-pill label-caps border border-border px-3 py-1 transition-colors data-[state=active]:bg-primary data-[state=active]:text-primary-foreground data-[state=active]:border-primary hover:bg-muted hover:border-foreground" data-state="active" aria-pressed="true" data-filter-type="year" data-filter-value="all">All</button>
-                {years.map(year => (
-                  <button type="button" class="gallery-filter-pill label-caps border border-border px-3 py-1 transition-colors data-[state=active]:bg-primary data-[state=active]:text-primary-foreground data-[state=active]:border-primary hover:bg-muted hover:border-foreground" aria-pressed="false" data-filter-type="year" data-filter-value={String(year)}>{year}</button>
-                ))}
-              </div>
-            )}
-            {categories.length > 0 && (
-              <div class="flex flex-wrap items-center gap-2">
-                <span class="label-caps text-muted-foreground mr-1">Category</span>
-                <button type="button" class="gallery-filter-pill label-caps border border-border px-3 py-1 transition-colors data-[state=active]:bg-primary data-[state=active]:text-primary-foreground data-[state=active]:border-primary hover:bg-muted hover:border-foreground" data-state="active" aria-pressed="true" data-filter-type="category" data-filter-value="all">All</button>
-                {categories.map(cat => (
-                  <button type="button" class="gallery-filter-pill label-caps border border-border px-3 py-1 transition-colors data-[state=active]:bg-primary data-[state=active]:text-primary-foreground data-[state=active]:border-primary hover:bg-muted hover:border-foreground" aria-pressed="false" data-filter-type="category" data-filter-value={cat}>{CATEGORY_LABELS[cat] || cat}</button>
-                ))}
-              </div>
-            )}
-          </div>
-        )}
+        {hasFilters && <GalleryFilterBar galleryId={galleryId} years={years} categories={categories} categoryLabels={CATEGORY_LABELS} class="mb-8" />}
         <div id={galleryId} class="pswp-gallery">
           <figure>
             {item.image?.asset && (

--- a/astro-app/src/components/blocks/custom/_partials/GalleryFilterBar.astro
+++ b/astro-app/src/components/blocks/custom/_partials/GalleryFilterBar.astro
@@ -1,0 +1,33 @@
+---
+interface Props {
+  galleryId: string;
+  years: number[];
+  categories: string[];
+  categoryLabels: Record<string, string>;
+  class?: string;
+}
+
+const { galleryId, years, categories, categoryLabels, class: className } = Astro.props;
+const pillClass = 'gallery-filter-pill label-caps border border-border px-3 py-1 transition-colors data-[state=active]:bg-primary data-[state=active]:text-primary-foreground data-[state=active]:border-primary hover:bg-muted hover:border-foreground';
+---
+
+<div class:list={['gallery-filters space-y-3 border-b border-border pb-6', className]} data-gallery-target={galleryId}>
+  {years.length > 0 && (
+    <div class="flex flex-wrap items-center gap-2">
+      <span class="label-caps text-muted-foreground mr-1">Year</span>
+      <button type="button" class={pillClass} data-state="active" aria-pressed="true" data-filter-type="year" data-filter-value="all">All</button>
+      {years.map(year => (
+        <button type="button" class={pillClass} aria-pressed="false" data-filter-type="year" data-filter-value={String(year)}>{year}</button>
+      ))}
+    </div>
+  )}
+  {categories.length > 0 && (
+    <div class="flex flex-wrap items-center gap-2">
+      <span class="label-caps text-muted-foreground mr-1">Category</span>
+      <button type="button" class={pillClass} data-state="active" aria-pressed="true" data-filter-type="category" data-filter-value="all">All</button>
+      {categories.map(cat => (
+        <button type="button" class={pillClass} aria-pressed="false" data-filter-type="category" data-filter-value={cat}>{categoryLabels[cat] || cat}</button>
+      ))}
+    </div>
+  )}
+</div>

--- a/astro-app/src/pages/[...slug].astro
+++ b/astro-app/src/pages/[...slug].astro
@@ -14,7 +14,9 @@ const visualEditingEnabled = import.meta.env.PUBLIC_SANITY_VISUAL_EDITING_ENABLE
 // getStaticPaths generates static routes for all published pages at build time
 export const getStaticPaths: GetStaticPaths = async () => {
   const pages = await sanityClient.fetch<ALL_PAGE_SLUGS_QUERY_RESULT>(ALL_PAGE_SLUGS_QUERY, getSiteParams());
-  const validPages = pages.filter((p): p is { slug: string } => typeof p.slug === 'string' && p.slug.length > 0);
+  // Exclude slugs that have dedicated page routes (e.g., /gallery/index.astro)
+  const DEDICATED_ROUTES = new Set(['gallery']);
+  const validPages = pages.filter((p): p is { slug: string } => typeof p.slug === 'string' && p.slug.length > 0 && !DEDICATED_ROUTES.has(p.slug));
   // Pre-fetch all pages in parallel batches to populate the cache
   await prefetchPages(validPages.map(p => p.slug));
   return validPages.map((page) => ({

--- a/astro-app/src/pages/gallery/index.astro
+++ b/astro-app/src/pages/gallery/index.astro
@@ -1,0 +1,45 @@
+---
+import Layout from '@/layouts/Layout.astro';
+import Breadcrumb from '@/components/Breadcrumb.astro';
+import ImageGallery from '@/components/blocks/custom/ImageGallery.astro';
+import BlockRenderer from '@/components/BlockRenderer.astro';
+import { Section, SectionContent } from '@/components/ui/section';
+import { getPage, getListingPage } from '@/lib/sanity';
+import type { ImageGalleryBlock } from '@/lib/types';
+
+const [page, listingPage] = await Promise.all([
+  getPage('gallery'),
+  getListingPage('gallery'),
+]);
+
+if (!page) {
+  return Astro.redirect('/404');
+}
+
+const pageTitle = listingPage?.title ?? page.title ?? 'Gallery';
+const pageDescription = listingPage?.description ?? null;
+const pageSeo = listingPage?.seo ?? page.seo ?? { metaDescription: 'Browse photos from the YWCC Industry Capstone program.' };
+
+const galleryBlock = (page.blocks ?? []).find(b => b._type === 'imageGallery') as ImageGalleryBlock | undefined;
+---
+
+<Layout title={pageTitle} seo={pageSeo}>
+  {listingPage?.headerBlocks && listingPage.headerBlocks.length > 0 && (
+    <BlockRenderer blocks={listingPage.headerBlocks} />
+  )}
+
+  <Section>
+    <SectionContent>
+      <Breadcrumb baseUrl={Astro.url.origin} items={[
+        { label: 'Home', href: '/' },
+        { label: pageTitle },
+      ]} />
+
+      {galleryBlock && <ImageGallery {...galleryBlock} bare />}
+    </SectionContent>
+  </Section>
+
+  {listingPage?.footerBlocks && listingPage.footerBlocks.length > 0 && (
+    <BlockRenderer blocks={listingPage.footerBlocks} />
+  )}
+</Layout>

--- a/studio/sanity.config.ts
+++ b/studio/sanity.config.ts
@@ -136,6 +136,7 @@ export default defineConfig([
           {id: 'listingPage-articles', schemaType: 'listingPage', title: 'Listing Page (Articles)', value: {route: 'articles'}},
           {id: 'listingPage-authors', schemaType: 'listingPage', title: 'Listing Page (Authors)', value: {route: 'authors'}},
           {id: 'listingPage-events', schemaType: 'listingPage', title: 'Listing Page (Events)', value: {route: 'events'}},
+          {id: 'listingPage-gallery', schemaType: 'listingPage', title: 'Listing Page (Gallery)', value: {route: 'gallery'}},
           {id: 'listingPage-projects', schemaType: 'listingPage', title: 'Listing Page (Projects)', value: {route: 'projects'}},
           {id: 'listingPage-sponsors', schemaType: 'listingPage', title: 'Listing Page (Sponsors)', value: {route: 'sponsors'}},
         ]

--- a/studio/sanity.config.ts
+++ b/studio/sanity.config.ts
@@ -65,7 +65,7 @@ function createRwcWorkspace(opts: RwcWorkspaceOptions): WorkspaceOptions {
           value: {site: opts.siteId},
         }))
         // Listing page singletons — pre-populate route for each (Story 21.0)
-        const listingTemplates = ['articles', 'authors', 'events', 'projects', 'sponsors'].map((route) => ({
+        const listingTemplates = ['articles', 'authors', 'events', 'gallery', 'projects', 'sponsors'].map((route) => ({
           id: `listingPage-${route}-${opts.siteId}`,
           title: `Listing Page (${route.charAt(0).toUpperCase() + route.slice(1)}) — ${opts.title}`,
           schemaType: 'listingPage',

--- a/studio/src/schemaTypes/documents/listing-page.ts
+++ b/studio/src/schemaTypes/documents/listing-page.ts
@@ -28,6 +28,7 @@ export const listingPage = defineType({
           {title: 'Articles', value: 'articles'},
           {title: 'Authors', value: 'authors'},
           {title: 'Events', value: 'events'},
+          {title: 'Gallery', value: 'gallery'},
           {title: 'Projects', value: 'projects'},
           {title: 'Sponsors', value: 'sponsors'},
         ],

--- a/studio/src/schemaTypes/documents/site-settings.ts
+++ b/studio/src/schemaTypes/documents/site-settings.ts
@@ -89,7 +89,7 @@ export const siteSettings = defineType({
               name: 'children',
               title: 'Sub-items',
               type: 'array',
-              description: 'Dropdown sub-navigation items (not yet rendered in header — planned for future story)',
+              description: 'Dropdown sub-navigation items shown under this parent in the header nav bar',
               of: [
                 defineArrayMember({
                   type: 'object',

--- a/studio/src/schemaTypes/objects/gallery-image.ts
+++ b/studio/src/schemaTypes/objects/gallery-image.ts
@@ -1,5 +1,15 @@
 import {defineType, defineField} from 'sanity'
 
+/** Canonical category options — frontend CATEGORY_LABELS in ImageGallery.astro must stay in sync */
+export const GALLERY_CATEGORY_OPTIONS = [
+  {title: 'Web Apps', value: 'web-apps'},
+  {title: 'Mobile', value: 'mobile'},
+  {title: 'AI/ML', value: 'ai-ml'},
+  {title: 'Data Viz', value: 'data-viz'},
+  {title: 'IoT', value: 'iot'},
+  {title: 'Other', value: 'other'},
+] as const
+
 export const galleryImage = defineType({
   name: 'galleryImage',
   title: 'Gallery Image',
@@ -46,14 +56,7 @@ export const galleryImage = defineType({
       title: 'Category',
       type: 'string',
       options: {
-        list: [
-          {title: 'Web Apps', value: 'web-apps'},
-          {title: 'Mobile', value: 'mobile'},
-          {title: 'AI/ML', value: 'ai-ml'},
-          {title: 'Data Viz', value: 'data-viz'},
-          {title: 'IoT', value: 'iot'},
-          {title: 'Other', value: 'other'},
-        ],
+        list: [...GALLERY_CATEGORY_OPTIONS],
         layout: 'dropdown',
       },
     }),

--- a/studio/src/structure/capstone-desk-structure.ts
+++ b/studio/src/structure/capstone-desk-structure.ts
@@ -39,6 +39,14 @@ export const capstoneDeskStructure = (S: StructureBuilder) =>
                     .initialValueTemplate('listingPage-events'),
                 ),
               S.listItem()
+                .title('Gallery')
+                .child(
+                  S.document()
+                    .schemaType('listingPage')
+                    .documentId('listingPage-gallery')
+                    .initialValueTemplate('listingPage-gallery'),
+                ),
+              S.listItem()
                 .title('Projects')
                 .child(
                   S.document()

--- a/tests/integration/listing-page-21-0/listing-page-schema.test.ts
+++ b/tests/integration/listing-page-21-0/listing-page-schema.test.ts
@@ -58,9 +58,9 @@ describe('Story 21.0: Listing Page Schema', () => {
       expect(getValidationChain(routeField)).toContain('required')
     })
 
-    test('has 5 route options', () => {
+    test('has 6 route options', () => {
       const values = routeField.options.list.map((o: any) => o.value)
-      expect(values).toEqual(['articles', 'authors', 'events', 'projects', 'sponsors'])
+      expect(values).toEqual(['articles', 'authors', 'events', 'gallery', 'projects', 'sponsors'])
     })
 
     test('is readOnly', () => {


### PR DESCRIPTION
## Summary

This PR fixes **9 bugs and improvements** found during a code review of the Image Gallery component (Story 22.4). The review used three independent reviewers checking the code from different angles — one looking only at the code changes, one hunting for edge cases, and one checking against the original requirements.

### What was wrong and what this fixes

#### Bug Fixes (things that were broken)

- **Featured images didn't open in the lightbox** — When you clicked a "featured" (larger) image at the top of the gallery, instead of opening the nice fullscreen viewer (PhotoSwipe), it opened the raw image file in a new browser tab. This happened because the featured images were placed *outside* the lightbox container in the HTML. Now they're inside it, so all images open in the lightbox as expected.

- **Filters broke the lightbox navigation** — If you filtered the gallery (e.g., "show only 2026 projects"), the lightbox still knew about *all* the images, including hidden ones. So you could swipe through invisible images, and the "3 of 12" counter was wrong. Now the lightbox reinitializes after every filter change so it only knows about visible images.

- **Share button silently failed on some browsers** — The "copy link" button in the lightbox used the clipboard API without checking if it was available or handling errors. On HTTP (non-HTTPS) pages or older browsers, clicking the button did nothing — no error message, no feedback. Now it shows "Copy failed" if something goes wrong.

- **Deep links with bad numbers could crash** — Opening a gallery with `?img=999` on a gallery with only 5 images could cause errors. Now it checks the number is within range before trying to open.

- **Share button didn't work on the first image** — If you opened the lightbox and immediately clicked share (without navigating), the copied URL was missing the `?img=1` parameter. Now the URL is set as soon as the lightbox opens, not just when you navigate between images.

#### Quality Improvements

- **Single-image layout loaded blurry on big screens** — The single-image variant had `srcset` widths only up to 800px, but displayed at 1600px. Browsers picked the 800px version, making it look blurry on desktops. Added 1200px and 1600px variants so the browser can pick the right size.

- **Invalid structured data (JSON-LD) for broken images** — If a Sanity image reference was malformed, the JSON-LD (search engine metadata) would contain `undefined` URLs, which is invalid. Now those entries are filtered out.

- **Missing "creator" in JSON-LD** — The spec required an Organization creator field in the gallery's structured data. Added a `getSiteSettings()` call (already cached by other components, so no extra API cost) to populate it.

- **Masonry and single variants had no filters or featured row** — The year/category filter pills and the featured hero row only worked in the grid layout. Now they work in all three layout variants (grid, masonry, single).

#### Test Updates

- Added `getSiteSettings` mock to `ImageGallery.test.ts` and `json-ld-blocks.test.ts` (the component now imports it)
- Added 5 new test cases: JSON-LD creator field, featured-inside-gallery structure, masonry filter pills, single srcset widths
- **Note:** All Astro component tests have a pre-existing parse failure from the Vite 7→6 downgrade in a prior commit. The Astro production build succeeds.

## Test plan

- [ ] `npm run build -w astro-app` completes without errors
- [ ] Open a page with an ImageGallery block in the browser
- [ ] Click a **featured** (large) image — should open PhotoSwipe lightbox (not a new tab)
- [ ] Apply a year or category filter, then click a visible image — lightbox should only show filtered images
- [ ] Open lightbox, click share button — URL with `?img=N` should be copied to clipboard
- [ ] Open lightbox on first image, click share immediately — URL should contain `?img=1`
- [ ] Navigate to a page with `?img=2` — lightbox should auto-open to second image
- [ ] Navigate with `?img=999` — should not crash (nothing opens or opens last image)
- [ ] Check page source for `<script type="application/ld+json">` — ImageGallery should have `creator`, `width`, `height`, `thumbnailUrl` fields and no `undefined` values
- [ ] Test masonry variant with year/category data — filter pills should appear
- [ ] View single-image variant on a large monitor — image should be sharp (1600px, not 800px)