### PR TITLE
fix(forms): switch to output:server so Astro Actions deploy on Cloudflare

### DIFF
--- a/astro-app/astro.config.mjs
+++ b/astro-app/astro.config.mjs
@@ -19,7 +19,7 @@ const studioUrl = `${studioUrlBase.replace(/\/$/, "")}${studioWorkspace}`;
 const visualEditingEnabled = env.PUBLIC_SANITY_VISUAL_EDITING_ENABLED || process.env.PUBLIC_SANITY_VISUAL_EDITING_ENABLED || "";
 
 export default defineConfig({
-  output: "static",
+  output: "server",
   site: siteUrl,
   env: {
     schema: {

--- a/astro-app/src/pages/[...slug].astro
+++ b/astro-app/src/pages/[...slug].astro
@@ -1,4 +1,5 @@
 ---
+export const prerender = true;
 import type { GetStaticPaths } from 'astro';
 import Layout from '@/layouts/Layout.astro';
 import BlockRenderer from '@/components/BlockRenderer.astro';

--- a/astro-app/src/pages/api/events/[slug].ics.ts
+++ b/astro-app/src/pages/api/events/[slug].ics.ts
@@ -3,6 +3,8 @@ import { getAllEvents, type SanityEvent } from '@/lib/sanity';
 import { generateIcsString } from '@/lib/ical';
 import { stegaClean } from '@sanity/client/stega';
 
+export const prerender = true;
+
 export const getStaticPaths: GetStaticPaths = async () => {
   const events = await getAllEvents();
   return events

--- a/astro-app/src/pages/articles/[slug].astro
+++ b/astro-app/src/pages/articles/[slug].astro
@@ -1,4 +1,5 @@
 ---
+export const prerender = true;
 import type { GetStaticPaths } from 'astro';
 import Layout from '@/layouts/Layout.astro';
 import Breadcrumb from '@/components/Breadcrumb.astro';

--- a/astro-app/src/pages/articles/category/[slug].astro
+++ b/astro-app/src/pages/articles/category/[slug].astro
@@ -1,4 +1,5 @@
 ---
+export const prerender = true;
 import type { GetStaticPaths } from 'astro';
 import Layout from '@/layouts/Layout.astro';
 import Breadcrumb from '@/components/Breadcrumb.astro';

--- a/astro-app/src/pages/articles/index.astro
+++ b/astro-app/src/pages/articles/index.astro
@@ -1,4 +1,5 @@
 ---
+export const prerender = true;
 import Layout from '@/layouts/Layout.astro';
 import Breadcrumb from '@/components/Breadcrumb.astro';
 import ArticleCard from '@/components/ArticleCard.astro';

--- a/astro-app/src/pages/authors/[slug].astro
+++ b/astro-app/src/pages/authors/[slug].astro
@@ -1,4 +1,5 @@
 ---
+export const prerender = true;
 import type { GetStaticPaths } from 'astro';
 import Layout from '@/layouts/Layout.astro';
 import Breadcrumb from '@/components/Breadcrumb.astro';

--- a/astro-app/src/pages/authors/index.astro
+++ b/astro-app/src/pages/authors/index.astro
@@ -1,4 +1,5 @@
 ---
+export const prerender = true;
 import Layout from '@/layouts/Layout.astro';
 import Breadcrumb from '@/components/Breadcrumb.astro';
 import AuthorCard from '@/components/AuthorCard.astro';

--- a/astro-app/src/pages/events/[slug].astro
+++ b/astro-app/src/pages/events/[slug].astro
@@ -1,4 +1,5 @@
 ---
+export const prerender = true;
 import type { GetStaticPaths } from 'astro';
 import Layout from '@/layouts/Layout.astro';
 import Breadcrumb from '@/components/Breadcrumb.astro';

--- a/astro-app/src/pages/events/index.astro
+++ b/astro-app/src/pages/events/index.astro
@@ -1,4 +1,5 @@
 ---
+export const prerender = true;
 import Layout from '@/layouts/Layout.astro';
 import Breadcrumb from '@/components/Breadcrumb.astro';
 import EventCard from '@/components/EventCard.astro';

--- a/astro-app/src/pages/gallery/index.astro
+++ b/astro-app/src/pages/gallery/index.astro
@@ -1,4 +1,5 @@
 ---
+export const prerender = true;
 import Layout from '@/layouts/Layout.astro';
 import Breadcrumb from '@/components/Breadcrumb.astro';
 import ImageGallery from '@/components/blocks/custom/ImageGallery.astro';

--- a/astro-app/src/pages/index.astro
+++ b/astro-app/src/pages/index.astro
@@ -1,4 +1,5 @@
 ---
+export const prerender = true;
 import Layout from '../layouts/Layout.astro';
 import BlockRenderer from '../components/BlockRenderer.astro';
 import SanityPageContent from '../components/SanityPageContent.astro';

--- a/astro-app/src/pages/projects/[slug].astro
+++ b/astro-app/src/pages/projects/[slug].astro
@@ -1,4 +1,5 @@
 ---
+export const prerender = true;
 import type { GetStaticPaths } from 'astro';
 import Layout from '@/layouts/Layout.astro';
 import Breadcrumb from '@/components/Breadcrumb.astro';

--- a/astro-app/src/pages/projects/index.astro
+++ b/astro-app/src/pages/projects/index.astro
@@ -1,4 +1,5 @@
 ---
+export const prerender = true;
 import SidebarLayout from '@/layouts/SidebarLayout.astro';
 import Breadcrumb from '@/components/Breadcrumb.astro';
 import BlockRenderer from '@/components/BlockRenderer.astro';

--- a/astro-app/src/pages/rss.xml.ts
+++ b/astro-app/src/pages/rss.xml.ts
@@ -3,6 +3,8 @@ import type { APIContext } from 'astro';
 import { stegaClean } from '@sanity/client/stega';
 import { getAllArticles, getSiteSettings } from '@/lib/sanity';
 
+export const prerender = true;
+
 const DEFAULT_TITLE = 'YWCC Industry Capstone';
 const DEFAULT_DESCRIPTION =
   'Latest articles, news, and updates from the YWCC Industry Capstone program.';

--- a/astro-app/src/pages/sponsors/[slug].astro
+++ b/astro-app/src/pages/sponsors/[slug].astro
@@ -1,4 +1,5 @@
 ---
+export const prerender = true;
 import type { GetStaticPaths } from 'astro';
 import Layout from '@/layouts/Layout.astro';
 import Breadcrumb from '@/components/Breadcrumb.astro';

--- a/astro-app/src/pages/sponsors/index.astro
+++ b/astro-app/src/pages/sponsors/index.astro
@@ -1,4 +1,5 @@
 ---
+export const prerender = true;
 import Layout from '@/layouts/Layout.astro';
 import Breadcrumb from '@/components/Breadcrumb.astro';
 import BlockRenderer from '@/components/BlockRenderer.astro';

--- a/tests/integration/deploy-5-2/cloudflare-deploy.test.ts
+++ b/tests/integration/deploy-5-2/cloudflare-deploy.test.ts
@@ -30,10 +30,12 @@ describe('Story 5-2: GA4, Security Headers & Cloudflare Deploy', () => {
       expect(configContent).toContain('enabled: true')
     })
 
-    test('[P0] 5.2-INT-004 — output defaults to static', () => {
-      // Output is conditionally set: isVisualEditing ? "server" : "static"
-      expect(configContent).toContain('"static"')
-      expect(configContent).toMatch(/output:/)
+    test('[P0] 5.2-INT-004 — output is server so Astro Actions deploy on the Worker', () => {
+      // Switched from "static" to "server" so /_actions/* mounts on the
+      // Cloudflare Worker. Marketing pages opt back into static via
+      // `export const prerender = true`.
+      expect(configContent).toContain('"server"')
+      expect(configContent).toMatch(/output:\s*"server"/)
     })
 
     test('[P0] 5.2-INT-005 — site property reads PUBLIC_SITE_URL env var', () => {


### PR DESCRIPTION
## Summary

The contact form was throwing **403 Forbidden** on `POST /_actions/submitForm/` in production. This PR fixes that and explains what changed in plain language.

## What was broken

Astro Actions (the thing that processes our forms — Turnstile check + writes the submission to Sanity + posts to Discord) need to run on a **server**. They are not static files.

Our config had `output: "static"`, which tells Astro "build everything as plain HTML files, no server needed." Because of that, the Cloudflare adapter never deployed a Worker function to handle `/_actions/*`. When the form POSTed, Cloudflare Pages looked for a static file at that path, didn't find one, and returned **403**.

## What changed

1. `astro-app/astro.config.mjs`: `output: "static"` → `output: "server"`
   - This tells Astro: "build a Worker for dynamic routes, but still let me opt pages into static rendering."
2. Added `export const prerender = true` to every page that was previously static (home, articles, sponsors, events, projects, authors, gallery, RSS feed, ICS endpoint, the `[...slug]` catch-all, etc.)
   - This keeps those pages as **plain HTML files at build time** — no extra server cost, same speed as before.
3. Portal / auth / student / `api/*` routes already had `prerender = false`. They keep working exactly as they did (SSR for auth + DB).
4. `/_actions/*` is now automatically attached to the Worker — the form will hit a real handler instead of a 404/403.

## Net effect

| Route group | Before | After |
| --- | --- | --- |
| Marketing pages (home, articles, sponsors, etc.) | static HTML | static HTML (unchanged) |
| Portal, auth, student, api/* | SSR | SSR (unchanged) |
| `/_actions/submitForm` | **403 — no handler** | **Works — runs on Worker** |

Build output is the same except a Worker bundle is now emitted, which is what Cloudflare Pages needs to serve actions.

## Follow-up (manual, not in this PR)

Cloudflare Turnstile widget allowlist needs `ywcccapstone1.com` added so the bot-check works on that domain too. The MCP token I have access to doesn't have Turnstile API permissions (returns 10000 auth error), so this step has to be done in the Cloudflare dashboard:

1. Cloudflare dashboard → **Turnstile**
2. Open the widget that matches `PUBLIC_TURNSTILE_SITE_KEY`
3. Under **Hostname management**, add `ywcccapstone1.com` (alongside `ywcc-capstone.pages.dev`)
4. Save

Also confirm these are set as **Pages env vars** on the production project (they are read from `context.locals.runtime.env`, not from `import.meta.env`):
- `TURNSTILE_SECRET_KEY`
- `SANITY_API_WRITE_TOKEN`
- `DISCORD_WEBHOOK_URL`

## Test plan

- [ ] CI build passes
- [ ] Preview deploy: open contact form → submit → expect 200, success state shows
- [ ] Verify a `submission` document appears in Sanity
- [ ] Verify Discord webhook fires
- [ ] Verify a marketing page (e.g. `/sponsors`) is still served as static HTML on the preview (view-source should match a normal HTML file, not a Worker response)
- [ ] Verify portal still requires auth (i.e. SSR behavior preserved)
- [ ] After deploy, confirm Turnstile allowlist includes new domain (manual dashboard step above)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration Updates**
  * Changed site rendering mode from static to server-based architecture.

* **Build & Performance**
  * Enabled build-time prerendering for all public pages and API endpoints, optimizing content delivery while utilizing server infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->