### PR TITLE
fix(tests): repair sponsor schema + logo URL assertions (unbreak CI)

### DIFF
--- a/astro-app/src/components/__tests__/ProjectCard.test.ts
+++ b/astro-app/src/components/__tests__/ProjectCard.test.ts
@@ -31,7 +31,7 @@ describe('ProjectCard', () => {
     });
 
     expect(html).toContain('Acme logo');
-    expect(html).toMatch(/src="[^"]*w=48[^"]*h=48/);
+    expect(html).toMatch(/src="[^"]*w=48[^"]*fit=max/);
   });
 
   test('renders technology tags as badges', async () => {

--- a/astro-app/src/components/__tests__/SponsorCards.test.ts
+++ b/astro-app/src/components/__tests__/SponsorCards.test.ts
@@ -43,8 +43,8 @@ describe('SponsorCards', () => {
     });
 
     expect(html).toContain('Acme logo');
-    // urlFor outputs CDN URL with w= and h= params
-    expect(html).toMatch(/src="[^"]*w=112[^"]*h=112/);
+    // urlFor uses single-dim sizing to preserve aspect ratio (w= + fit=max)
+    expect(html).toMatch(/src="[^"]*w=112[^"]*fit=max/);
   });
 
   test('renders initials fallback when no logo', async () => {

--- a/tests/integration/sponsor-3-1/sponsor-schema.test.ts
+++ b/tests/integration/sponsor-3-1/sponsor-schema.test.ts
@@ -26,11 +26,13 @@ describe('Story 3-1: Sponsor Document Schema (ATDD)', () => {
 
     test('[P0] 3.1-INT-002 — sponsor schema has all required fields', () => {
       const fieldNames = (sponsor as any).fields.map((f: any) => f.name)
-      expect(fieldNames).toHaveLength(13)
+      expect(fieldNames).toHaveLength(15)
       expect(fieldNames).toContain('name')
       expect(fieldNames).toContain('slug')
       expect(fieldNames).toContain('site')
       expect(fieldNames).toContain('logo')
+      expect(fieldNames).toContain('logoSquare')
+      expect(fieldNames).toContain('logoHorizontal')
       expect(fieldNames).toContain('description')
       expect(fieldNames).toContain('website')
       expect(fieldNames).toContain('contactEmail')


### PR DESCRIPTION
## What this fixes

Our CI pipeline has been **failing on every PR to preview** since the morning of 2026-04-14. This PR fixes the three failing tests so we can merge green again.

## What broke and why

Last week, **PR #641** (`fix/mobile-nav-sponsor-logos`) made two legitimate improvements:

1. **Added two new sponsor logo variants** to the Sanity schema so CMS admins can upload context-specific versions:
   - `logoSquare` — tiny version for listing card thumbnails
   - `logoHorizontal` — wide version for detail pages
2. **Fixed ugly logo cropping** across the site (Bank of America, Cisco, Verizon were getting chopped up). To do this, the image URL builder switched from forcing a square — `urlFor(logo).width(N).height(N)` — to preserving aspect ratio — `urlFor(logo).width(N).fit('max')`.

Both changes shipped and work correctly in production. The bug is that **the tests that check these files were never updated to match**, so they fail every time they run.

## Three tests, three tiny changes

| Test | Problem | Fix |
|---|---|---|
| `sponsor-schema.test.ts` — `3.1-INT-002` | Asserted schema has exactly 13 fields; now has 15 (logo variants added) | Bump expected count to 15 + assert the two new fields exist |
| `ProjectCard.test.ts` | Asserted logo URL contains `w=48` AND `h=48`; now only `w=48` + `fit=max` | Swap `h=48` pattern for `fit=max` |
| `SponsorCards.test.ts` | Same issue — expected `w=112` AND `h=112` | Swap for `w=112` + `fit=max` |

No production code changes. Only assertions.

## How this happened

PR #641 was merged at 06:24 UTC on 2026-04-14 through the chained feature branch. The tests got carried forward to preview via PR #644 without running — CI caught it but the PR was merged red anyway. This PR closes that loop.

## How to verify

Run the unit test suite locally:

```bash
npm run test:unit
```

Expected output:
```
Test Files  106 passed (106)
     Tests  1791 passed | 3 skipped (1794)
```

✅ Verified green locally on 2026-04-14 — 0 failures.

## Test plan

- [ ] CI `unit-tests` job passes (previously 3 failures in those 3 files)
- [ ] CI `lighthouse` job remains green
- [ ] No changes to Sanity schema, GROQ queries, or rendered output — this is a test-only change