### PR TITLE
Fix Lighthouse accessibility issues and optimize images

### DIFF
--- a/astro-app/src/components/CookieConsent.astro
+++ b/astro-app/src/components/CookieConsent.astro
@@ -20,16 +20,16 @@ const { gtmId } = Astro.props;
       <p class="text-sm text-background/80 max-w-2xl">
         We use cookies to analyze site traffic and optimize your experience. By clicking "Accept," you consent to our use of analytics cookies.
       </p>
-      <div class="flex gap-3 shrink-0">
+      <div class="flex gap-4 shrink-0">
         <button
           data-cookie-reject
-          class="px-4 py-2 text-sm font-medium text-background/60 hover:text-background border border-background/20 hover:border-background/40 transition-colors"
+          class="px-5 py-2.5 min-h-[44px] text-sm font-medium text-background/60 hover:text-background border border-background/20 hover:border-background/40 transition-colors"
         >
           Reject
         </button>
         <button
           data-cookie-accept
-          class="px-4 py-2 text-sm font-medium bg-primary text-primary-foreground hover:bg-primary/90 transition-colors"
+          class="px-5 py-2.5 min-h-[44px] text-sm font-medium bg-primary text-primary-foreground hover:bg-primary/90 transition-colors"
         >
           Accept
         </button>

--- a/astro-app/src/components/Footer.astro
+++ b/astro-app/src/components/Footer.astro
@@ -83,7 +83,7 @@ const addressLine2 = addressLines.slice(2).join(', ');
     <!-- Programs Section -->
     <div class="lg:col-span-2">
       <FooterGroup>
-        <FooterGroupLabel class="text-background/40 uppercase text-xs tracking-widest font-bold mb-4">Programs</FooterGroupLabel>
+        <FooterGroupLabel class="text-background/60 uppercase text-xs tracking-widest font-bold mb-4">Programs</FooterGroupLabel>
         <FooterMenu>
           {(programLinks || []).map((item) => (
             <FooterMenuItem>
@@ -97,7 +97,7 @@ const addressLine2 = addressLines.slice(2).join(', ');
     <!-- Resources Section -->
     <div class="lg:col-span-2">
       <FooterGroup>
-        <FooterGroupLabel class="text-background/40 uppercase text-xs tracking-widest font-bold mb-4">Resources</FooterGroupLabel>
+        <FooterGroupLabel class="text-background/60 uppercase text-xs tracking-widest font-bold mb-4">Resources</FooterGroupLabel>
         <FooterMenu>
           {(resourceLinks || []).map((item) => (
             <FooterMenuItem>
@@ -117,7 +117,7 @@ const addressLine2 = addressLines.slice(2).join(', ');
     <!-- Contact Information -->
     <div class="lg:col-span-2">
       <FooterGroup>
-        <FooterGroupLabel class="text-background/40 uppercase text-xs tracking-widest font-bold mb-4">Contact</FooterGroupLabel>
+        <FooterGroupLabel class="text-background/60 uppercase text-xs tracking-widest font-bold mb-4">Contact</FooterGroupLabel>
         <FooterMenu>
           {addressLine1 && (
             <FooterMenuItem>
@@ -146,14 +146,14 @@ const addressLine2 = addressLines.slice(2).join(', ');
 
   <!-- Bottom Bar -->
   <FooterSpread class="border-t border-background/10 pt-8 mt-12">
-    <FooterCopyright class="text-background/40 text-sm">&copy; {footerContent?.copyrightText || `${new Date().getFullYear()} All rights reserved.`}</FooterCopyright>
+    <FooterCopyright class="text-background/60 text-sm">&copy; {footerContent?.copyrightText || `${new Date().getFullYear()} All rights reserved.`}</FooterCopyright>
     <FooterMenu orientation="horizontal" class="flex-wrap justify-center md:justify-end">
       {(footerLinks || []).map((item) => (
         <FooterMenuItem>
           <FooterMenuLink
             href={item.href}
             {...((item.href || '').startsWith('http') ? { target: '_blank', rel: 'noopener' } : {})}
-            class="text-background/40 hover:text-background text-xs transition-colors"
+            class="text-background/60 hover:text-background text-xs transition-colors"
             data-gtm-category="footer"
             data-gtm-label={stegaClean(item.label)}
           >{item.label}</FooterMenuLink>
@@ -164,7 +164,7 @@ const addressLine2 = addressLines.slice(2).join(', ');
           <button
             type="button"
             data-cookie-settings-trigger
-            class="text-background/40 hover:text-background text-xs transition-colors cursor-pointer"
+            class="text-background/60 hover:text-background text-xs transition-colors cursor-pointer"
             data-gtm-category="footer"
             data-gtm-label="cookie-settings"
           >Cookie Settings</button>

--- a/astro-app/src/components/Header.astro
+++ b/astro-app/src/components/Header.astro
@@ -71,14 +71,13 @@ const isActive = (href: string) =>
       {/* Search trigger — typographic, no input */}
       <button
         type="button"
-        class="hidden lg:inline-flex items-center gap-3 bg-transparent text-foreground/60 transition-colors hover:text-foreground cursor-pointer"
-        aria-label="Search site"
+        class="hidden lg:inline-flex items-center gap-3 bg-transparent text-foreground/70 transition-colors hover:text-foreground cursor-pointer"
         data-gtm-category="navigation"
         data-gtm-label="search"
       >
         <Icon name="search" class="h-4 w-4" />
         <span class="label-caps text-[10px]">Search</span>
-        <kbd class="border-2 border-foreground/20 px-1.5 pt-1 pb-0.5 text-[10px] font-mono text-foreground/40 leading-none">⌘K</kbd>
+        <kbd class="border-2 border-foreground/20 px-1.5 pt-1 pb-0.5 text-[10px] font-mono text-foreground/70 leading-none" aria-hidden="true">⌘K</kbd>
       </button>
 
       {/* CTA button — Swiss structural accent */}

--- a/astro-app/src/components/__tests__/HeroBanner.test.ts
+++ b/astro-app/src/components/__tests__/HeroBanner.test.ts
@@ -305,7 +305,7 @@ describe('HeroBanner', () => {
       expect(html).toContain('srcset="');
       expect(html).toContain('640w');
       expect(html).toContain('1024w');
-      expect(html).toContain('1440w');
+      expect(html).toContain('1280w');
       expect(html).toContain('1920w');
       expect(html).toContain('sizes="100vw"');
     });

--- a/astro-app/src/components/blocks/custom/HeroBanner.astro
+++ b/astro-app/src/components/blocks/custom/HeroBanner.astro
@@ -43,7 +43,7 @@ function buildSrcset(image: NonNullable<typeof firstImage>, baseWidth: number, b
             ? urlFor(image).width(1920).height(1080).fit('crop').url()
             : '';
           const isFirst = index === 0;
-          const srcset = image.asset ? buildSrcset(image, 1920, 1080, [640, 1024, 1440, 1920]) : undefined;
+          const srcset = image.asset ? buildSrcset(image, 1920, 1080, [640, 1024, 1280, 1920]) : undefined;
           return (
             <div
               class="hero-carousel-slide absolute inset-0 transition-opacity duration-1000"
@@ -123,7 +123,7 @@ function buildSrcset(image: NonNullable<typeof firstImage>, baseWidth: number, b
             ? urlFor(image).width(1920).height(1080).fit('crop').url()
             : '';
           const isFirst = index === 0;
-          const srcset = image.asset ? buildSrcset(image, 1920, 1080, [640, 1024, 1440, 1920]) : undefined;
+          const srcset = image.asset ? buildSrcset(image, 1920, 1080, [640, 1024, 1280, 1920]) : undefined;
           return (
             <div
               class="hero-carousel-slide absolute inset-0 transition-opacity duration-1000"
@@ -359,7 +359,7 @@ function buildSrcset(image: NonNullable<typeof firstImage>, baseWidth: number, b
       <div class="absolute inset-0">
         <img
           src={urlFor(firstImage).width(1920).height(1080).fit('crop').url()}
-          srcset={buildSrcset(firstImage, 1920, 1080, [640, 1024, 1440, 1920])}
+          srcset={buildSrcset(firstImage, 1920, 1080, [640, 1024, 1280, 1920])}
           sizes="100vw"
           alt={firstImage.alt || ''}
           width={1920}


### PR DESCRIPTION
## What This PR Does

This PR fixes **accessibility problems** that were found by running [Google Lighthouse](https://developer.chrome.com/docs/lighthouse/) on our live site. Lighthouse is a tool that checks websites for performance, accessibility, SEO, and best practices — it gives each category a score out of 100.

**Before this PR:**
- Accessibility: **92** / 100
- SEO: **92** / 100

**After this PR:**
- Accessibility: **100** / 100
- SEO: **100** / 100 (via Sanity CMS content update)

---

## What Was Wrong (and How We Fixed It)

### 1. Text was hard to read (color contrast)

**The problem:** Some text in the header and footer didn't have enough contrast against its background. This makes it hard for people with low vision to read. The [WCAG standard](https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum.html) requires a contrast ratio of at least **4.5:1** for normal-sized text.

**What we changed:**
- **Footer labels, links, and copyright** — Changed `text-background/40` (40% opacity white on dark background = 3.7:1 ratio) to `text-background/60` (60% opacity = 5.6:1 ratio). This means the text went from a faded gray to a more readable lighter gray.
- **Header search button** — Changed `text-foreground/60` to `text-foreground/70` so the "Search" label and `⌘K` keyboard shortcut are easier to read.

**Files:** `Footer.astro`, `Header.astro`

### 2. Buttons were too small to tap (touch targets)

**The problem:** The "Accept" and "Reject" buttons on the cookie consent banner were too close together and too small. On phones or tablets, users might accidentally tap the wrong button. WCAG requires touch targets to be at least **24×24 pixels** with enough spacing.

**What we changed:**
- Increased button padding (`px-4 py-2` → `px-5 py-2.5`)
- Added minimum height (`min-h-[44px]`) — 44px is the recommended mobile tap target size
- Increased gap between buttons (`gap-3` → `gap-4`)

**File:** `CookieConsent.astro`

### 3. Screen reader confusion (label mismatch)

**The problem:** The search button had `aria-label="Search site"` but its visible text was "Search ⌘K". When the spoken label doesn't match what's on screen, voice-control users can't activate the button by saying what they see.

**What we changed:**
- Removed the `aria-label` so the button's accessible name comes from its visible text ("Search")
- Added `aria-hidden="true"` to the `⌘K` shortcut hint so screen readers skip it (it's a visual hint for keyboard users, not meaningful for screen readers)

**File:** `Header.astro`

### 4. Hero images were larger than needed (performance)

**The problem:** The hero carousel images had a gap in their responsive `srcset` breakpoints. On a typical desktop (~1350px wide), the browser had to choose between a 1024px image (too small) and a 1440px image (too big, wasting ~45% of downloaded bytes).

**What we changed:**
- Replaced the 1440w breakpoint with 1280w in the srcset: `[640, 1024, 1440, 1920]` → `[640, 1024, 1280, 1920]`
- This gives the browser a better-fitting option for common desktop viewports

**Files:** `HeroBanner.astro`, `HeroBanner.test.ts`

### 5. Non-descriptive link text (SEO — Sanity CMS update)

**The problem:** Two CTA buttons on the homepage said "Learn More" — Lighthouse flags this because search engines and screen readers can't tell where the link goes without context.

**What we changed (in Sanity CMS, not in code):**
- "Learn More" → **"Explore Sponsorship"** (links to /sponsors/)
- "Learn More" → **"About the Program"** (links to /about/)

---

## How to Verify

1. Run Lighthouse on the homepage after deploying:
   ```
   CHROME_PATH=/usr/bin/chromium-browser npx lighthouse https://ywcc-capstone.pages.dev/ --preset=desktop
   ```
2. Check that Accessibility is 100 and no color-contrast, target-size, or label-content-name-mismatch failures appear.

## Test plan

- [x] All 1764 unit tests pass (`npm run test:unit`)
- [x] Local Lighthouse audit: Accessibility 100, all 3 failing audits resolved
- [x] Build succeeds (`npm run build -w astro-app`)
- [ ] Visual check: footer text is still readable and maintains design intent (slightly brighter, not jarring)
- [ ] Visual check: cookie consent buttons have comfortable spacing
- [ ] Verify Sanity CMS shows updated CTA text in Studio

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Increased cookie consent button size and spacing for enhanced usability.
  * Improved footer text visibility and contrast across all sections.
  * Refined header search button styling and keyboard shortcut display.

* **Chores**
  * Optimized responsive image breakpoints for hero banner to improve performance across different screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->