### PR TITLE
fix(studio): site-aware Presentation resolver + workspace tooling cleanup (Story 15.9)

### DIFF
--- a/astro-app/vitest.config.ts
+++ b/astro-app/vitest.config.ts
@@ -27,6 +27,7 @@ export default getViteConfig({
       "src/**/__tests__/**/*.test.ts",
       "src/**/__tests__/**/*.test.tsx",
       "../tests/integration/**/*.test.ts",
+      "../studio/src/__tests__/**/*.test.ts",
       "../studio/src/tools/__tests__/**/*.test.tsx",
     ],
     exclude: ["node_modules", "dist", ".astro"],

--- a/studio/sanity.config.ts
+++ b/studio/sanity.config.ts
@@ -1,5 +1,5 @@
-import {defineConfig, type WorkspaceOptions} from 'sanity'
-import {structureTool} from 'sanity/structure'
+import {defineConfig, type WorkspaceOptions, type PluginOptions} from 'sanity'
+import {structureTool, type StructureResolver} from 'sanity/structure'
 import {presentationTool} from 'sanity/presentation'
 import {visionTool} from '@sanity/vision'
 import {RocketIcon, EarthAmericasIcon, EarthGlobeIcon} from '@sanity/icons'
@@ -8,15 +8,52 @@ import {media} from 'sanity-plugin-media'
 import {createWorkspaceSchemaTypes} from './src/schemaTypes/workspace-utils'
 import {capstoneDeskStructure} from './src/structure/capstone-desk-structure'
 import {createRwcDeskStructure} from './src/structure/rwc-desk-structure'
-import {resolve} from './src/presentation/resolve'
+import {createResolve} from './src/presentation/resolve'
 import {
   CAPSTONE_SINGLETON_TYPES,
+  LISTING_PAGE_ROUTES,
   SITE_AWARE_TYPES,
 } from './src/constants'
+// Capstone-only — depends on `sponsorAgreement` document type, which RWC datasets do not ship.
 import {sponsorAcceptancesTool} from './src/tools/SponsorAcceptancesTool'
 
-// Environment variables for project configuration
-const projectId = process.env.SANITY_STUDIO_PROJECT_ID || '<your project ID>'
+// Environment variables for project configuration. Fail fast on missing
+// SANITY_STUDIO_PROJECT_ID — a placeholder fallback silently breaks every
+// Studio request and is impossible to diagnose from the resulting 404s.
+const projectId = process.env.SANITY_STUDIO_PROJECT_ID
+if (!projectId) {
+  throw new Error(
+    'SANITY_STUDIO_PROJECT_ID is required — set it in studio/.env or your deploy environment.',
+  )
+}
+
+interface CommonPluginsOptions {
+  structure: StructureResolver
+  previewOrigin: string
+  resolve: ReturnType<typeof createResolve>
+}
+
+/**
+ * Shared plugin set for every workspace. Capstone and RWC differ only in
+ * `structure`, `previewOrigin`, and Presentation `resolve` — every other
+ * plugin is identical, so changes (e.g. adding a new studio plugin) only
+ * need to land here.
+ */
+function commonPlugins(opts: CommonPluginsOptions): PluginOptions[] {
+  return [
+    structureTool({structure: opts.structure}),
+    presentationTool({
+      resolve: opts.resolve,
+      previewUrl: {
+        origin: opts.previewOrigin,
+        preview: '/',
+      },
+    }),
+    visionTool(),
+    media(),
+    formSchema({}),
+  ]
+}
 
 interface RwcWorkspaceOptions {
   name: string
@@ -37,20 +74,11 @@ function createRwcWorkspace(opts: RwcWorkspaceOptions): WorkspaceOptions {
     icon: opts.icon,
     projectId: opts.projectId,
     dataset: 'rwc',
-    plugins: [
-      structureTool({structure: createRwcDeskStructure(opts.siteId, opts.title)}),
-      presentationTool({
-        resolve,
-        previewUrl: {
-          origin: opts.originEnv || opts.defaultOrigin,
-          preview: '/',
-        },
-      }),
-      visionTool(),
-      media(),
-      formSchema({}),
-    ],
-    tools: (prev) => [...prev, sponsorAcceptancesTool()],
+    plugins: commonPlugins({
+      structure: createRwcDeskStructure(opts.siteId, opts.title),
+      previewOrigin: opts.originEnv || opts.defaultOrigin,
+      resolve: createResolve(opts.siteId),
+    }),
     schema: {
       types: createWorkspaceSchemaTypes('rwc'),
       templates: (prev) => {
@@ -69,7 +97,7 @@ function createRwcWorkspace(opts: RwcWorkspaceOptions): WorkspaceOptions {
           value: {site: opts.siteId},
         }))
         // Listing page singletons — pre-populate route for each (Story 21.0)
-        const listingTemplates = ['articles', 'authors', 'events', 'gallery', 'projects', 'sponsors'].map((route) => ({
+        const listingTemplates = LISTING_PAGE_ROUTES.map((route) => ({
           id: `listingPage-${route}-${opts.siteId}`,
           title: `Listing Page (${route.charAt(0).toUpperCase() + route.slice(1)}) — ${opts.title}`,
           schemaType: 'listingPage',
@@ -118,21 +146,12 @@ export default defineConfig([
     icon: RocketIcon,
     projectId,
     dataset: 'production',
-    plugins: [
-      structureTool({structure: capstoneDeskStructure}),
-      presentationTool({
-        resolve,
-        previewUrl: {
-          origin:
-            process.env.SANITY_STUDIO_PREVIEW_ORIGIN ||
-            'http://localhost:4321',
-          preview: '/',
-        },
-      }),
-      visionTool(),
-      media(),
-      formSchema({}),
-    ],
+    plugins: commonPlugins({
+      structure: capstoneDeskStructure,
+      previewOrigin:
+        process.env.SANITY_STUDIO_PREVIEW_ORIGIN || 'http://localhost:4321',
+      resolve: createResolve(undefined),
+    }),
     tools: (prev) => [...prev, sponsorAcceptancesTool()],
     schema: {
       types: createWorkspaceSchemaTypes('production'),
@@ -143,12 +162,12 @@ export default defineConfig([
         return [
           ...filtered,
           // Listing page singletons — pre-populate route for each (Story 21.0)
-          {id: 'listingPage-articles', schemaType: 'listingPage', title: 'Listing Page (Articles)', value: {route: 'articles'}},
-          {id: 'listingPage-authors', schemaType: 'listingPage', title: 'Listing Page (Authors)', value: {route: 'authors'}},
-          {id: 'listingPage-events', schemaType: 'listingPage', title: 'Listing Page (Events)', value: {route: 'events'}},
-          {id: 'listingPage-gallery', schemaType: 'listingPage', title: 'Listing Page (Gallery)', value: {route: 'gallery'}},
-          {id: 'listingPage-projects', schemaType: 'listingPage', title: 'Listing Page (Projects)', value: {route: 'projects'}},
-          {id: 'listingPage-sponsors', schemaType: 'listingPage', title: 'Listing Page (Sponsors)', value: {route: 'sponsors'}},
+          ...LISTING_PAGE_ROUTES.map((route) => ({
+            id: `listingPage-${route}`,
+            schemaType: 'listingPage',
+            title: `Listing Page (${route.charAt(0).toUpperCase() + route.slice(1)})`,
+            value: {route},
+          })),
           // Portal page singletons (Story 22.9)
           {id: 'portalPage-dashboard', schemaType: 'portalPage', title: 'Portal Page (Dashboard)', value: {route: 'dashboard'}},
           {id: 'portalPage-events', schemaType: 'portalPage', title: 'Portal Page (Events)', value: {route: 'events'}},

--- a/studio/src/__tests__/presentation-resolve.test.ts
+++ b/studio/src/__tests__/presentation-resolve.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Story 15.9: Site-aware Presentation resolve factory.
+ *
+ * Asserts that:
+ *  - In Capstone (siteId = undefined) `mainDocuments` filters carry NO site scope.
+ *  - In RWC workspaces every `mainDocuments` filter is appended with
+ *    `site == "<siteId>"` so Presentation never matches the wrong RWC site.
+ *
+ *  - LISTING_PAGE_ROUTES is the single source of truth (length 6, includes
+ *    'authors' so the Capstone Authors-last drift can never recur).
+ */
+import {describe, test, expect, vi} from 'vitest'
+
+vi.mock('sanity/presentation', () => ({
+  defineDocuments: <T,>(docs: T) => docs,
+  defineLocations: <T,>(loc: T) => loc,
+}))
+
+vi.mock('rxjs', () => ({
+  map: () => (source: unknown) => source,
+}))
+
+import {createResolve} from '../presentation/resolve'
+import {LISTING_PAGE_ROUTES} from '../constants'
+
+const ROUTES = ['/', '/sponsors/:slug', '/projects/:slug', '/events/:slug', '/:slug']
+
+describe('createResolve()', () => {
+  test('Capstone (siteId undefined): no `site ==` clause appears on any route filter', () => {
+    const resolve = createResolve(undefined)
+    const mainDocuments = resolve.mainDocuments as Array<{route: string; filter: string}>
+
+    expect(mainDocuments).toHaveLength(ROUTES.length)
+    for (const doc of mainDocuments) {
+      expect(doc.filter).not.toMatch(/site\s*==/)
+    }
+    // Sanity-check: home filter still queries the page document.
+    expect(mainDocuments[0].route).toBe('/')
+    expect(mainDocuments[0].filter).toContain('_type == "page"')
+    expect(mainDocuments[0].filter).toContain('slug.current == "home"')
+  })
+
+  test('RWC US (siteId "rwc-us"): every route filter is appended with `site == "rwc-us"`', () => {
+    const resolve = createResolve('rwc-us')
+    const mainDocuments = resolve.mainDocuments as Array<{route: string; filter: string}>
+
+    expect(mainDocuments).toHaveLength(ROUTES.length)
+    for (const doc of mainDocuments) {
+      expect(doc.filter).toContain('site == "rwc-us"')
+    }
+    expect(mainDocuments[0].filter).toBe(
+      '_type == "page" && slug.current == "home" && site == "rwc-us"',
+    )
+  })
+
+  test('RWC International (siteId "rwc-intl"): every route filter is appended with `site == "rwc-intl"` (and never "rwc-us")', () => {
+    const resolve = createResolve('rwc-intl')
+    const mainDocuments = resolve.mainDocuments as Array<{route: string; filter: string}>
+
+    for (const doc of mainDocuments) {
+      expect(doc.filter).toContain('site == "rwc-intl"')
+      expect(doc.filter).not.toContain('site == "rwc-us"')
+    }
+  })
+
+  test('All five expected routes are present in stable order (catch-all `/:slug` last)', () => {
+    const resolve = createResolve('rwc-us')
+    const mainDocuments = resolve.mainDocuments as Array<{route: string; filter: string}>
+    expect(mainDocuments.map((d) => d.route)).toEqual(ROUTES)
+  })
+
+  test('Returned shape matches PresentationPluginOptions["resolve"]', () => {
+    const resolve = createResolve(undefined)
+    expect(resolve).toHaveProperty('mainDocuments')
+    expect(resolve).toHaveProperty('locations')
+    expect(typeof resolve.locations).toBe('function')
+  })
+})
+
+describe('LISTING_PAGE_ROUTES (single source of truth)', () => {
+  test('contains all six routes, including authors', () => {
+    expect(LISTING_PAGE_ROUTES).toHaveLength(6)
+    expect(LISTING_PAGE_ROUTES).toContain('authors')
+    expect([...LISTING_PAGE_ROUTES]).toEqual([
+      'articles',
+      'authors',
+      'events',
+      'gallery',
+      'projects',
+      'sponsors',
+    ])
+  })
+
+  test('is readonly at the type level (immutable)', () => {
+    // `as const` produces a readonly tuple — runtime length stable.
+    const arr: ReadonlyArray<string> = LISTING_PAGE_ROUTES
+    expect(arr.length).toBe(6)
+  })
+})

--- a/studio/src/constants.ts
+++ b/studio/src/constants.ts
@@ -19,3 +19,22 @@ export const SITE_AWARE_TYPES = [
   'form',
   'submission',
 ]
+
+/**
+ * Single source of truth for listing-page singleton routes (Story 21.0).
+ * Consumed by:
+ *   - Capstone listing-page templates (`sanity.config.ts`)
+ *   - RWC listing-page templates (`sanity.config.ts` → `createRwcWorkspace`)
+ *   - Capstone desk structure (`structure/capstone-desk-structure.ts`)
+ *   - RWC desk structure   (`structure/rwc-desk-structure.ts`)
+ */
+export const LISTING_PAGE_ROUTES = [
+  'articles',
+  'authors',
+  'events',
+  'gallery',
+  'projects',
+  'sponsors',
+] as const
+
+export type ListingPageRoute = (typeof LISTING_PAGE_ROUTES)[number]

--- a/studio/src/presentation/resolve.ts
+++ b/studio/src/presentation/resolve.ts
@@ -2,142 +2,205 @@ import {
   defineDocuments,
   defineLocations,
   type DocumentLocationResolver,
-  type PresentationPluginOptions,
 } from 'sanity/presentation'
 import {map} from 'rxjs'
 
-// Main document resolvers — tell Presentation which document to open
-// when navigating to a given route in the preview iframe.
-export const mainDocuments = defineDocuments([
-  {
-    route: '/',
-    filter: `_type == "page" && slug.current == "home"`,
-  },
-  {
-    route: '/sponsors/:slug',
-    filter: `_type == "sponsor" && slug.current == $slug`,
-  },
-  {
-    route: '/projects/:slug',
-    filter: `_type == "project" && slug.current == $slug`,
-  },
-  {
-    route: '/events/:slug',
-    filter: `_type == "event" && slug.current == $slug`,
-  },
-  // Catch-all pages — must be last (first match wins)
-  {
-    route: '/:slug',
-    filter: `_type == "page" && slug.current == $slug`,
-  },
-])
-
 /**
- * Advanced location resolver for siteSettings.
- * Queries all pages in real-time and lists them as clickable navigation links
- * so editors can browse between pages from the Presentation tool.
+ * Build a Presentation `resolve` config scoped to a single workspace.
+ *
+ * - Capstone (single-site `production` dataset) calls `createResolve(undefined)` —
+ *   filters stay un-scoped because no `site` field exists.
+ * - RWC US / RWC Intl share the `rwc` dataset and discriminate via the `site`
+ *   field; pass the active workspace's `siteId` so Presentation only matches
+ *   documents belonging to that site.
+ *
+ * Without the site scope, `_type == "page" && slug.current == "home"` returns
+ * BOTH RWC home documents and Presentation arbitrarily picks one — typically
+ * surfacing as "clicking Home in RWC US opens the RWC International page".
  */
-const siteSettingsLocations: DocumentLocationResolver = (params, context) => {
-  if (params.type !== 'siteSettings') return null
+export function createResolve(siteId?: string) {
+  const siteFilter = siteId ? ` && site == "${siteId}"` : ''
 
-  const doc$ = context.documentStore.listenQuery(
-    `*[_type == "page" && defined(slug.current)] | order(title asc) { title, "slug": slug.current }`,
-    {},
-    {perspective: 'drafts'},
-  )
+  const mainDocuments = defineDocuments([
+    {
+      route: '/',
+      filter: `_type == "page" && slug.current == "home"${siteFilter}`,
+    },
+    {
+      route: '/sponsors/:slug',
+      filter: `_type == "sponsor" && slug.current == $slug${siteFilter}`,
+    },
+    {
+      route: '/projects/:slug',
+      filter: `_type == "project" && slug.current == $slug${siteFilter}`,
+    },
+    {
+      route: '/events/:slug',
+      filter: `_type == "event" && slug.current == $slug${siteFilter}`,
+    },
+    // Catch-all pages — must be last (first match wins)
+    {
+      route: '/:slug',
+      filter: `_type == "page" && slug.current == $slug${siteFilter}`,
+    },
+  ])
 
-  return doc$.pipe(
-    map((pages: Array<{title?: string; slug?: string}> | null) => {
-      if (!pages) {
+  /**
+   * Advanced location resolver for siteSettings: lists every page in the
+   * active workspace's site so editors can browse from the Presentation panel.
+   */
+  const siteSettingsLocations: DocumentLocationResolver = (params, context) => {
+    if (params.type !== 'siteSettings') return null
+
+    const query = siteId
+      ? `*[_type == "page" && defined(slug.current) && site == $site] | order(title asc) { title, "slug": slug.current }`
+      : `*[_type == "page" && defined(slug.current)] | order(title asc) { title, "slug": slug.current }`
+
+    const queryParams: Record<string, string> = siteId ? {site: siteId} : {}
+
+    const doc$ = context.documentStore.listenQuery(
+      query,
+      queryParams,
+      {perspective: 'drafts'},
+    )
+
+    return doc$.pipe(
+      map((pages: Array<{title?: string; slug?: string}> | null) => {
+        if (!pages) {
+          return {
+            message: 'This document is used on all pages',
+            tone: 'caution' as const,
+          }
+        }
+
         return {
           message: 'This document is used on all pages',
           tone: 'caution' as const,
+          locations: pages.map((page) => ({
+            title: page.title || 'Untitled',
+            href: page.slug === 'home' ? '/' : `/${page.slug}`,
+          })),
         }
-      }
-
-      return {
-        message: 'This document is used on all pages',
-        tone: 'caution' as const,
-        locations: pages.map((page) => ({
-          title: page.title || 'Untitled',
-          href: page.slug === 'home' ? '/' : `/${page.slug}`,
-        })),
-      }
-    }),
-  )
-}
-
-// Location resolvers — "Used on X pages" banner + quick-navigate links.
-export const locations: DocumentLocationResolver = (params, context) => {
-  // siteSettings: dynamic list of all pages
-  if (params.type === 'siteSettings') {
-    return siteSettingsLocations(params, context)
+      }),
+    )
   }
 
-  // All other types use defineLocations
-  const staticLocations: Record<string, ReturnType<typeof defineLocations>> = {
-    page: defineLocations({
-      select: {title: 'title', slug: 'slug.current'},
-      resolve: (doc) => ({
-        locations: [
-          {
-            title: doc?.title || 'Untitled',
-            href: doc?.slug === 'home' ? '/' : `/${doc?.slug}`,
-          },
-        ],
-      }),
-    }),
-    sponsor: defineLocations({
-      select: {title: 'name', slug: 'slug.current'},
-      resolve: (doc) => ({
-        locations: [
-          {
-            title: doc?.title || 'Untitled',
-            href: `/sponsors/${doc?.slug}`,
-          },
-          {
-            title: 'All Sponsors',
-            href: '/sponsors',
-          },
-        ],
-      }),
-    }),
-    project: defineLocations({
-      select: {title: 'title', slug: 'slug.current'},
-      resolve: (doc) => ({
-        locations: [
-          {
-            title: doc?.title || 'Untitled',
-            href: `/projects/${doc?.slug}`,
-          },
-          {
-            title: 'All Projects',
-            href: '/projects',
-          },
-        ],
-      }),
-    }),
-    event: defineLocations({
-      select: {title: 'title', slug: 'slug.current'},
-      resolve: (doc) => ({
-        locations: [
-          {
-            title: doc?.title || 'Untitled',
-            href: `/events/${doc?.slug}`,
-          },
-          {
-            title: 'All Events',
-            href: '/events',
-          },
-        ],
-      }),
-    }),
+  /**
+   * Guard that filters out documents whose `site` ≠ active workspace siteId.
+   * In Capstone (siteId undefined) we don't select `site` at all and pass
+   * through. In RWC workspaces, returning `null` from `resolve` hides the
+   * "Used on these pages" panel for cross-site documents.
+   */
+  const page = siteId
+    ? defineLocations({
+        select: {title: 'title', slug: 'slug.current', site: 'site'},
+        resolve: (doc) => {
+          if (doc?.site !== siteId) return null
+          return {
+            locations: [
+              {
+                title: doc?.title || 'Untitled',
+                href: doc?.slug === 'home' ? '/' : `/${doc?.slug}`,
+              },
+            ],
+          }
+        },
+      })
+    : defineLocations({
+        select: {title: 'title', slug: 'slug.current'},
+        resolve: (doc) => ({
+          locations: [
+            {
+              title: doc?.title || 'Untitled',
+              href: doc?.slug === 'home' ? '/' : `/${doc?.slug}`,
+            },
+          ],
+        }),
+      })
+
+  const sponsor = siteId
+    ? defineLocations({
+        select: {title: 'name', slug: 'slug.current', site: 'site'},
+        resolve: (doc) => {
+          if (doc?.site !== siteId) return null
+          return {
+            locations: [
+              {title: doc?.title || 'Untitled', href: `/sponsors/${doc?.slug}`},
+              {title: 'All Sponsors', href: '/sponsors'},
+            ],
+          }
+        },
+      })
+    : defineLocations({
+        select: {title: 'name', slug: 'slug.current'},
+        resolve: (doc) => ({
+          locations: [
+            {title: doc?.title || 'Untitled', href: `/sponsors/${doc?.slug}`},
+            {title: 'All Sponsors', href: '/sponsors'},
+          ],
+        }),
+      })
+
+  const project = siteId
+    ? defineLocations({
+        select: {title: 'title', slug: 'slug.current', site: 'site'},
+        resolve: (doc) => {
+          if (doc?.site !== siteId) return null
+          return {
+            locations: [
+              {title: doc?.title || 'Untitled', href: `/projects/${doc?.slug}`},
+              {title: 'All Projects', href: '/projects'},
+            ],
+          }
+        },
+      })
+    : defineLocations({
+        select: {title: 'title', slug: 'slug.current'},
+        resolve: (doc) => ({
+          locations: [
+            {title: doc?.title || 'Untitled', href: `/projects/${doc?.slug}`},
+            {title: 'All Projects', href: '/projects'},
+          ],
+        }),
+      })
+
+  const event = siteId
+    ? defineLocations({
+        select: {title: 'title', slug: 'slug.current', site: 'site'},
+        resolve: (doc) => {
+          if (doc?.site !== siteId) return null
+          return {
+            locations: [
+              {title: doc?.title || 'Untitled', href: `/events/${doc?.slug}`},
+              {title: 'All Events', href: '/events'},
+            ],
+          }
+        },
+      })
+    : defineLocations({
+        select: {title: 'title', slug: 'slug.current'},
+        resolve: (doc) => ({
+          locations: [
+            {title: doc?.title || 'Untitled', href: `/events/${doc?.slug}`},
+            {title: 'All Events', href: '/events'},
+          ],
+        }),
+      })
+
+  const locations: DocumentLocationResolver = (params, context) => {
+    if (params.type === 'siteSettings') {
+      return siteSettingsLocations(params, context)
+    }
+
+    const staticLocations: Record<string, ReturnType<typeof defineLocations>> = {
+      page,
+      sponsor,
+      project,
+      event,
+    }
+
+    return staticLocations[params.type] ?? null
   }
 
-  return staticLocations[params.type] ?? null
-}
-
-export const resolve: PresentationPluginOptions['resolve'] = {
-  mainDocuments,
-  locations,
+  return {mainDocuments, locations}
 }

--- a/studio/src/structure/capstone-desk-structure.ts
+++ b/studio/src/structure/capstone-desk-structure.ts
@@ -1,6 +1,6 @@
 import {CogIcon, DashboardIcon, DocumentsIcon, DocumentTextIcon, EnvelopeIcon} from '@sanity/icons'
 import type {StructureBuilder} from 'sanity/structure'
-import {CAPSTONE_SINGLETON_TYPES} from '../constants'
+import {CAPSTONE_SINGLETON_TYPES, LISTING_PAGE_ROUTES} from '../constants'
 
 export const capstoneDeskStructure = (S: StructureBuilder) =>
   S.list()
@@ -21,56 +21,18 @@ export const capstoneDeskStructure = (S: StructureBuilder) =>
         .child(
           S.list()
             .title('Listing Pages')
-            .items([
-              S.listItem()
-                .title('Articles')
-                .child(
-                  S.document()
-                    .schemaType('listingPage')
-                    .documentId('listingPage-articles')
-                    .initialValueTemplate('listingPage-articles'),
-                ),
-              S.listItem()
-                .title('Events')
-                .child(
-                  S.document()
-                    .schemaType('listingPage')
-                    .documentId('listingPage-events')
-                    .initialValueTemplate('listingPage-events'),
-                ),
-              S.listItem()
-                .title('Gallery')
-                .child(
-                  S.document()
-                    .schemaType('listingPage')
-                    .documentId('listingPage-gallery')
-                    .initialValueTemplate('listingPage-gallery'),
-                ),
-              S.listItem()
-                .title('Projects')
-                .child(
-                  S.document()
-                    .schemaType('listingPage')
-                    .documentId('listingPage-projects')
-                    .initialValueTemplate('listingPage-projects'),
-                ),
-              S.listItem()
-                .title('Sponsors')
-                .child(
-                  S.document()
-                    .schemaType('listingPage')
-                    .documentId('listingPage-sponsors')
-                    .initialValueTemplate('listingPage-sponsors'),
-                ),
-              S.listItem()
-                .title('Authors')
-                .child(
-                  S.document()
-                    .schemaType('listingPage')
-                    .documentId('listingPage-authors')
-                    .initialValueTemplate('listingPage-authors'),
-                ),
-            ]),
+            .items(
+              LISTING_PAGE_ROUTES.map((route) =>
+                S.listItem()
+                  .title(route.charAt(0).toUpperCase() + route.slice(1))
+                  .child(
+                    S.document()
+                      .schemaType('listingPage')
+                      .documentId(`listingPage-${route}`)
+                      .initialValueTemplate(`listingPage-${route}`),
+                  ),
+              ),
+            ),
         ),
       // Singleton group: Portal Pages (Story 22.9)
       S.listItem()

--- a/studio/src/structure/rwc-desk-structure.ts
+++ b/studio/src/structure/rwc-desk-structure.ts
@@ -1,6 +1,6 @@
 import {CogIcon, DocumentsIcon, EnvelopeIcon} from '@sanity/icons'
 import type {StructureBuilder} from 'sanity/structure'
-import {SITE_AWARE_TYPES} from '../constants'
+import {LISTING_PAGE_ROUTES, SITE_AWARE_TYPES} from '../constants'
 
 /**
  * Singletons and top-level-special doc types that must be excluded from the
@@ -50,16 +50,15 @@ export function createRwcDeskStructure(siteId: string, siteTitle: string) {
             S.list()
               .title('Listing Pages')
               .items(
-                ['articles', 'authors', 'events', 'gallery', 'projects', 'sponsors'].map(
-                  (route) =>
-                    S.listItem()
-                      .title(route.charAt(0).toUpperCase() + route.slice(1))
-                      .child(
-                        S.document()
-                          .schemaType('listingPage')
-                          .documentId(`listingPage-${route}-${siteId}`)
-                          .initialValueTemplate(`listingPage-${route}-${siteId}`),
-                      ),
+                LISTING_PAGE_ROUTES.map((route) =>
+                  S.listItem()
+                    .title(route.charAt(0).toUpperCase() + route.slice(1))
+                    .child(
+                      S.document()
+                        .schemaType('listingPage')
+                        .documentId(`listingPage-${route}-${siteId}`)
+                        .initialValueTemplate(`listingPage-${route}-${siteId}`),
+                    ),
                 ),
               ),
           ),

--- a/tests/integration/schema-polish-7-12/schema-polish.test.ts
+++ b/tests/integration/schema-polish-7-12/schema-polish.test.ts
@@ -40,7 +40,12 @@ import { blockBaseFields } from '../../../studio/src/schemaTypes/objects/block-b
 import { button } from '../../../studio/src/schemaTypes/objects/button'
 
 // Presentation
-import { resolve } from '../../../studio/src/presentation/resolve'
+import { createResolve } from '../../../studio/src/presentation/resolve'
+
+// Story 15.9: `resolve` is now produced by a workspace-scoped factory.
+// AC6 just verifies the resolver shape — Capstone (siteId undefined) is
+// equivalent to the previous static export.
+const resolve = createResolve(undefined)
 
 // Helper to get fields from a schema
 function getFields(schema: any): any[] {


### PR DESCRIPTION
## Summary

Fixes a multi-workspace bug where clicking **Home** in the **RWC US** workspace's Presentation tool would open the **RWC International** home page (and vice-versa). Also cleans up three smaller drifts that surfaced during the same code review.

Story: `_bmad-output/implementation-artifacts/15-9-fix-studio-workspace-presentation-and-tooling.md`

---

## Why was Home opening the wrong site?

Both RWC workspaces (RWC US and RWC International) share the **same Sanity dataset** (`rwc`). The way they tell each other apart is a `site` field on every document — `"rwc-us"` or `"rwc-intl"`.

Sanity's Presentation tool uses a GROQ query to figure out which document to open when you click "Home". The old query was:

```groq
_type == "page" && slug.current == "home"
```

That returns **both** sites' home pages. Presentation then picked one arbitrarily (it ended up being RWC International most of the time because `rwc-intl` sorts before `rwc-us` alphabetically by `_id`).

The fix: pass the active workspace's `siteId` into the resolver and append `&& site == "rwc-us"` (or `"rwc-intl"`) to every filter. Capstone uses a different dataset (`production`) that has no `site` field, so it keeps the old behaviour.

---

## What changed (in plain English)

1. **`studio/src/presentation/resolve.ts`** — was a single shared object; is now a `createResolve(siteId?)` function. Each workspace calls it with its own `siteId`. The function adds a `site == "<id>"` clause to every Presentation query so the right site's documents are always returned.

2. **`studio/sanity.config.ts`**
   - The shared list of plugins (StructureTool, PresentationTool, Vision, Media, FormToolkit) was duplicated between Capstone and RWC. Extracted to a `commonPlugins(opts)` helper — adding a new plugin now needs **one edit instead of three**.
   - The Sponsor Acceptances tool (a custom Studio tool that depends on the `sponsorAgreement` document type) is no longer registered in RWC workspaces, where that document type doesn't exist.
   - Missing `SANITY_STUDIO_PROJECT_ID` now throws a clear error at startup. Previously it silently used `'<your project ID>'` as a placeholder, which broke every Studio request without an obvious reason.

3. **`studio/src/constants.ts`** — added `LISTING_PAGE_ROUTES` (a frozen list of the six listing-page routes: articles, authors, events, gallery, projects, sponsors). Both desk structures and both template arrays now derive from this single constant.
   - Bonus: Capstone's listing-page menu used to put **Authors last**; RWC put it **second**. Now both match the constant's order, so the menu is consistent.

4. **Tests** — new `studio/src/__tests__/presentation-resolve.test.ts` (7 cases) asserts the GROQ filter strings directly:
   - Capstone has **no** `site ==` clause anywhere
   - RWC US has `site == "rwc-us"` on all 5 routes
   - RWC International has `site == "rwc-intl"` (and never `"rwc-us"`)
   - `LISTING_PAGE_ROUTES` shape is stable

---

## What did NOT change

- **No schema changes.** No documents, fields, or types were added/modified. **No `npx sanity schema deploy` or `npm run typegen` is required.**
- **No Astro app changes** beyond `astro-app/vitest.config.ts` (added one glob so the new test file runs from `npm run test:unit`).
- **`studio/sanity.cli.ts`** still has the same `'<your project ID>'` placeholder fallback — out of scope per the story's file-touch list. Worth a follow-up if Studio CLI build hardening is wanted.
- **Out of scope** (separate astro-app concern, not this PR): the "5 clicks before blocks become editable in Presentation" overlay-attachment latency.

---

## Test plan

### Automated (already green)
- [x] `npm run test:unit` — 116 files / 1889 passed / 3 skipped / **0 regressions**
- [x] New `studio/src/__tests__/presentation-resolve.test.ts` — all 7 cases pass
- [x] Existing `tests/integration/schema-polish-7-12` AC6 (`7.12-INT-022`) — updated to use `createResolve(undefined)` and continues to pass
- [x] `cd studio && npx tsc --noEmit` — only **pre-existing** errors remain (verified via baseline `git stash` run); no new TS errors introduced

### Manual (please verify before merging — this is AC #12)

- [ ] `npm run dev -w studio`
- [ ] Open `http://localhost:3333/capstone` → Presentation → click **Home** → verify **Capstone** home opens
- [ ] Switch to `/rwc-us` → Presentation → click **Home** → verify **RWC US** home opens (NOT International)
- [ ] Switch to `/rwc-intl` → Presentation → click **Home** → verify **RWC International** home opens
- [ ] In each RWC workspace, click a sponsor / project / event location card → verify the document opened belongs to the active site
- [ ] Open Site Settings in RWC US → confirm "Used on these pages" lists only RWC US pages
- [ ] In RWC US, open the **Tools** menu → confirm **Sponsor Acceptances is NOT listed**
- [ ] In Capstone, open the **Tools** menu → confirm **Sponsor Acceptances IS listed**
- [ ] In RWC US, click **+ Create new → Page** → confirm the new doc opens with `site` pre-filled to `rwc-us`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Centralized and consolidated Studio plugin configuration across workspaces with shared helpers
  * Refactored listing page routes to use a programmatic, data-driven approach
  * Converted presentation resolve to a factory function for improved multi-site configuration handling
  * Added strict validation for required configuration values

* **Tests**
  * Added comprehensive tests for presentation resolve factory and listing route configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->