### PR TITLE
feat(portal): sponsor acceptances Studio tool + scroll-to-accept gate

### DIFF
--- a/astro-app/astro.config.mjs
+++ b/astro-app/astro.config.mjs
@@ -84,6 +84,17 @@ export default defineConfig({
         access: "secret",
         optional: true,
       }),
+      STUDIO_ADMIN_TOKEN: envField.string({
+        context: "server",
+        access: "secret",
+        optional: true,
+        startsWith: "sat_",
+      }),
+      STUDIO_ORIGIN: envField.string({
+        context: "server",
+        access: "public",
+        optional: true,
+      }),
     },
     validateSecrets: true,
   },

--- a/astro-app/src/components/portal/SponsorAgreementModal.tsx
+++ b/astro-app/src/components/portal/SponsorAgreementModal.tsx
@@ -45,6 +45,7 @@ export default function SponsorAgreementModal({
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [pdfReady, setPdfReady] = useState(false);
+  const [scrolledToEnd, setScrolledToEnd] = useState(false);
   const dialogRef = useRef<HTMLDivElement>(null);
   const acceptBtnRef = useRef<HTMLButtonElement>(null);
 
@@ -88,6 +89,7 @@ export default function SponsorAgreementModal({
 
   const isConfigured = Boolean(pdfUrl);
   const onPdfReady = useCallback((numPages: number) => setPdfReady(numPages > 0), []);
+  const onScrolledToEnd = useCallback(() => setScrolledToEnd(true), []);
 
   async function onAccept() {
     if (!accepted || submitting || !pdfReady) return;
@@ -137,11 +139,25 @@ export default function SponsorAgreementModal({
         </div>
 
         {isConfigured && pdfUrl ? (
-          <SponsorAgreementViewer pdfUrl={pdfUrl} maxHeight="60vh" onReady={onPdfReady} />
+          <SponsorAgreementViewer
+            pdfUrl={pdfUrl}
+            maxHeight="60vh"
+            onReady={onPdfReady}
+            onScrolledToEnd={onScrolledToEnd}
+          />
         ) : (
           <div className="border bg-muted/30 p-6 text-sm text-muted-foreground">
             Sponsor agreement is not yet configured. Please contact your program administrator.
           </div>
+        )}
+
+        {isConfigured && pdfReady && !scrolledToEnd && (
+          <p
+            className="text-xs text-muted-foreground"
+            data-testid="agreement-scroll-hint"
+          >
+            Scroll to the end of the agreement to enable acceptance.
+          </p>
         )}
 
         {isConfigured && (
@@ -150,7 +166,7 @@ export default function SponsorAgreementModal({
               type="checkbox"
               checked={accepted}
               onChange={(e) => setAccepted(e.target.checked)}
-              disabled={!pdfReady}
+              disabled={!pdfReady || !scrolledToEnd}
               className="mt-1 size-4 shrink-0 border-input disabled:opacity-50"
               data-testid="agreement-checkbox"
             />

--- a/astro-app/src/components/portal/SponsorAgreementModal.tsx
+++ b/astro-app/src/components/portal/SponsorAgreementModal.tsx
@@ -92,7 +92,7 @@ export default function SponsorAgreementModal({
   const onScrolledToEnd = useCallback(() => setScrolledToEnd(true), []);
 
   async function onAccept() {
-    if (!accepted || submitting || !pdfReady) return;
+    if (!accepted || submitting || !pdfReady || !scrolledToEnd) return;
     setSubmitting(true);
     setError(null);
     try {
@@ -153,6 +153,7 @@ export default function SponsorAgreementModal({
 
         {isConfigured && pdfReady && !scrolledToEnd && (
           <p
+            id="agreement-scroll-hint"
             className="text-xs text-muted-foreground"
             data-testid="agreement-scroll-hint"
           >
@@ -167,6 +168,7 @@ export default function SponsorAgreementModal({
               checked={accepted}
               onChange={(e) => setAccepted(e.target.checked)}
               disabled={!pdfReady || !scrolledToEnd}
+              aria-describedby={pdfReady && !scrolledToEnd ? 'agreement-scroll-hint' : undefined}
               className="mt-1 size-4 shrink-0 border-input disabled:opacity-50"
               data-testid="agreement-checkbox"
             />
@@ -195,7 +197,7 @@ export default function SponsorAgreementModal({
               ref={acceptBtnRef}
               type="button"
               onClick={onAccept}
-              disabled={!accepted || submitting || !pdfReady}
+              disabled={!accepted || submitting || !pdfReady || !scrolledToEnd}
               data-testid="agreement-accept"
               className="bg-primary text-primary-foreground px-6 py-2 text-sm font-semibold uppercase tracking-wide transition-opacity disabled:opacity-50 disabled:cursor-not-allowed"
             >

--- a/astro-app/src/components/portal/SponsorAgreementViewer.tsx
+++ b/astro-app/src/components/portal/SponsorAgreementViewer.tsx
@@ -16,15 +16,20 @@ interface Props {
   /** Fires when the PDF reports its page count. Empty/corrupt PDFs report 0 — caller should
    *  use this to keep the accept checkbox/button disabled. */
   onReady?: (numPages: number) => void;
+  /** Fires once per mount when the user has scrolled to the end of the agreement (8px tolerance).
+   *  Short PDFs that fit entirely in the viewport fire this immediately after `onReady`. */
+  onScrolledToEnd?: () => void;
 }
 
 const DEFAULT_WIDTH = 800;
+const SCROLL_TOLERANCE_PX = 8;
 
 export default function SponsorAgreementViewer({
   pdfUrl,
   maxHeight = '70vh',
   className = '',
   onReady,
+  onScrolledToEnd,
 }: Props) {
   const containerRef = useRef<HTMLDivElement>(null);
   const [numPages, setNumPages] = useState<number | null>(null);
@@ -32,6 +37,8 @@ export default function SponsorAgreementViewer({
   // Default width keeps pages legible before/without ResizeObserver (older browsers).
   const [width, setWidth] = useState<number>(DEFAULT_WIDTH);
   const [reloadKey, setReloadKey] = useState(0);
+  const [scrolledToEnd, setScrolledToEnd] = useState(false);
+  const hasFiredRef = useRef(false);
 
   // Debounced ResizeObserver: avoid thrashing pdfjs on every resize tick.
   useEffect(() => {
@@ -52,6 +59,38 @@ export default function SponsorAgreementViewer({
     };
   }, []);
 
+  // Scroll listener: fire onScrolledToEnd once when within 8px of the bottom.
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el || !onScrolledToEnd) return;
+    const onScroll = () => {
+      if (hasFiredRef.current) return;
+      if (el.scrollTop + el.clientHeight >= el.scrollHeight - SCROLL_TOLERANCE_PX) {
+        hasFiredRef.current = true;
+        setScrolledToEnd(true);
+        onScrolledToEnd();
+      }
+    };
+    el.addEventListener('scroll', onScroll, { passive: true });
+    return () => el.removeEventListener('scroll', onScroll);
+  }, [onScrolledToEnd]);
+
+  // Short-PDF auto-fire: once pages render and width settles, if the entire content fits
+  // in the viewport (no scroll possible), fire onScrolledToEnd immediately.
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el || !numPages || hasFiredRef.current || !onScrolledToEnd) return;
+    const id = requestAnimationFrame(() => {
+      if (!el || hasFiredRef.current) return;
+      if (el.scrollHeight <= el.clientHeight + SCROLL_TOLERANCE_PX) {
+        hasFiredRef.current = true;
+        setScrolledToEnd(true);
+        onScrolledToEnd();
+      }
+    });
+    return () => cancelAnimationFrame(id);
+  }, [numPages, width, onScrolledToEnd]);
+
   // Memoize the page list so an unrelated parent re-render doesn't reset every page.
   const pages = useMemo(() => {
     if (!numPages) return null;
@@ -66,41 +105,67 @@ export default function SponsorAgreementViewer({
   }, [numPages, width]);
 
   return (
-    <div
-      ref={containerRef}
-      className={`border bg-muted/30 overflow-y-auto ${className}`}
-      style={{ maxHeight }}
-      data-testid="agreement-viewer"
-    >
-      {loadError ? (
-        <div className="flex flex-col items-center gap-3 p-8 text-center">
-          <p className="text-sm text-muted-foreground">{loadError}</p>
-          <button
-            type="button"
-            onClick={() => {
-              setLoadError(null);
-              setNumPages(null);
-              setReloadKey((k) => k + 1);
+    <div className={`relative ${className}`}>
+      <div
+        ref={containerRef}
+        className="border bg-muted/30 overflow-y-auto"
+        style={{ maxHeight }}
+        data-testid="agreement-viewer"
+      >
+        {loadError ? (
+          <div className="flex flex-col items-center gap-3 p-8 text-center">
+            <p className="text-sm text-muted-foreground">{loadError}</p>
+            <button
+              type="button"
+              onClick={() => {
+                setLoadError(null);
+                setNumPages(null);
+                hasFiredRef.current = false;
+                setScrolledToEnd(false);
+                setReloadKey((k) => k + 1);
+              }}
+              className="text-sm underline"
+            >
+              Try again
+            </button>
+          </div>
+        ) : (
+          <Document
+            key={reloadKey}
+            file={pdfUrl}
+            onLoadSuccess={({ numPages: n }) => {
+              setNumPages(n);
+              onReady?.(n);
+              if (n === 0) setLoadError('PDF is empty. Contact your program administrator.');
             }}
-            className="text-sm underline"
+            onLoadError={() => setLoadError('Could not load PDF. Try refreshing.')}
+            loading={<div className="p-8 text-center text-sm text-muted-foreground">Loading agreement…</div>}
           >
-            Try again
-          </button>
-        </div>
-      ) : (
-        <Document
-          key={reloadKey}
-          file={pdfUrl}
-          onLoadSuccess={({ numPages: n }) => {
-            setNumPages(n);
-            onReady?.(n);
-            if (n === 0) setLoadError('PDF is empty. Contact your program administrator.');
-          }}
-          onLoadError={() => setLoadError('Could not load PDF. Try refreshing.')}
-          loading={<div className="p-8 text-center text-sm text-muted-foreground">Loading agreement…</div>}
+            {pages}
+          </Document>
+        )}
+      </div>
+      {!loadError && numPages != null && !scrolledToEnd && onScrolledToEnd && (
+        <span
+          aria-hidden="true"
+          data-testid="agreement-scroll-indicator"
+          className="pointer-events-none absolute bottom-3 right-3 inline-flex items-center gap-1 border bg-background/90 px-2 py-1 text-xs text-muted-foreground shadow"
         >
-          {pages}
-        </Document>
+          Keep scrolling
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="12"
+            height="12"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <polyline points="6 9 12 15 18 9" />
+          </svg>
+        </span>
       )}
     </div>
   );

--- a/astro-app/src/components/portal/SponsorAgreementViewer.tsx
+++ b/astro-app/src/components/portal/SponsorAgreementViewer.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Document, Page, pdfjs } from 'react-pdf';
 import 'react-pdf/dist/Page/AnnotationLayer.css';
 import 'react-pdf/dist/Page/TextLayer.css';
@@ -38,6 +38,7 @@ export default function SponsorAgreementViewer({
   const [width, setWidth] = useState<number>(DEFAULT_WIDTH);
   const [reloadKey, setReloadKey] = useState(0);
   const [scrolledToEnd, setScrolledToEnd] = useState(false);
+  const [renderedPages, setRenderedPages] = useState(0);
   const hasFiredRef = useRef(false);
 
   // Debounced ResizeObserver: avoid thrashing pdfjs on every resize tick.
@@ -75,11 +76,14 @@ export default function SponsorAgreementViewer({
     return () => el.removeEventListener('scroll', onScroll);
   }, [onScrolledToEnd]);
 
-  // Short-PDF auto-fire: once pages render and width settles, if the entire content fits
-  // in the viewport (no scroll possible), fire onScrolledToEnd immediately.
+  // Short-PDF auto-fire: once ALL pages have rendered (not just `onLoadSuccess`) and width has
+  // settled, measure scrollHeight. Without waiting for `onRenderSuccess`, the rAF tick can run
+  // while pages are still laying out, making `scrollHeight <= clientHeight` falsely true and
+  // bypassing the scroll gate on multi-page PDFs.
   useEffect(() => {
     const el = containerRef.current;
     if (!el || !numPages || hasFiredRef.current || !onScrolledToEnd) return;
+    if (renderedPages < numPages) return;
     const id = requestAnimationFrame(() => {
       if (!el || hasFiredRef.current) return;
       if (el.scrollHeight <= el.clientHeight + SCROLL_TOLERANCE_PX) {
@@ -89,7 +93,23 @@ export default function SponsorAgreementViewer({
       }
     });
     return () => cancelAnimationFrame(id);
-  }, [numPages, width, onScrolledToEnd]);
+  }, [numPages, renderedPages, width, onScrolledToEnd]);
+
+  const onPageRendered = useCallback(() => setRenderedPages((n) => n + 1), []);
+
+  const onDocumentLoadSuccess = useCallback(
+    ({ numPages: n }: { numPages: number }) => {
+      setRenderedPages(0);
+      setNumPages(n);
+      onReady?.(n);
+      if (n === 0) setLoadError('PDF is empty. Contact your program administrator.');
+    },
+    [onReady],
+  );
+  const onDocumentLoadError = useCallback(
+    () => setLoadError('Could not load PDF. Try refreshing.'),
+    [],
+  );
 
   // Memoize the page list so an unrelated parent re-render doesn't reset every page.
   const pages = useMemo(() => {
@@ -100,9 +120,10 @@ export default function SponsorAgreementViewer({
         pageNumber={i + 1}
         width={width}
         className="mb-2"
+        onRenderSuccess={onPageRendered}
       />
     ));
-  }, [numPages, width]);
+  }, [numPages, width, onPageRendered]);
 
   return (
     <div className={`relative ${className}`}>
@@ -120,6 +141,7 @@ export default function SponsorAgreementViewer({
               onClick={() => {
                 setLoadError(null);
                 setNumPages(null);
+                setRenderedPages(0);
                 hasFiredRef.current = false;
                 setScrolledToEnd(false);
                 setReloadKey((k) => k + 1);
@@ -133,12 +155,8 @@ export default function SponsorAgreementViewer({
           <Document
             key={reloadKey}
             file={pdfUrl}
-            onLoadSuccess={({ numPages: n }) => {
-              setNumPages(n);
-              onReady?.(n);
-              if (n === 0) setLoadError('PDF is empty. Contact your program administrator.');
-            }}
-            onLoadError={() => setLoadError('Could not load PDF. Try refreshing.')}
+            onLoadSuccess={onDocumentLoadSuccess}
+            onLoadError={onDocumentLoadError}
             loading={<div className="p-8 text-center text-sm text-muted-foreground">Loading agreement…</div>}
           >
             {pages}

--- a/astro-app/src/components/portal/__tests__/SponsorAgreementModal.test.tsx
+++ b/astro-app/src/components/portal/__tests__/SponsorAgreementModal.test.tsx
@@ -7,13 +7,40 @@ import { createRoot, type Root } from 'react-dom/client';
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
 // Mock the viewer to skip loading the pdfjs worker in jsdom.
-// Synchronously fires onReady so the modal treats the PDF as loaded.
+// Default: synchronously fires onReady (3 pages) AND onScrolledToEnd so existing tests
+// that don't care about the scroll gate work without modification.
+// Tests that exercise the scroll gate flip `viewerMockState.fireScrolledToEnd = false`.
+const { viewerMockState } = vi.hoisted(() => ({
+  viewerMockState: { fireScrolledToEnd: true },
+}));
+
 vi.mock('../SponsorAgreementViewer', () => {
   return {
-    default: ({ pdfUrl, onReady }: { pdfUrl: string; onReady?: (n: number) => void }) => {
-      // Fire on first render so tests don't need to await pdfjs
+    default: ({
+      pdfUrl,
+      onReady,
+      onScrolledToEnd,
+    }: {
+      pdfUrl: string;
+      onReady?: (n: number) => void;
+      onScrolledToEnd?: () => void;
+    }) => {
       if (onReady) onReady(3);
-      return <div data-testid="agreement-viewer-mock">viewer: {pdfUrl}</div>;
+      if (onScrolledToEnd && viewerMockState.fireScrolledToEnd) onScrolledToEnd();
+      return (
+        <div data-testid="agreement-viewer-mock">
+          viewer: {pdfUrl}
+          {onScrolledToEnd && (
+            <button
+              type="button"
+              data-testid="mock-trigger-scroll-end"
+              onClick={() => onScrolledToEnd()}
+            >
+              fire-scroll-end
+            </button>
+          )}
+        </div>
+      );
     },
   };
 });
@@ -71,6 +98,7 @@ const BASE_PROPS = {
 describe('SponsorAgreementModal', () => {
   beforeEach(() => {
     vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout', 'Date'] });
+    viewerMockState.fireScrolledToEnd = true;
     // @ts-expect-error jsdom - assign reload spy
     window.location = { ...window.location, reload: vi.fn(), origin: 'http://localhost' };
   });
@@ -171,5 +199,37 @@ describe('SponsorAgreementModal', () => {
     expect(document.body.style.overflow).toBe('hidden');
     unmount();
     expect(document.body.style.overflow).toBe('');
+  });
+
+  describe('scroll-to-accept gate', () => {
+    it('checkbox is disabled when pdfReady=true and scrolledToEnd=false', () => {
+      viewerMockState.fireScrolledToEnd = false;
+      render(<SponsorAgreementModal {...BASE_PROPS} />);
+      const cb = container.querySelector('[data-testid="agreement-checkbox"]') as HTMLInputElement;
+      expect(cb.disabled).toBe(true);
+    });
+
+    it('checkbox becomes enabled after the viewer fires onScrolledToEnd', async () => {
+      viewerMockState.fireScrolledToEnd = false;
+      render(<SponsorAgreementModal {...BASE_PROPS} />);
+      const cb = container.querySelector('[data-testid="agreement-checkbox"]') as HTMLInputElement;
+      expect(cb.disabled).toBe(true);
+
+      const trigger = container.querySelector('[data-testid="mock-trigger-scroll-end"]');
+      await click(trigger);
+
+      expect(cb.disabled).toBe(false);
+    });
+
+    it('hint text is visible when !scrolledToEnd, hidden when scrolledToEnd', async () => {
+      viewerMockState.fireScrolledToEnd = false;
+      render(<SponsorAgreementModal {...BASE_PROPS} />);
+      expect(container.querySelector('[data-testid="agreement-scroll-hint"]')).toBeTruthy();
+
+      const trigger = container.querySelector('[data-testid="mock-trigger-scroll-end"]');
+      await click(trigger);
+
+      expect(container.querySelector('[data-testid="agreement-scroll-hint"]')).toBeNull();
+    });
   });
 });

--- a/astro-app/src/components/portal/__tests__/SponsorAgreementViewer.test.tsx
+++ b/astro-app/src/components/portal/__tests__/SponsorAgreementViewer.test.tsx
@@ -1,0 +1,266 @@
+// @vitest-environment jsdom
+import React, { act } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createRoot, type Root } from 'react-dom/client';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+// Replace `react-pdf` with a minimal stub so jsdom doesn't try to load the worker.
+// Document fires onLoadSuccess on mount (or onLoadError when forceLoadError is set).
+const { documentMock, pageMock, mockState } = vi.hoisted(() => ({
+  documentMock: vi.fn(),
+  pageMock: vi.fn(),
+  mockState: { forceLoadError: false },
+}));
+
+vi.mock('react-pdf', () => ({
+  pdfjs: { GlobalWorkerOptions: { workerSrc: '' } },
+  Document: ({
+    file,
+    onLoadSuccess,
+    onLoadError,
+    children,
+  }: {
+    file: string;
+    onLoadSuccess?: (info: { numPages: number }) => void;
+    onLoadError?: (e: Error) => void;
+    children?: React.ReactNode;
+  }) => {
+    documentMock(file);
+    React.useEffect(() => {
+      if (mockState.forceLoadError) onLoadError?.(new Error('boom'));
+      else onLoadSuccess?.({ numPages: 3 });
+    }, [onLoadSuccess, onLoadError]);
+    return <div data-testid="pdf-document">{children}</div>;
+  },
+  Page: ({ pageNumber }: { pageNumber: number }) => {
+    pageMock(pageNumber);
+    return <div data-testid="pdf-page" data-page={pageNumber} style={{ height: 600 }} />;
+  },
+}));
+
+// React-pdf CSS imports — stub as empty modules
+vi.mock('react-pdf/dist/Page/AnnotationLayer.css', () => ({}));
+vi.mock('react-pdf/dist/Page/TextLayer.css', () => ({}));
+
+import SponsorAgreementViewer from '../SponsorAgreementViewer';
+
+let container: HTMLDivElement;
+let root: Root;
+
+function render(ui: React.ReactElement) {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => {
+    root.render(ui);
+  });
+}
+
+function unmount() {
+  act(() => {
+    root.unmount();
+  });
+  container.remove();
+}
+
+async function flush() {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+function getViewerEl(): HTMLDivElement {
+  const el = container.querySelector<HTMLDivElement>('[data-testid="agreement-viewer"]');
+  if (!el) throw new Error('viewer container not found');
+  return el;
+}
+
+/** Override scroll metrics on a div so we can drive the scroll listener deterministically. */
+function setScrollMetrics(el: HTMLElement, opts: {
+  scrollTop: number;
+  clientHeight: number;
+  scrollHeight: number;
+}) {
+  Object.defineProperty(el, 'scrollTop', { configurable: true, get: () => opts.scrollTop });
+  Object.defineProperty(el, 'clientHeight', { configurable: true, get: () => opts.clientHeight });
+  Object.defineProperty(el, 'scrollHeight', { configurable: true, get: () => opts.scrollHeight });
+}
+
+beforeEach(() => {
+  documentMock.mockClear();
+  pageMock.mockClear();
+  mockState.forceLoadError = false;
+  // Polyfill rAF for the short-pdf detection path
+  vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
+    return setTimeout(() => cb(performance.now()), 0) as unknown as number;
+  });
+  vi.stubGlobal('cancelAnimationFrame', (id: number) => clearTimeout(id as unknown as ReturnType<typeof setTimeout>));
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  if (container) unmount();
+});
+
+describe('SponsorAgreementViewer — onScrolledToEnd', () => {
+  it('fires when scroll position reaches the bottom (within 8px tolerance)', async () => {
+    const onScrolledToEnd = vi.fn();
+    render(
+      <SponsorAgreementViewer
+        pdfUrl="/agreement.pdf"
+        onScrolledToEnd={onScrolledToEnd}
+      />,
+    );
+    await flush();
+
+    const el = getViewerEl();
+    // Tall content, NOT at bottom → no fire
+    setScrollMetrics(el, { scrollTop: 0, clientHeight: 200, scrollHeight: 1000 });
+    await act(async () => {
+      el.dispatchEvent(new Event('scroll'));
+    });
+    expect(onScrolledToEnd).not.toHaveBeenCalled();
+
+    // Within tolerance (scrollHeight - (top+client) = 5 < 8)
+    setScrollMetrics(el, { scrollTop: 795, clientHeight: 200, scrollHeight: 1000 });
+    await act(async () => {
+      el.dispatchEvent(new Event('scroll'));
+    });
+    expect(onScrolledToEnd).toHaveBeenCalledTimes(1);
+  });
+
+  it('fires immediately for short PDFs that fit entirely in the viewport', async () => {
+    const onScrolledToEnd = vi.fn();
+
+    // Pre-set "fits in viewport" metrics on every fresh div the component creates.
+    // Patch at the prototype level for this test.
+    const origScrollHeight = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'scrollHeight');
+    const origClientHeight = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'clientHeight');
+    Object.defineProperty(HTMLElement.prototype, 'scrollHeight', { configurable: true, get: () => 200 });
+    Object.defineProperty(HTMLElement.prototype, 'clientHeight', { configurable: true, get: () => 400 });
+
+    try {
+      render(
+        <SponsorAgreementViewer
+          pdfUrl="/short.pdf"
+          onScrolledToEnd={onScrolledToEnd}
+        />,
+      );
+      // Wait for onLoadSuccess effect + rAF callback
+      await act(async () => {
+        await new Promise((r) => setTimeout(r, 20));
+      });
+      await flush();
+      expect(onScrolledToEnd).toHaveBeenCalledTimes(1);
+    } finally {
+      if (origScrollHeight) Object.defineProperty(HTMLElement.prototype, 'scrollHeight', origScrollHeight);
+      else Reflect.deleteProperty(HTMLElement.prototype, 'scrollHeight');
+      if (origClientHeight) Object.defineProperty(HTMLElement.prototype, 'clientHeight', origClientHeight);
+      else Reflect.deleteProperty(HTMLElement.prototype, 'clientHeight');
+    }
+  });
+
+  it('reload (Try again) resets the once-only guard so the user must scroll again', async () => {
+    const onScrolledToEnd = vi.fn();
+    // Force the container scrollable so the short-PDF auto-fire path doesn't trigger
+    Object.defineProperty(HTMLElement.prototype, 'scrollHeight', { configurable: true, get: () => 1000 });
+    Object.defineProperty(HTMLElement.prototype, 'clientHeight', { configurable: true, get: () => 200 });
+    Object.defineProperty(HTMLElement.prototype, 'scrollTop', { configurable: true, get: () => 0, set: () => {} });
+
+    try {
+      mockState.forceLoadError = true;
+      render(
+        <SponsorAgreementViewer
+          pdfUrl="/agreement.pdf"
+          onScrolledToEnd={onScrolledToEnd}
+        />,
+      );
+      await flush();
+
+      mockState.forceLoadError = false;
+      const btn = container.querySelector('button');
+      expect(btn?.textContent).toMatch(/try again/i);
+      await act(async () => {
+        btn?.click();
+      });
+      await act(async () => {
+        await new Promise((r) => setTimeout(r, 20));
+      });
+      await flush();
+
+      // After reload, onScrolledToEnd has not yet fired (PDF is scrollable, user hasn't scrolled).
+      expect(onScrolledToEnd).not.toHaveBeenCalled();
+
+      const el = getViewerEl();
+      setScrollMetrics(el, { scrollTop: 800, clientHeight: 200, scrollHeight: 1000 });
+      await act(async () => {
+        el.dispatchEvent(new Event('scroll'));
+      });
+      expect(onScrolledToEnd).toHaveBeenCalledTimes(1);
+    } finally {
+      Reflect.deleteProperty(HTMLElement.prototype, 'scrollHeight');
+      Reflect.deleteProperty(HTMLElement.prototype, 'clientHeight');
+      Reflect.deleteProperty(HTMLElement.prototype, 'scrollTop');
+    }
+  });
+
+  it('fires exactly once even when the user scrolls past the threshold multiple times', async () => {
+    const onScrolledToEnd = vi.fn();
+    render(
+      <SponsorAgreementViewer
+        pdfUrl="/agreement.pdf"
+        onScrolledToEnd={onScrolledToEnd}
+      />,
+    );
+    await flush();
+
+    const el = getViewerEl();
+    setScrollMetrics(el, { scrollTop: 800, clientHeight: 200, scrollHeight: 1000 });
+    for (let i = 0; i < 5; i++) {
+      await act(async () => {
+        el.dispatchEvent(new Event('scroll'));
+      });
+    }
+    expect(onScrolledToEnd).toHaveBeenCalledTimes(1);
+  });
+
+  it('hides the "Keep scrolling" indicator after onScrolledToEnd fires', async () => {
+    const onScrolledToEnd = vi.fn();
+
+    // Ensure scrollable (scrollHeight > clientHeight + tolerance) so the short-PDF auto-fire
+    // doesn't trip and the indicator is visible before the user scrolls.
+    Object.defineProperty(HTMLElement.prototype, 'scrollHeight', { configurable: true, get: () => 1000 });
+    Object.defineProperty(HTMLElement.prototype, 'clientHeight', { configurable: true, get: () => 200 });
+    Object.defineProperty(HTMLElement.prototype, 'scrollTop', { configurable: true, get: () => 0, set: () => {} });
+
+    try {
+      render(
+        <SponsorAgreementViewer
+          pdfUrl="/agreement.pdf"
+          onScrolledToEnd={onScrolledToEnd}
+        />,
+      );
+      await act(async () => {
+        await new Promise((r) => setTimeout(r, 20));
+      });
+      await flush();
+      expect(container.querySelector('[data-testid="agreement-scroll-indicator"]')).toBeTruthy();
+
+      const el = getViewerEl();
+      // Override on this specific element so we can simulate scroll-to-bottom
+      setScrollMetrics(el, { scrollTop: 800, clientHeight: 200, scrollHeight: 1000 });
+      await act(async () => {
+        el.dispatchEvent(new Event('scroll'));
+      });
+
+      expect(container.querySelector('[data-testid="agreement-scroll-indicator"]')).toBeNull();
+    } finally {
+      Reflect.deleteProperty(HTMLElement.prototype, 'scrollHeight');
+      Reflect.deleteProperty(HTMLElement.prototype, 'clientHeight');
+      Reflect.deleteProperty(HTMLElement.prototype, 'scrollTop');
+    }
+  });
+});

--- a/astro-app/src/components/portal/__tests__/SponsorAgreementViewer.test.tsx
+++ b/astro-app/src/components/portal/__tests__/SponsorAgreementViewer.test.tsx
@@ -33,8 +33,17 @@ vi.mock('react-pdf', () => ({
     }, [onLoadSuccess, onLoadError]);
     return <div data-testid="pdf-document">{children}</div>;
   },
-  Page: ({ pageNumber }: { pageNumber: number }) => {
+  Page: ({
+    pageNumber,
+    onRenderSuccess,
+  }: {
+    pageNumber: number;
+    onRenderSuccess?: () => void;
+  }) => {
     pageMock(pageNumber);
+    React.useEffect(() => {
+      onRenderSuccess?.();
+    }, [onRenderSuccess]);
     return <div data-testid="pdf-page" data-page={pageNumber} style={{ height: 600 }} />;
   },
 }));

--- a/astro-app/src/pages/api/portal/admin/__tests__/acceptances.test.ts
+++ b/astro-app/src/pages/api/portal/admin/__tests__/acceptances.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { GET, OPTIONS, ALL } from '../acceptances';
+
+const mockD1All = vi.fn();
+const mockD1Prepare = vi.fn().mockReturnValue({ all: mockD1All });
+
+const TOKEN = 'sat_test_token_value';
+const ORIGIN = 'https://capstone.sanity.studio';
+
+function buildEnv(overrides: Record<string, unknown> = {}) {
+  return {
+    PORTAL_DB: { prepare: mockD1Prepare },
+    STUDIO_ADMIN_TOKEN: TOKEN,
+    STUDIO_ORIGIN: ORIGIN,
+    ...overrides,
+  };
+}
+
+function buildCtx(opts: {
+  method?: string;
+  origin?: string | null;
+  authToken?: string | null;
+  search?: string;
+  env?: Record<string, unknown> | null;
+} = {}) {
+  const headers: Record<string, string> = {};
+  if (opts.origin !== null) headers.origin = opts.origin ?? ORIGIN;
+  if (opts.authToken !== null && opts.authToken !== undefined) {
+    headers.authorization = `Bearer ${opts.authToken}`;
+  } else if (opts.authToken === undefined) {
+    headers.authorization = `Bearer ${TOKEN}`;
+  }
+  // explicit null = omit header
+  const search = opts.search ?? '';
+  const url = new URL(`https://app.example.com/api/portal/admin/acceptances${search}`);
+  return {
+    url,
+    request: new Request(url.toString(), {
+      method: opts.method ?? 'GET',
+      headers,
+    }),
+    locals: {
+      runtime: opts.env === null ? undefined : { env: opts.env ?? buildEnv() },
+    } as unknown,
+  };
+}
+
+describe('GET /api/portal/admin/acceptances', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockD1All.mockReset().mockResolvedValue({
+      results: [
+        { email: 'a@co.com', name: 'Alice', role: 'sponsor', agreement_accepted_at: 1700000000000 },
+        { email: 'b@co.com', name: 'Bob', role: 'sponsor', agreement_accepted_at: null },
+      ],
+    });
+    mockD1Prepare.mockReset().mockReturnValue({ all: mockD1All });
+  });
+
+  it('returns 401 when authorization header is missing', async () => {
+    const ctx = buildCtx({ authToken: null });
+    const res = await GET(ctx as never);
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({ error: 'unauthorized' });
+  });
+
+  it('returns 401 when bearer token does not match', async () => {
+    const ctx = buildCtx({ authToken: 'sat_wrong_token_value_x' });
+    const res = await GET(ctx as never);
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 403 when origin does not match STUDIO_ORIGIN', async () => {
+    const ctx = buildCtx({ origin: 'https://evil.example' });
+    const res = await GET(ctx as never);
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: 'forbidden_origin' });
+  });
+
+  it('returns 200 with acceptances array on valid token + origin', async () => {
+    const ctx = buildCtx({});
+    const res = await GET(ctx as never);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.acceptances).toEqual([
+      { email: 'a@co.com', name: 'Alice', role: 'sponsor', agreementAcceptedAt: 1700000000000 },
+      { email: 'b@co.com', name: 'Bob', role: 'sponsor', agreementAcceptedAt: null },
+    ]);
+    expect(typeof body.generatedAt).toBe('number');
+    expect(res.headers.get('access-control-allow-origin')).toBe(ORIGIN);
+  });
+
+  it('?accepted=true narrows query to non-null acceptance timestamps', async () => {
+    const ctx = buildCtx({ search: '?accepted=true' });
+    await GET(ctx as never);
+    const sql = mockD1Prepare.mock.calls[0][0];
+    expect(sql).toContain("role = 'sponsor'");
+    expect(sql).toContain('agreement_accepted_at IS NOT NULL');
+    expect(sql).not.toContain('agreement_accepted_at IS NULL ');
+  });
+
+  it('?accepted=false narrows query to null acceptance timestamps', async () => {
+    const ctx = buildCtx({ search: '?accepted=false' });
+    await GET(ctx as never);
+    const sql = mockD1Prepare.mock.calls[0][0];
+    expect(sql).toContain('agreement_accepted_at IS NULL');
+    expect(sql).not.toContain('IS NOT NULL');
+  });
+
+  it('emits Cache-Control: private, max-age=0, must-revalidate', async () => {
+    const ctx = buildCtx({});
+    const res = await GET(ctx as never);
+    expect(res.headers.get('cache-control')).toBe('private, max-age=0, must-revalidate');
+  });
+
+  it('returns 503 with no detail leakage when D1 throws', async () => {
+    mockD1All.mockRejectedValue(new Error('table user does not exist'));
+    const ctx = buildCtx({});
+    const res = await GET(ctx as never);
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body).toEqual({ error: 'service_unavailable' });
+    expect(JSON.stringify(body)).not.toContain('table user');
+  });
+
+  it('returns 503 when STUDIO_ADMIN_TOKEN env is missing (fail closed)', async () => {
+    const ctx = buildCtx({ env: buildEnv({ STUDIO_ADMIN_TOKEN: undefined }) });
+    const res = await GET(ctx as never);
+    expect(res.status).toBe(503);
+  });
+});
+
+describe('OPTIONS /api/portal/admin/acceptances', () => {
+  it('returns 204 with full CORS headers when origin matches', async () => {
+    const ctx = buildCtx({ method: 'OPTIONS' });
+    const res = await OPTIONS(ctx as never);
+    expect(res.status).toBe(204);
+    expect(res.headers.get('access-control-allow-origin')).toBe(ORIGIN);
+    expect(res.headers.get('access-control-allow-methods')).toBe('GET, OPTIONS');
+    expect(res.headers.get('access-control-allow-headers')).toBe('authorization, content-type');
+    expect(res.headers.get('access-control-max-age')).toBe('600');
+  });
+
+  it('returns 403 when origin does not match', async () => {
+    const ctx = buildCtx({ method: 'OPTIONS', origin: 'https://evil.example' });
+    const res = await OPTIONS(ctx as never);
+    expect(res.status).toBe(403);
+  });
+});
+
+describe('ALL handler — POST/PUT/DELETE', () => {
+  it('returns 405 with Allow: GET, OPTIONS', async () => {
+    const res = await ALL(null as never);
+    expect(res.status).toBe(405);
+    expect(res.headers.get('allow')).toBe('GET, OPTIONS');
+  });
+});

--- a/astro-app/src/pages/api/portal/admin/__tests__/acceptances.test.ts
+++ b/astro-app/src/pages/api/portal/admin/__tests__/acceptances.test.ts
@@ -63,6 +63,8 @@ describe('GET /api/portal/admin/acceptances', () => {
     const res = await GET(ctx as never);
     expect(res.status).toBe(401);
     expect(await res.json()).toEqual({ error: 'unauthorized' });
+    // Error responses must echo CORS so the Studio caller can read the body.
+    expect(res.headers.get('access-control-allow-origin')).toBe(ORIGIN);
   });
 
   it('returns 401 when bearer token does not match', async () => {
@@ -122,12 +124,16 @@ describe('GET /api/portal/admin/acceptances', () => {
     const body = await res.json();
     expect(body).toEqual({ error: 'service_unavailable' });
     expect(JSON.stringify(body)).not.toContain('table user');
+    // 503 from D1 catch must still echo CORS (origin matched at top of handler).
+    expect(res.headers.get('access-control-allow-origin')).toBe(ORIGIN);
   });
 
   it('returns 503 when STUDIO_ADMIN_TOKEN env is missing (fail closed)', async () => {
     const ctx = buildCtx({ env: buildEnv({ STUDIO_ADMIN_TOKEN: undefined }) });
     const res = await GET(ctx as never);
     expect(res.status).toBe(503);
+    // Even when env is missing, if origin matches we still echo CORS so Studio sees the body.
+    expect(res.headers.get('access-control-allow-origin')).toBe(ORIGIN);
   });
 });
 
@@ -146,6 +152,15 @@ describe('OPTIONS /api/portal/admin/acceptances', () => {
     const ctx = buildCtx({ method: 'OPTIONS', origin: 'https://evil.example' });
     const res = await OPTIONS(ctx as never);
     expect(res.status).toBe(403);
+  });
+
+  it('returns 503 (fail closed) when STUDIO_ORIGIN env is missing', async () => {
+    const ctx = buildCtx({
+      method: 'OPTIONS',
+      env: buildEnv({ STUDIO_ORIGIN: undefined }),
+    });
+    const res = await OPTIONS(ctx as never);
+    expect(res.status).toBe(503);
   });
 });
 

--- a/astro-app/src/pages/api/portal/admin/acceptances.ts
+++ b/astro-app/src/pages/api/portal/admin/acceptances.ts
@@ -1,0 +1,108 @@
+import type { APIRoute } from 'astro';
+
+export const prerender = false;
+
+const ALLOW_HEADERS = 'authorization, content-type';
+const ALLOW_METHODS = 'GET, OPTIONS';
+
+interface AcceptanceRow {
+  email: string;
+  name: string;
+  role: string;
+  agreement_accepted_at: number | null;
+}
+
+interface AdminEnv {
+  PORTAL_DB?: D1Database;
+  STUDIO_ADMIN_TOKEN?: string;
+  STUDIO_ORIGIN?: string;
+}
+
+function corsHeaders(origin: string): Record<string, string> {
+  return {
+    'Access-Control-Allow-Origin': origin,
+    'Access-Control-Allow-Methods': ALLOW_METHODS,
+    'Access-Control-Allow-Headers': ALLOW_HEADERS,
+    'Access-Control-Max-Age': '600',
+    Vary: 'Origin',
+  };
+}
+
+function constantTimeEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  let mismatch = 0;
+  for (let i = 0; i < a.length; i++) mismatch |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  return mismatch === 0;
+}
+
+function json(body: Record<string, unknown>, status: number, extraHeaders: Record<string, string> = {}) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json', ...extraHeaders },
+  });
+}
+
+export const OPTIONS: APIRoute = ({ request, locals }) => {
+  const env = (locals.runtime?.env ?? {}) as AdminEnv;
+  const origin = request.headers.get('origin');
+  if (!env.STUDIO_ORIGIN || origin !== env.STUDIO_ORIGIN) {
+    return new Response(null, { status: 403 });
+  }
+  return new Response(null, { status: 204, headers: corsHeaders(env.STUDIO_ORIGIN) });
+};
+
+export const GET: APIRoute = async ({ request, locals, url }) => {
+  const env = (locals.runtime?.env ?? {}) as AdminEnv;
+  if (!env.STUDIO_ADMIN_TOKEN || !env.STUDIO_ORIGIN || !env.PORTAL_DB) {
+    return json({ error: 'service_unavailable' }, 503);
+  }
+
+  const origin = request.headers.get('origin');
+  if (origin !== env.STUDIO_ORIGIN) {
+    return json({ error: 'forbidden_origin' }, 403);
+  }
+
+  const auth = request.headers.get('authorization') ?? '';
+  const token = auth.startsWith('Bearer ') ? auth.slice(7) : '';
+  if (!token || !constantTimeEqual(token, env.STUDIO_ADMIN_TOKEN)) {
+    return json({ error: 'unauthorized' }, 401);
+  }
+
+  const filter = url.searchParams.get('accepted'); // true | false | all | null
+  let where = "role = 'sponsor'";
+  if (filter === 'true') where += ' AND agreement_accepted_at IS NOT NULL';
+  else if (filter === 'false') where += ' AND agreement_accepted_at IS NULL';
+
+  // `agreement_accepted_at IS NULL` first puts NULLs after non-null when sorted DESC,
+  // matching `NULLS LAST` semantics across all SQLite versions (D1 backend may vary).
+  const sql =
+    `SELECT email, name, role, agreement_accepted_at FROM user WHERE ${where} ` +
+    `ORDER BY agreement_accepted_at IS NULL, agreement_accepted_at DESC, email ASC`;
+
+  try {
+    const rs = await env.PORTAL_DB.prepare(sql).all<AcceptanceRow>();
+    const acceptances = (rs.results ?? []).map((r) => ({
+      email: r.email,
+      name: r.name,
+      role: r.role,
+      agreementAcceptedAt: r.agreement_accepted_at,
+    }));
+    return json(
+      { acceptances, generatedAt: Date.now() },
+      200,
+      {
+        'cache-control': 'private, max-age=0, must-revalidate',
+        ...corsHeaders(env.STUDIO_ORIGIN),
+      },
+    );
+  } catch (e) {
+    console.error('[admin/acceptances] D1 error:', e);
+    return json({ error: 'service_unavailable' }, 503);
+  }
+};
+
+export const ALL: APIRoute = () =>
+  new Response('Method Not Allowed', {
+    status: 405,
+    headers: { allow: ALLOW_METHODS, 'content-type': 'text/plain' },
+  });

--- a/astro-app/src/pages/api/portal/admin/acceptances.ts
+++ b/astro-app/src/pages/api/portal/admin/acceptances.ts
@@ -44,8 +44,12 @@ function json(body: Record<string, unknown>, status: number, extraHeaders: Recor
 
 export const OPTIONS: APIRoute = ({ request, locals }) => {
   const env = (locals.runtime?.env ?? {}) as AdminEnv;
+  // Fail-closed when env is missing so misconfiguration is observable rather than masked as CORS.
+  if (!env.STUDIO_ORIGIN) {
+    return new Response(null, { status: 503 });
+  }
   const origin = request.headers.get('origin');
-  if (!env.STUDIO_ORIGIN || origin !== env.STUDIO_ORIGIN) {
+  if (origin !== env.STUDIO_ORIGIN) {
     return new Response(null, { status: 403 });
   }
   return new Response(null, { status: 204, headers: corsHeaders(env.STUDIO_ORIGIN) });
@@ -53,11 +57,16 @@ export const OPTIONS: APIRoute = ({ request, locals }) => {
 
 export const GET: APIRoute = async ({ request, locals, url }) => {
   const env = (locals.runtime?.env ?? {}) as AdminEnv;
+  const origin = request.headers.get('origin');
+  // Echo CORS on error responses when origin matches, so the Studio caller can read the body
+  // (browsers block cross-origin reads without Access-Control-Allow-Origin).
+  const errorCors =
+    env.STUDIO_ORIGIN && origin === env.STUDIO_ORIGIN ? corsHeaders(env.STUDIO_ORIGIN) : {};
+
   if (!env.STUDIO_ADMIN_TOKEN || !env.STUDIO_ORIGIN || !env.PORTAL_DB) {
-    return json({ error: 'service_unavailable' }, 503);
+    return json({ error: 'service_unavailable' }, 503, errorCors);
   }
 
-  const origin = request.headers.get('origin');
   if (origin !== env.STUDIO_ORIGIN) {
     return json({ error: 'forbidden_origin' }, 403);
   }
@@ -65,7 +74,7 @@ export const GET: APIRoute = async ({ request, locals, url }) => {
   const auth = request.headers.get('authorization') ?? '';
   const token = auth.startsWith('Bearer ') ? auth.slice(7) : '';
   if (!token || !constantTimeEqual(token, env.STUDIO_ADMIN_TOKEN)) {
-    return json({ error: 'unauthorized' }, 401);
+    return json({ error: 'unauthorized' }, 401, errorCors);
   }
 
   const filter = url.searchParams.get('accepted'); // true | false | all | null
@@ -97,7 +106,7 @@ export const GET: APIRoute = async ({ request, locals, url }) => {
     );
   } catch (e) {
     console.error('[admin/acceptances] D1 error:', e);
-    return json({ error: 'service_unavailable' }, 503);
+    return json({ error: 'service_unavailable' }, 503, errorCors);
   }
 };
 

--- a/astro-app/vitest.config.ts
+++ b/astro-app/vitest.config.ts
@@ -27,6 +27,7 @@ export default getViteConfig({
       "src/**/__tests__/**/*.test.ts",
       "src/**/__tests__/**/*.test.tsx",
       "../tests/integration/**/*.test.ts",
+      "../studio/src/tools/__tests__/**/*.test.tsx",
     ],
     exclude: ["node_modules", "dist", ".astro"],
     // React component tests use jsdom; non-component tests stay in node.

--- a/astro-app/wrangler.jsonc
+++ b/astro-app/wrangler.jsonc
@@ -15,6 +15,9 @@
   "vars": {
     // GitHub OAuth, Resend API key, and Google OAuth secrets are set via the CF Pages dashboard.
     // Local dev bypasses auth via the `import.meta.env.DEV` check in middleware.
+    // STUDIO_ORIGIN is the allowlisted Studio host for the admin acceptances endpoint
+    // (CORS + Origin check). STUDIO_ADMIN_TOKEN is set via `wrangler secret put`.
+    "STUDIO_ORIGIN": "https://capstone.sanity.studio"
   },
   "d1_databases": [
     {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ywcc-capstone-template",
-  "version": "1.18.0",
+  "version": "1.19.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ywcc-capstone-template",
-      "version": "1.18.0",
+      "version": "1.19.0",
       "workspaces": [
         "studio",
         "astro-app",
@@ -8885,7 +8885,7 @@
       "version": "0.41.2",
       "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.41.2.tgz",
       "integrity": "sha512-7G0Uf0yK3f2bjElBLGHIQzgRgMESczOMyYVasq1XK8P5HaXtlW4eQhz9MBL+TQILZLaruq+ClGId+hH0w4jvWw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@open-draft/deferred-promise": "^2.2.0",
@@ -9048,13 +9048,11 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -9070,13 +9068,11 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -9092,13 +9088,11 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -9114,13 +9108,11 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -9136,13 +9128,11 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -9158,13 +9148,11 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -9180,13 +9168,11 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -9202,13 +9188,11 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -9224,13 +9208,11 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -9246,13 +9228,11 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -9268,13 +9248,11 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -9641,14 +9619,14 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz",
       "integrity": "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@open-draft/logger": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@open-draft/logger/-/logger-0.3.0.tgz",
       "integrity": "sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "is-node-process": "^1.2.0",
@@ -9659,7 +9637,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
       "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@oslojs/encoding": {
@@ -15515,7 +15493,7 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/statuses/-/statuses-2.0.6.tgz",
       "integrity": "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/stylis": {
@@ -22865,7 +22843,7 @@
       "version": "16.12.0",
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.12.0.tgz",
       "integrity": "sha512-DKKrynuQRne0PNpEbzuEdHlYOMksHSUI8Zc9Unei5gTsMNA2/vMpoMz/yKba50pejK56qj98qM0SjYxAKi13gQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
@@ -23215,7 +23193,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-4.0.3.tgz",
       "integrity": "sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/history": {
@@ -24322,7 +24300,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
       "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/is-number": {
@@ -27572,7 +27550,7 @@
       "version": "2.12.9",
       "resolved": "https://registry.npmjs.org/msw/-/msw-2.12.9.tgz",
       "integrity": "sha512-NYbi51C6M3dujGmcmuGemu68jy12KqQPoVWGeroKToLGsBgrwG5ErM8WctoIIg49/EV49SEvYM9WSqO4G7kNeQ==",
-      "dev": true,
+      "devOptional": true,
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -27617,7 +27595,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.0.tgz",
       "integrity": "sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "tldts": "^7.0.5"
@@ -27630,7 +27608,7 @@
       "version": "5.4.3",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.4.3.tgz",
       "integrity": "sha512-AXSAQJu79WGc79/3e9/CR77I/KQgeY1AhNvcShIH4PTcGYyC4xv6H4R4AUOwkPS5799KlVDAu8zExeCrkGquiA==",
-      "dev": true,
+      "devOptional": true,
       "license": "(MIT OR CC0-1.0)",
       "dependencies": {
         "tagged-tag": "^1.0.0"
@@ -28311,7 +28289,7 @@
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.4.3.tgz",
       "integrity": "sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/own-keys": {
@@ -30872,7 +30850,7 @@
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/rettime/-/rettime-0.10.1.tgz",
       "integrity": "sha512-uyDrIlUEH37cinabq0AX4QbgV4HbFZ/gqoiunWQ1UqBtRvTTytwhNYjE++pO/MjPTZL5KQCf2bEoJ/BJNVQ5Kw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/reusify": {
@@ -32684,7 +32662,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
       "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -32879,7 +32857,7 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
       "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/strict-uri-encode": {
@@ -34821,7 +34799,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/until-async/-/until-async-3.0.2.tgz",
       "integrity": "sha512-IiSk4HlzAMqTUseHHe3VhIGyuFmN90zMTpD3Z3y8jeQbzLIq500MVM7Jq2vUAnTKAFPJrqwkzr6PoTcPhGcOiw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/kettanaito"
@@ -36437,6 +36415,7 @@
       "dependencies": {
         "@sanity/form-toolkit": "^2.2.3",
         "@sanity/vision": "^5.21.0",
+        "groq": "^5.8.1",
         "react": "^19.2.1",
         "react-dom": "^19.2.1",
         "sanity": "^5.21.0",

--- a/studio/.env.example
+++ b/studio/.env.example
@@ -1,0 +1,17 @@
+# Sanity Studio environment variables.
+# Studio only exposes vars prefixed `SANITY_STUDIO_*` to the client bundle.
+
+# Project (typically set automatically by `sanity init`)
+SANITY_STUDIO_PROJECT_ID=
+
+# Preview origins for the Presentation tool (per workspace)
+SANITY_STUDIO_PREVIEW_ORIGIN=
+SANITY_STUDIO_RWC_US_PREVIEW_ORIGIN=
+SANITY_STUDIO_RWC_INTL_PREVIEW_ORIGIN=
+
+# Sponsor Acceptances Studio Tool
+# - ADMIN_TOKEN: bearer token shared with the astro-app `STUDIO_ADMIN_TOKEN` Worker secret
+#   (generate: `openssl rand -base64 32 | tr '/+' '_-' | tr -d '=' | sed 's/^/sat_/'`)
+# - ACCEPTANCES_API_URL: production URL of the admin endpoint
+SANITY_STUDIO_ADMIN_TOKEN=
+SANITY_STUDIO_ACCEPTANCES_API_URL=

--- a/studio/package.json
+++ b/studio/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "@sanity/form-toolkit": "^2.2.3",
     "@sanity/vision": "^5.21.0",
+    "groq": "^5.8.1",
     "react": "^19.2.1",
     "react-dom": "^19.2.1",
     "sanity": "^5.21.0",

--- a/studio/sanity.config.ts
+++ b/studio/sanity.config.ts
@@ -13,6 +13,7 @@ import {
   CAPSTONE_SINGLETON_TYPES,
   SITE_AWARE_TYPES,
 } from './src/constants'
+import {sponsorAcceptancesTool} from './src/tools/SponsorAcceptancesTool'
 
 // Environment variables for project configuration
 const projectId = process.env.SANITY_STUDIO_PROJECT_ID || '<your project ID>'
@@ -49,6 +50,7 @@ function createRwcWorkspace(opts: RwcWorkspaceOptions): WorkspaceOptions {
       media(),
       formSchema({}),
     ],
+    tools: (prev) => [...prev, sponsorAcceptancesTool()],
     schema: {
       types: createWorkspaceSchemaTypes('rwc'),
       templates: (prev) => {
@@ -131,6 +133,7 @@ export default defineConfig([
       media(),
       formSchema({}),
     ],
+    tools: (prev) => [...prev, sponsorAcceptancesTool()],
     schema: {
       types: createWorkspaceSchemaTypes('production'),
       templates: (prev) => {

--- a/studio/src/tools/SponsorAcceptancesTool.tsx
+++ b/studio/src/tools/SponsorAcceptancesTool.tsx
@@ -12,7 +12,7 @@ import {
   Text,
   TextInput,
 } from '@sanity/ui'
-import {useCallback, useEffect, useMemo, useState} from 'react'
+import {useCallback, useEffect, useMemo, useRef, useState} from 'react'
 import {defineQuery} from 'groq'
 import {useClient} from 'sanity'
 import {IntentLink} from 'sanity/router'
@@ -80,6 +80,9 @@ export function SponsorAcceptancesView(props: ToolConfig = {}) {
   const [error, setError] = useState<string | null>(null)
   const [loading, setLoading] = useState(true)
   const [reloadKey, setReloadKey] = useState(0)
+  // Stamp each load() call so a stale fetch (e.g. slow Sanity client.fetch that the
+  // AbortController doesn't propagate to) can't overwrite newer data.
+  const requestIdRef = useRef(0)
 
   // Debounce search at 200ms
   useEffect(() => {
@@ -97,6 +100,8 @@ export function SponsorAcceptancesView(props: ToolConfig = {}) {
         setData(null)
         return
       }
+      const requestId = ++requestIdRef.current
+      const isStale = () => requestId !== requestIdRef.current
       setLoading(true)
       setError(null)
       try {
@@ -104,13 +109,18 @@ export function SponsorAcceptancesView(props: ToolConfig = {}) {
           headers: {authorization: `Bearer ${token}`},
           signal: controller?.signal,
         })
+        if (isStale()) return
         if (!res.ok) throw new Error(`API ${res.status}`)
         const body = (await res.json()) as {acceptances: Acceptance[]}
+        if (isStale()) return
         setData(body.acceptances)
 
-        const emails = body.acceptances.map((a) => a.email.toLowerCase())
+        const emails = body.acceptances
+          .map((a) => a.email.toLowerCase())
+          .filter((e) => e.length > 0)
         if (emails.length) {
           const docs = await client.fetch<SponsorDoc[]>(SPONSORS_BY_EMAIL_QUERY, {emails})
+          if (isStale()) return
           setSponsors(
             Object.fromEntries(docs.map((d) => [d.contactEmail.toLowerCase(), d])),
           )
@@ -119,9 +129,10 @@ export function SponsorAcceptancesView(props: ToolConfig = {}) {
         }
       } catch (e: unknown) {
         if ((e as Error).name === 'AbortError') return
+        if (isStale()) return
         setError((e as Error).message ?? 'Unknown error')
       } finally {
-        setLoading(false)
+        if (!isStale()) setLoading(false)
       }
     },
     [apiUrl, token, filter, client],
@@ -157,7 +168,8 @@ export function SponsorAcceptancesView(props: ToolConfig = {}) {
             </Heading>
             <Text muted size={1}>
               Read-only audit of sponsor agreement acceptance. Source of truth: D1 (
-              <code>user.agreement_accepted_at</code>).
+              <code>user.agreement_accepted_at</code>). Data is capstone-scoped — RWC
+              workspaces show the same shared rows (RWC has no portal sponsors).
             </Text>
           </Stack>
           <Button
@@ -215,9 +227,14 @@ export function SponsorAcceptancesView(props: ToolConfig = {}) {
 
         {!loading && !error && visible.length === 0 && (
           <Card padding={4} radius={2} border tone="transparent" data-testid="acceptances-empty">
-            <Text muted size={1}>
-              No sponsors match the current filter.
-            </Text>
+            <Stack space={3}>
+              <Text muted size={1}>
+                No sponsors match the current filter.
+              </Text>
+              <Box>
+                <Button text="Refresh" mode="ghost" onClick={handleRefresh} />
+              </Box>
+            </Stack>
           </Card>
         )}
 

--- a/studio/src/tools/SponsorAcceptancesTool.tsx
+++ b/studio/src/tools/SponsorAcceptancesTool.tsx
@@ -12,8 +12,14 @@ import {
   Text,
   TextInput,
 } from '@sanity/ui'
-import {useCallback, useEffect, useMemo, useRef, useState} from 'react'
-import {IntentLink, useClient} from 'sanity'
+import {useCallback, useEffect, useMemo, useState} from 'react'
+import {defineQuery} from 'groq'
+import {useClient} from 'sanity'
+import {IntentLink} from 'sanity/router'
+
+const SPONSORS_BY_EMAIL_QUERY = defineQuery(
+  `*[_type=="sponsor" && lower(contactEmail) in $emails]{ _id, contactEmail, name }`,
+)
 
 type FilterMode = 'all' | 'true' | 'false'
 
@@ -27,7 +33,7 @@ interface Acceptance {
 interface SponsorDoc {
   _id: string
   contactEmail: string
-  title: string
+  name: string
 }
 
 interface ToolConfig {
@@ -73,7 +79,7 @@ export function SponsorAcceptancesView(props: ToolConfig = {}) {
   const [sponsors, setSponsors] = useState<Record<string, SponsorDoc>>({})
   const [error, setError] = useState<string | null>(null)
   const [loading, setLoading] = useState(true)
-  const reloadCounter = useRef(0)
+  const [reloadKey, setReloadKey] = useState(0)
 
   // Debounce search at 200ms
   useEffect(() => {
@@ -104,10 +110,7 @@ export function SponsorAcceptancesView(props: ToolConfig = {}) {
 
         const emails = body.acceptances.map((a) => a.email.toLowerCase())
         if (emails.length) {
-          const docs = await client.fetch<SponsorDoc[]>(
-            `*[_type=="sponsor" && lower(contactEmail) in $emails]{ _id, contactEmail, title }`,
-            {emails},
-          )
+          const docs = await client.fetch<SponsorDoc[]>(SPONSORS_BY_EMAIL_QUERY, {emails})
           setSponsors(
             Object.fromEntries(docs.map((d) => [d.contactEmail.toLowerCase(), d])),
           )
@@ -128,7 +131,7 @@ export function SponsorAcceptancesView(props: ToolConfig = {}) {
     const controller = new AbortController()
     load(controller)
     return () => controller.abort()
-  }, [load, reloadCounter])
+  }, [load, reloadKey])
 
   const visible = useMemo(() => {
     if (!data) return []
@@ -141,8 +144,7 @@ export function SponsorAcceptancesView(props: ToolConfig = {}) {
   }, [data, debouncedSearch])
 
   const handleRefresh = () => {
-    reloadCounter.current += 1
-    load()
+    setReloadKey((k) => k + 1)
   }
 
   return (
@@ -289,7 +291,7 @@ export function SponsorAcceptancesView(props: ToolConfig = {}) {
                           params={{id: doc._id, type: 'sponsor'}}
                           data-testid="acceptances-sponsor-link"
                         >
-                          {doc.title || 'Open'}
+                          {doc.name || 'Open'}
                         </IntentLink>
                       ) : (
                         <Text size={1} muted>—</Text>

--- a/studio/src/tools/SponsorAcceptancesTool.tsx
+++ b/studio/src/tools/SponsorAcceptancesTool.tsx
@@ -1,0 +1,307 @@
+import {UsersIcon} from '@sanity/icons'
+import {
+  Badge,
+  Box,
+  Button,
+  Card,
+  Flex,
+  Heading,
+  Inline,
+  Spinner,
+  Stack,
+  Text,
+  TextInput,
+} from '@sanity/ui'
+import {useCallback, useEffect, useMemo, useRef, useState} from 'react'
+import {IntentLink, useClient} from 'sanity'
+
+type FilterMode = 'all' | 'true' | 'false'
+
+interface Acceptance {
+  email: string
+  name: string
+  role: string
+  agreementAcceptedAt: number | null
+}
+
+interface SponsorDoc {
+  _id: string
+  contactEmail: string
+  title: string
+}
+
+interface ToolConfig {
+  apiUrl?: string
+  token?: string
+}
+
+function readConfig(): ToolConfig {
+  const e = (import.meta as unknown as {env?: Record<string, string | undefined>}).env ?? {}
+  return {
+    apiUrl: e.SANITY_STUDIO_ACCEPTANCES_API_URL,
+    token: e.SANITY_STUDIO_ADMIN_TOKEN,
+  }
+}
+
+export function sponsorAcceptancesTool(overrides?: ToolConfig) {
+  const ResolvedView = () => <SponsorAcceptancesView {...(overrides ?? readConfig())} />
+  return {
+    name: 'sponsor-acceptances',
+    title: 'Sponsor Acceptances',
+    icon: UsersIcon,
+    component: ResolvedView,
+  }
+}
+
+function formatAcceptedAt(value: number | null): string {
+  if (value == null) return '—'
+  try {
+    return new Date(value).toLocaleString()
+  } catch {
+    return '—'
+  }
+}
+
+export function SponsorAcceptancesView(props: ToolConfig = {}) {
+  const {apiUrl, token} = props
+  const client = useClient({apiVersion: '2024-10-01'})
+
+  const [filter, setFilter] = useState<FilterMode>('all')
+  const [search, setSearch] = useState('')
+  const [debouncedSearch, setDebouncedSearch] = useState('')
+  const [data, setData] = useState<Acceptance[] | null>(null)
+  const [sponsors, setSponsors] = useState<Record<string, SponsorDoc>>({})
+  const [error, setError] = useState<string | null>(null)
+  const [loading, setLoading] = useState(true)
+  const reloadCounter = useRef(0)
+
+  // Debounce search at 200ms
+  useEffect(() => {
+    const id = setTimeout(() => setDebouncedSearch(search.trim().toLowerCase()), 200)
+    return () => clearTimeout(id)
+  }, [search])
+
+  const load = useCallback(
+    async (controller?: AbortController) => {
+      if (!apiUrl || !token) {
+        setError(
+          'Acceptances API not configured. Set SANITY_STUDIO_ACCEPTANCES_API_URL and SANITY_STUDIO_ADMIN_TOKEN.',
+        )
+        setLoading(false)
+        setData(null)
+        return
+      }
+      setLoading(true)
+      setError(null)
+      try {
+        const res = await fetch(`${apiUrl}?accepted=${filter}`, {
+          headers: {authorization: `Bearer ${token}`},
+          signal: controller?.signal,
+        })
+        if (!res.ok) throw new Error(`API ${res.status}`)
+        const body = (await res.json()) as {acceptances: Acceptance[]}
+        setData(body.acceptances)
+
+        const emails = body.acceptances.map((a) => a.email.toLowerCase())
+        if (emails.length) {
+          const docs = await client.fetch<SponsorDoc[]>(
+            `*[_type=="sponsor" && lower(contactEmail) in $emails]{ _id, contactEmail, title }`,
+            {emails},
+          )
+          setSponsors(
+            Object.fromEntries(docs.map((d) => [d.contactEmail.toLowerCase(), d])),
+          )
+        } else {
+          setSponsors({})
+        }
+      } catch (e: unknown) {
+        if ((e as Error).name === 'AbortError') return
+        setError((e as Error).message ?? 'Unknown error')
+      } finally {
+        setLoading(false)
+      }
+    },
+    [apiUrl, token, filter, client],
+  )
+
+  useEffect(() => {
+    const controller = new AbortController()
+    load(controller)
+    return () => controller.abort()
+  }, [load, reloadCounter])
+
+  const visible = useMemo(() => {
+    if (!data) return []
+    if (!debouncedSearch) return data
+    return data.filter(
+      (a) =>
+        a.email.toLowerCase().includes(debouncedSearch) ||
+        (a.name ?? '').toLowerCase().includes(debouncedSearch),
+    )
+  }, [data, debouncedSearch])
+
+  const handleRefresh = () => {
+    reloadCounter.current += 1
+    load()
+  }
+
+  return (
+    <Card padding={4} height="fill" tone="default">
+      <Stack space={4}>
+        <Flex align="center" justify="space-between" gap={3}>
+          <Stack space={2}>
+            <Heading as="h1" size={2}>
+              Sponsor Acceptances
+            </Heading>
+            <Text muted size={1}>
+              Read-only audit of sponsor agreement acceptance. Source of truth: D1 (
+              <code>user.agreement_accepted_at</code>).
+            </Text>
+          </Stack>
+          <Button
+            text="Refresh"
+            mode="ghost"
+            onClick={handleRefresh}
+            data-testid="acceptances-refresh"
+          />
+        </Flex>
+
+        <Flex gap={2} wrap="wrap" align="center">
+          <Inline space={2}>
+            {(['all', 'true', 'false'] as FilterMode[]).map((mode) => (
+              <Button
+                key={mode}
+                text={mode === 'all' ? 'All' : mode === 'true' ? 'Accepted' : 'Pending'}
+                mode={filter === mode ? 'default' : 'ghost'}
+                tone={filter === mode ? 'primary' : 'default'}
+                onClick={() => setFilter(mode)}
+                data-testid={`acceptances-filter-${mode}`}
+              />
+            ))}
+          </Inline>
+          <Box flex={1} style={{minWidth: 220}}>
+            <TextInput
+              placeholder="Search email or name…"
+              value={search}
+              onChange={(event) => setSearch(event.currentTarget.value)}
+              data-testid="acceptances-search"
+            />
+          </Box>
+        </Flex>
+
+        {loading && (
+          <Card padding={4} radius={2} border tone="transparent" data-testid="acceptances-loading">
+            <Flex align="center" gap={3}>
+              <Spinner muted />
+              <Text muted size={1}>
+                Loading acceptances…
+              </Text>
+            </Flex>
+          </Card>
+        )}
+
+        {!loading && error && (
+          <Card padding={4} radius={2} tone="critical" border data-testid="acceptances-error">
+            <Stack space={3}>
+              <Text size={1}>{error}</Text>
+              <Box>
+                <Button text="Retry" mode="ghost" onClick={handleRefresh} />
+              </Box>
+            </Stack>
+          </Card>
+        )}
+
+        {!loading && !error && visible.length === 0 && (
+          <Card padding={4} radius={2} border tone="transparent" data-testid="acceptances-empty">
+            <Text muted size={1}>
+              No sponsors match the current filter.
+            </Text>
+          </Card>
+        )}
+
+        {!loading && !error && visible.length > 0 && (
+          <Card border radius={2} overflow="auto" data-testid="acceptances-table">
+            <Stack as="ul" space={0} padding={0}>
+              <Flex
+                as="li"
+                paddingY={2}
+                paddingX={3}
+                gap={3}
+                style={{
+                  listStyle: 'none',
+                  borderBottom: '1px solid var(--card-border-color)',
+                  fontWeight: 600,
+                }}
+              >
+                <Box flex={2}>
+                  <Text size={1} weight="medium">Email</Text>
+                </Box>
+                <Box flex={2}>
+                  <Text size={1} weight="medium">Name</Text>
+                </Box>
+                <Box flex={1}>
+                  <Text size={1} weight="medium">Status</Text>
+                </Box>
+                <Box flex={2}>
+                  <Text size={1} weight="medium">Accepted At</Text>
+                </Box>
+                <Box flex={1}>
+                  <Text size={1} weight="medium">Sponsor Doc</Text>
+                </Box>
+              </Flex>
+              {visible.map((row) => {
+                const doc = sponsors[row.email.toLowerCase()]
+                const accepted = row.agreementAcceptedAt != null
+                return (
+                  <Flex
+                    key={row.email}
+                    as="li"
+                    paddingY={2}
+                    paddingX={3}
+                    gap={3}
+                    style={{
+                      listStyle: 'none',
+                      borderBottom: '1px solid var(--card-border-color)',
+                    }}
+                    data-testid="acceptances-row"
+                    data-email={row.email}
+                  >
+                    <Box flex={2}>
+                      <Text size={1}>{row.email}</Text>
+                    </Box>
+                    <Box flex={2}>
+                      <Text size={1}>{row.name || '—'}</Text>
+                    </Box>
+                    <Box flex={1}>
+                      <Badge tone={accepted ? 'positive' : 'caution'} mode="outline">
+                        {accepted ? 'Accepted' : 'Pending'}
+                      </Badge>
+                    </Box>
+                    <Box flex={2}>
+                      <Text size={1} muted={!accepted}>
+                        {formatAcceptedAt(row.agreementAcceptedAt)}
+                      </Text>
+                    </Box>
+                    <Box flex={1}>
+                      {doc ? (
+                        <IntentLink
+                          intent="edit"
+                          params={{id: doc._id, type: 'sponsor'}}
+                          data-testid="acceptances-sponsor-link"
+                        >
+                          {doc.title || 'Open'}
+                        </IntentLink>
+                      ) : (
+                        <Text size={1} muted>—</Text>
+                      )}
+                    </Box>
+                  </Flex>
+                )
+              })}
+            </Stack>
+          </Card>
+        )}
+      </Stack>
+    </Card>
+  )
+}

--- a/studio/src/tools/__tests__/SponsorAcceptancesTool.test.tsx
+++ b/studio/src/tools/__tests__/SponsorAcceptancesTool.test.tsx
@@ -1,0 +1,219 @@
+// @vitest-environment jsdom
+import {act} from 'react'
+import {createRoot, type Root} from 'react-dom/client'
+import {ThemeProvider, studioTheme} from '@sanity/ui'
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+
+;(globalThis as {IS_REACT_ACT_ENVIRONMENT?: boolean}).IS_REACT_ACT_ENVIRONMENT = true
+
+const {mockClientFetch} = vi.hoisted(() => ({mockClientFetch: vi.fn()}))
+
+vi.mock('sanity', () => {
+  const stableClient = {fetch: mockClientFetch}
+  return {
+    useClient: () => stableClient,
+    IntentLink: ({children, ...rest}: {children: React.ReactNode}) => (
+      <a data-testid="acceptances-sponsor-link" {...rest}>
+        {children}
+      </a>
+    ),
+  }
+})
+
+import {SponsorAcceptancesView, sponsorAcceptancesTool} from '../SponsorAcceptancesTool'
+
+let container: HTMLDivElement
+let root: Root
+
+function render(ui: React.ReactElement) {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+  act(() => {
+    root.render(<ThemeProvider theme={studioTheme}>{ui}</ThemeProvider>)
+  })
+}
+
+function unmount() {
+  act(() => {
+    root.unmount()
+  })
+  container.remove()
+}
+
+async function flush() {
+  await act(async () => {
+    await Promise.resolve()
+    await Promise.resolve()
+    await Promise.resolve()
+  })
+}
+
+const ACCEPTED = {
+  email: 'alice@example.com',
+  name: 'Alice',
+  role: 'sponsor',
+  agreementAcceptedAt: 1700000000000,
+}
+const PENDING = {
+  email: 'bob@example.com',
+  name: 'Bob',
+  role: 'sponsor',
+  agreementAcceptedAt: null,
+}
+
+const API_URL = 'https://app.example/api/portal/admin/acceptances'
+const TOKEN = 'sat_test_token_value'
+
+beforeEach(() => {
+  mockClientFetch.mockReset().mockResolvedValue([])
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  if (container) unmount()
+})
+
+describe('sponsorAcceptancesTool factory', () => {
+  it('returns a Studio tool descriptor with name, title, icon, component', () => {
+    const t = sponsorAcceptancesTool()
+    expect(t.name).toBe('sponsor-acceptances')
+    expect(t.title).toBe('Sponsor Acceptances')
+    expect(typeof t.component).toBe('function')
+    expect(t.icon).toBeDefined()
+  })
+})
+
+describe('<SponsorAcceptancesView />', () => {
+  it('shows loading spinner while fetching', () => {
+    vi.stubGlobal('fetch', vi.fn(() => new Promise(() => {})))
+    render(<SponsorAcceptancesView apiUrl={API_URL} token={TOKEN} />)
+    expect(container.querySelector('[data-testid="acceptances-loading"]')).toBeTruthy()
+  })
+
+  it('renders an error card with retry button when fetch fails', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({ok: false, status: 500, json: async () => ({})}),
+    )
+    render(<SponsorAcceptancesView apiUrl={API_URL} token={TOKEN} />)
+    await flush()
+    const errCard = container.querySelector('[data-testid="acceptances-error"]')
+    expect(errCard).toBeTruthy()
+    expect(errCard?.textContent).toMatch(/API 500/)
+    expect(errCard?.querySelector('button')).toBeTruthy()
+  })
+
+  it('renders empty-state copy when no rows returned', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({ok: true, status: 200, json: async () => ({acceptances: []})}),
+    )
+    render(<SponsorAcceptancesView apiUrl={API_URL} token={TOKEN} />)
+    await flush()
+    expect(container.querySelector('[data-testid="acceptances-empty"]')).toBeTruthy()
+  })
+
+  it('renders rows with Accepted and Pending badges', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({acceptances: [ACCEPTED, PENDING]}),
+      }),
+    )
+    render(<SponsorAcceptancesView apiUrl={API_URL} token={TOKEN} />)
+    await flush()
+    const rows = container.querySelectorAll('[data-testid="acceptances-row"]')
+    expect(rows.length).toBe(2)
+    const text = container.textContent ?? ''
+    expect(text).toContain('Accepted')
+    expect(text).toContain('Pending')
+  })
+
+  it('filter tabs swap rows by re-fetching with ?accepted query param', async () => {
+    const fetchSpy = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({acceptances: [ACCEPTED]}),
+    })
+    vi.stubGlobal('fetch', fetchSpy)
+    render(<SponsorAcceptancesView apiUrl={API_URL} token={TOKEN} />)
+    await flush()
+
+    const acceptedTab = container.querySelector(
+      '[data-testid="acceptances-filter-true"]',
+    ) as HTMLButtonElement
+    await act(async () => {
+      acceptedTab.click()
+    })
+    await flush()
+
+    const calledUrls = fetchSpy.mock.calls.map((c) => String(c[0]))
+    expect(calledUrls.some((u) => u.includes('?accepted=all'))).toBe(true)
+    expect(calledUrls.some((u) => u.includes('?accepted=true'))).toBe(true)
+  })
+
+  it('search input narrows visible rows by email substring (debounced)', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({acceptances: [ACCEPTED, PENDING]}),
+      }),
+    )
+    render(<SponsorAcceptancesView apiUrl={API_URL} token={TOKEN} />)
+    await flush()
+
+    const input = container.querySelector(
+      '[data-testid="acceptances-search"]',
+    ) as HTMLInputElement
+    await act(async () => {
+      const setter = Object.getOwnPropertyDescriptor(
+        window.HTMLInputElement.prototype,
+        'value',
+      )?.set
+      setter?.call(input, 'alice')
+      input.dispatchEvent(new Event('input', {bubbles: true}))
+    })
+    // Wait for 200ms debounce + a microtask flush
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 250))
+    })
+    await flush()
+
+    const rows = container.querySelectorAll('[data-testid="acceptances-row"]')
+    expect(rows.length).toBe(1)
+    expect((rows[0] as HTMLElement).getAttribute('data-email')).toBe('alice@example.com')
+  })
+
+  it('sponsor doc IntentLink only renders when matching sponsor doc exists', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({acceptances: [ACCEPTED, PENDING]}),
+      }),
+    )
+    mockClientFetch.mockResolvedValue([
+      {_id: 'sponsor-1', contactEmail: 'alice@example.com', title: 'Acme Co'},
+    ])
+    render(<SponsorAcceptancesView apiUrl={API_URL} token={TOKEN} />)
+    await flush()
+
+    const links = container.querySelectorAll('[data-testid="acceptances-sponsor-link"]')
+    expect(links.length).toBe(1)
+    expect(links[0].textContent).toBe('Acme Co')
+  })
+
+  it('renders configuration error when api url / token props are missing', async () => {
+    vi.stubGlobal('fetch', vi.fn())
+    render(<SponsorAcceptancesView />)
+    await flush()
+    const err = container.querySelector('[data-testid="acceptances-error"]')
+    expect(err?.textContent).toMatch(/not configured/i)
+  })
+})

--- a/studio/src/tools/__tests__/SponsorAcceptancesTool.test.tsx
+++ b/studio/src/tools/__tests__/SponsorAcceptancesTool.test.tsx
@@ -10,15 +10,16 @@ const {mockClientFetch} = vi.hoisted(() => ({mockClientFetch: vi.fn()}))
 
 vi.mock('sanity', () => {
   const stableClient = {fetch: mockClientFetch}
-  return {
-    useClient: () => stableClient,
-    IntentLink: ({children, ...rest}: {children: React.ReactNode}) => (
-      <a data-testid="acceptances-sponsor-link" {...rest}>
-        {children}
-      </a>
-    ),
-  }
+  return {useClient: () => stableClient}
 })
+
+vi.mock('sanity/router', () => ({
+  IntentLink: ({children, ...rest}: {children: React.ReactNode}) => (
+    <a data-testid="acceptances-sponsor-link" {...rest}>
+      {children}
+    </a>
+  ),
+}))
 
 import {SponsorAcceptancesView, sponsorAcceptancesTool} from '../SponsorAcceptancesTool'
 
@@ -199,7 +200,7 @@ describe('<SponsorAcceptancesView />', () => {
       }),
     )
     mockClientFetch.mockResolvedValue([
-      {_id: 'sponsor-1', contactEmail: 'alice@example.com', title: 'Acme Co'},
+      {_id: 'sponsor-1', contactEmail: 'alice@example.com', name: 'Acme Co'},
     ])
     render(<SponsorAcceptancesView apiUrl={API_URL} token={TOKEN} />)
     await flush()


### PR DESCRIPTION
## What this PR does (in plain English)

Two related portal improvements for sponsors and admins:

### 1. Admins get a new "Sponsor Acceptances" view inside Sanity Studio

Today, the only way to see which sponsors have accepted the agreement is to run a Cloudflare D1 query from the dashboard or `wrangler` CLI. After this PR, admins can open Sanity Studio and click the new **Sponsor Acceptances** tab in the top nav (next to Structure / Vision) to see:

- A list of every sponsor in the database
- A green **Accepted** badge or amber **Pending** badge per row
- The exact date/time each sponsor accepted (or `—` if they haven't yet)
- A direct link to the matching Sanity sponsor document (when one exists)
- Filter tabs: **All / Accepted / Pending**
- A search box that filters by email or name

It's **read-only** — no buttons that could accidentally change anything. D1 stays the single source of truth; the Studio just *reads* it through a small admin API.

### 2. Sponsors must scroll through the agreement PDF before they can check "I accept"

Right now, a sponsor can land on the agreement modal and immediately tick the checkbox — there's no proof they actually read it. After this PR:

- The acceptance checkbox is **disabled** until the sponsor has scrolled to the bottom of the PDF
- A small **"Keep scrolling ⌄"** indicator appears in the bottom-right corner of the PDF viewer
- A hint message above the checkbox says: *"Scroll to the end of the agreement to enable acceptance."*
- Short PDFs that fit entirely on screen automatically pass the gate (no impossible state)
- If the PDF fails to load and the sponsor clicks **Try again**, the scroll requirement resets

## How the pieces fit together

```
Sanity Studio (sanity.studio)         astro-app Worker (your domain)
─────────────────────────             ────────────────────────────────
Sponsor Acceptances tool   ──fetch──> GET /api/portal/admin/acceptances
                                      ├─ checks Origin == STUDIO_ORIGIN
                                      ├─ checks Bearer == STUDIO_ADMIN_TOKEN
                                      └─ reads D1 user table
```

- Two origins, two checks: only the configured Studio host *and* the right token can read.
- Constant-time token compare (no timing leaks).
- D1 query uses an explicit column allow-list — never `SELECT *` on the user table.
- Cache-Control: `private, max-age=0, must-revalidate` (audit data must never cache).
- 405 on POST/PUT/DELETE; 403 on bad origin; 401 on bad token; 503 if D1/env is missing.

## Files at a glance

**New**
- `astro-app/src/pages/api/portal/admin/acceptances.ts` — the admin endpoint
- `astro-app/src/pages/api/portal/admin/__tests__/acceptances.test.ts` — 12 tests
- `astro-app/src/components/portal/__tests__/SponsorAgreementViewer.test.tsx` — 5 tests
- `studio/src/tools/SponsorAcceptancesTool.tsx` — the Studio tool itself
- `studio/src/tools/__tests__/SponsorAcceptancesTool.test.tsx` — 9 tests
- `studio/.env.example` — placeholder for the new env vars

**Modified**
- `astro-app/astro.config.mjs` — adds `STUDIO_ADMIN_TOKEN` (secret) and `STUDIO_ORIGIN` (public) to the env schema
- `astro-app/wrangler.jsonc` — adds `STUDIO_ORIGIN` plain var (token is a secret)
- `astro-app/vitest.config.ts` — extends include glob so the Studio tool tests run in the unified suite
- `astro-app/src/components/portal/SponsorAgreementViewer.tsx` — new `onScrolledToEnd` prop + scroll listener + once-only guard + retry reset + indicator
- `astro-app/src/components/portal/SponsorAgreementModal.tsx` — wires `scrolledToEnd` state + checkbox predicate + hint row
- `astro-app/src/components/portal/__tests__/SponsorAgreementModal.test.tsx` — 3 new scroll-gate tests, viewer mock now drives the new callback (existing 7 tests preserved)
- `studio/sanity.config.ts` — registers the new tool in capstone + RWC workspaces
- `studio/package.json` — adds `groq` direct dep so the Studio Tool can use `defineQuery`

## Post-review fixes (2026-04-29)

Self-review surfaced four issues — all addressed in commit `9b96718`:

1. **GROQ now wrapped in `defineQuery`** (project standard). `groq: ^5.8.1` added as a direct studio dep.
2. **Real bug fixed:** the GROQ projection asked for `title`, but the `sponsor` schema field is `name` — the sponsor-doc link was silently rendering `'Open'` as its label. Query, type, and render all updated to `name`.
3. **Dead `useEffect` dep removed:** `reloadCounter` `useRef` (whose mutation never triggers re-renders) replaced with `reloadKey` `useState` so the **Refresh** button actually re-fires the fetch effect.
4. **Browser runtime fix:** `IntentLink` is exported from `sanity/router`, not the `sanity` umbrella. The original import threw `SyntaxError: ... does not provide an export named 'IntentLink'` when loading the Studio at `localhost:3333`. Import + test mock split.

## Production environment configuration

Cloudflare Pages project `ywcc-capstone` (account `70bc6caa244ede05b7f964c0c2d533bb`) has `STUDIO_ADMIN_TOKEN` (secret) and `STUDIO_ORIGIN=https://ywcccapstone.sanity.studio` set on **both production and preview** environments. Studio host: `ywcccapstone.sanity.studio`. Astro app prod domain: `ywcccapstone1.com` — Studio's `SANITY_STUDIO_ACCEPTANCES_API_URL` therefore resolves to `https://ywcccapstone1.com/api/portal/admin/acceptances`.

## Operator runbook (post-merge)

1. **Generate a token (locally):**
   ```sh
   openssl rand -base64 32 | tr '/+' '_-' | tr -d '=' | sed 's/^/sat_/'
   ```
2. **Set the secret on the Worker / Pages project:**
   ```sh
   # Standalone Worker:
   cd astro-app && npx wrangler secret put STUDIO_ADMIN_TOKEN
   # Cloudflare Pages (this project):
   npx wrangler pages secret put STUDIO_ADMIN_TOKEN --project-name ywcc-capstone
   ```
3. **Set the same token on the Studio host (Sanity-managed deploys read from `studio/.env` at build time):**
   - `SANITY_STUDIO_ADMIN_TOKEN=<same value>`
   - `SANITY_STUDIO_ACCEPTANCES_API_URL=https://<your-domain>/api/portal/admin/acceptances`
4. **Confirm `STUDIO_ORIGIN`** on the Pages project: `https://ywcccapstone.sanity.studio`.
5. **Re-deploy the Studio:**
   ```sh
   npm run deploy -w studio
   ```

To rotate the token: re-run `wrangler pages secret put`, update the Studio env, redeploy. Old token is immediately invalid; no DB changes needed.

## Test plan

- [x] Unit suite green: `npm run test:unit` → 1881 passed / 3 skipped / 0 failed
- [x] `npm run build -w astro-app` clean
- [x] `cd studio && npm run build` clean
- [x] Studio loads at `localhost:3333` without the `IntentLink` SyntaxError (post-review fix verified)
- [ ] After merge + secrets set: log in as a sponsor with `agreement_accepted_at IS NULL`
  - Confirm the modal blocks until scrolled to the end of the PDF
  - Confirm the chevron + hint disappear after scrolling
  - Click Accept; confirm reload removes the modal
- [ ] After acceptance: open Sanity Studio → **Sponsor Acceptances** tab
  - Confirm the new acceptance row shows with a green badge and the correct timestamp
  - Confirm filter tabs (All / Accepted / Pending) work
  - Confirm search by email narrows the rows
  - Confirm the sponsor doc link shows the sponsor's `name` and routes into the desk for that sponsor
- [ ] Negative tests: hit `/api/portal/admin/acceptances` from a different origin → 403; with no/wrong bearer → 401; without the secret set → 503

## Notes for reviewers

- The endpoint deliberately does NOT use the user session cookie — Studio is a different actor on a different origin. Per-user OAuth is over-engineering for an admin-only Studio; a shared bearer + origin allow-list is the right granularity here.
- D1 stays the single source of truth — there is no sync into Sanity. The Studio tool joins by email at read time via a single GROQ query (`*[_type=="sponsor" && lower(contactEmail) in $emails]{ _id, contactEmail, name }`), now wrapped in `defineQuery`.
- The scroll gate uses an 8px tolerance to handle sub-pixel layout / momentum scrolling / zoom — exact equality on `scrollTop + clientHeight === scrollHeight` is fragile.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Sponsor Acceptances management tool in Sanity Studio for viewing, filtering (all/accepted/pending), searching, and refreshing acceptance records with links to matching sponsor docs.
  * Updated sponsor agreement flow: users must scroll agreement PDFs to the end before the accept checkbox/button is enabled.
  * New admin acceptances API to back the Studio tool and provide acceptances data and CORS-aware responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->