### PR TITLE
feat(portal): sponsor agreement gate redesign — drop scroll lock, pin version, capture audit (15.11)

### DIFF
--- a/astro-app/migrations/0009_add_agreement_version_and_audit.sql
+++ b/astro-app/migrations/0009_add_agreement_version_and_audit.sql
@@ -1,0 +1,5 @@
+-- Story 15.11: Sponsor Agreement Gate — version pinning + audit capture.
+-- Three NULL-able columns; no backfill (existing rows treated as version-drift on next request).
+ALTER TABLE user ADD COLUMN agreement_version TEXT;
+ALTER TABLE user ADD COLUMN agreement_accepted_ip TEXT;
+ALTER TABLE user ADD COLUMN agreement_accepted_user_agent TEXT;

--- a/astro-app/src/__tests__/middleware-agreement.test.ts
+++ b/astro-app/src/__tests__/middleware-agreement.test.ts
@@ -17,6 +17,7 @@ const {
   mockD1Bind,
   mockD1Prepare,
   mockEnv,
+  mockGetRev,
 } = vi.hoisted(() => {
   const mockGetSession = vi.fn();
   const mockGetDrizzle = vi.fn().mockReturnValue({ __drizzle: true });
@@ -26,9 +27,10 @@ const {
   const mockKvPut = vi.fn().mockResolvedValue(undefined);
   const mockKvDelete = vi.fn().mockResolvedValue(undefined);
   const mockD1Run = vi.fn().mockResolvedValue({});
-  const mockD1First = vi.fn().mockResolvedValue({ agreement_accepted_at: null });
+  const mockD1First = vi.fn().mockResolvedValue({ agreement_accepted_at: null, agreement_version: null });
   const mockD1Bind = vi.fn().mockReturnValue({ run: mockD1Run, first: mockD1First });
   const mockD1Prepare = vi.fn().mockReturnValue({ bind: mockD1Bind });
+  const mockGetRev = vi.fn();
   // Adapter v13 reads bindings via `import { env } from "cloudflare:workers"`,
   // not `locals.runtime.env`. This object is the single source of truth: the
   // mocked module returns it AND tests mutate it through beforeEach.
@@ -57,6 +59,7 @@ const {
     mockD1Bind,
     mockD1Prepare,
     mockEnv,
+    mockGetRev,
   };
 });
 
@@ -66,8 +69,11 @@ vi.mock('@/lib/auth-config', () => ({
   checkSponsorWhitelist: mockCheckSponsorWhitelist,
 }));
 vi.mock('cloudflare:workers', () => ({ env: mockEnv }));
+vi.mock('@/lib/sanity', () => ({ getSponsorAgreementRev: mockGetRev }));
 
-import { onRequest } from '../middleware';
+import { onRequest, _resetAgreementRevCache } from '../middleware';
+
+const CURRENT_REV = 'rev-current-xyz';
 
 function createMockContext(pathname: string, headers?: Record<string, string>) {
   return {
@@ -84,6 +90,7 @@ const sessionCookie = 'better-auth.session_token=tok; Path=/';
 describe('middleware — sponsor agreement gate', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    _resetAgreementRevCache();
     import.meta.env.DEV = false;
     mockEnv.SESSION_CACHE = undefined;
     mockEnv.RATE_LIMITER = undefined;
@@ -91,14 +98,16 @@ describe('middleware — sponsor agreement gate', () => {
     mockKvPut.mockReset().mockResolvedValue(undefined);
     mockKvDelete.mockReset().mockResolvedValue(undefined);
     mockD1Run.mockReset().mockResolvedValue({});
-    mockD1First.mockReset().mockResolvedValue({ agreement_accepted_at: null });
+    mockD1First.mockReset().mockResolvedValue({ agreement_accepted_at: null, agreement_version: null });
     mockD1Bind.mockReset().mockReturnValue({ run: mockD1Run, first: mockD1First });
     mockD1Prepare.mockReset().mockReturnValue({ bind: mockD1Bind });
     mockCheckSponsorWhitelist.mockReset().mockResolvedValue(false);
+    mockGetRev.mockReset().mockResolvedValue(CURRENT_REV);
   });
 
   afterEach(() => {
     import.meta.env.DEV = false;
+    _resetAgreementRevCache();
   });
 
   it('sponsor with NULL acceptance sets requiresAgreement=true on gated portal route', async () => {
@@ -106,23 +115,74 @@ describe('middleware — sponsor agreement gate', () => {
       user: { id: '1', email: 's@co.com', name: 'Sponsor', role: 'sponsor' },
       session: { id: 's1', token: 'tok' },
     });
-    mockD1First.mockResolvedValueOnce({ agreement_accepted_at: null });
+    mockD1First.mockResolvedValueOnce({ agreement_accepted_at: null, agreement_version: null });
 
     const ctx = createMockContext('/portal/', { cookie: sessionCookie });
     await onRequest(ctx as never, mockNext);
 
     expect(ctx.locals.user?.role).toBe('sponsor');
     expect(ctx.locals.requiresAgreement).toBe(true);
-    expect(mockD1Prepare).toHaveBeenCalledWith('SELECT agreement_accepted_at FROM user WHERE LOWER(email) = ?');
+    expect(mockD1Prepare).toHaveBeenCalledWith(
+      'SELECT agreement_accepted_at, agreement_version FROM user WHERE LOWER(email) = ?',
+    );
     expect(mockD1Bind).toHaveBeenCalledWith('s@co.com');
   });
 
-  it('sponsor with existing timestamp sets requiresAgreement=false', async () => {
+  it('sponsor with matching version sets requiresAgreement=false (no prompt)', async () => {
     mockGetSession.mockResolvedValue({
       user: { id: '1', email: 's@co.com', name: 'Sponsor', role: 'sponsor' },
       session: { id: 's1', token: 'tok' },
     });
-    mockD1First.mockResolvedValueOnce({ agreement_accepted_at: 1234567890 });
+    mockD1First.mockResolvedValueOnce({ agreement_accepted_at: 1234567890, agreement_version: CURRENT_REV });
+
+    const ctx = createMockContext('/portal/', { cookie: sessionCookie });
+    await onRequest(ctx as never, mockNext);
+
+    expect(ctx.locals.requiresAgreement).toBe(false);
+  });
+
+  it('sponsor with mismatched version sets requiresAgreement=true (drift re-prompt)', async () => {
+    mockGetSession.mockResolvedValue({
+      user: { id: '1', email: 's@co.com', name: 'Sponsor', role: 'sponsor' },
+      session: { id: 's1', token: 'tok' },
+    });
+    mockD1First.mockResolvedValueOnce({
+      agreement_accepted_at: 1234567890,
+      agreement_version: 'rev-stale-old',
+    });
+
+    const ctx = createMockContext('/portal/', { cookie: sessionCookie });
+    await onRequest(ctx as never, mockNext);
+
+    expect(ctx.locals.requiresAgreement).toBe(true);
+  });
+
+  it('grandfathered sponsor (acceptedAt set, version NULL) is treated as drift → prompt', async () => {
+    mockGetSession.mockResolvedValue({
+      user: { id: '1', email: 's@co.com', name: 'Sponsor', role: 'sponsor' },
+      session: { id: 's1', token: 'tok' },
+    });
+    mockD1First.mockResolvedValueOnce({
+      agreement_accepted_at: 1234567890,
+      agreement_version: null,
+    });
+
+    const ctx = createMockContext('/portal/', { cookie: sessionCookie });
+    await onRequest(ctx as never, mockNext);
+
+    expect(ctx.locals.requiresAgreement).toBe(true);
+  });
+
+  it('Sanity rev fetch failure fails open — accepted sponsor with NULL rev does NOT re-prompt', async () => {
+    mockGetSession.mockResolvedValue({
+      user: { id: '1', email: 's@co.com', name: 'Sponsor', role: 'sponsor' },
+      session: { id: 's1', token: 'tok' },
+    });
+    mockD1First.mockResolvedValueOnce({
+      agreement_accepted_at: 1234567890,
+      agreement_version: 'rev-pinned',
+    });
+    mockGetRev.mockResolvedValueOnce(null);
 
     const ctx = createMockContext('/portal/', { cookie: sessionCookie });
     await onRequest(ctx as never, mockNext);
@@ -141,7 +201,7 @@ describe('middleware — sponsor agreement gate', () => {
 
     expect(ctx.locals.requiresAgreement).toBe(false);
     expect(mockD1Prepare).not.toHaveBeenCalledWith(
-      'SELECT agreement_accepted_at FROM user WHERE LOWER(email) = ?',
+      'SELECT agreement_accepted_at, agreement_version FROM user WHERE LOWER(email) = ?',
     );
   });
 
@@ -195,13 +255,14 @@ describe('middleware — sponsor agreement gate', () => {
     expect(mockD1Prepare).not.toHaveBeenCalled();
   });
 
-  it('uses cached agreementAcceptedAt from KV when present (no D1 call)', async () => {
+  it('uses cached agreementVersion + acceptedAt from KV when present (no D1 call)', async () => {
     mockEnv.SESSION_CACHE = { get: mockKvGet, put: mockKvPut, delete: mockKvDelete } as unknown;
     mockKvGet.mockResolvedValue({
       email: 's@co.com',
       name: 'Sponsor',
       role: 'sponsor',
       agreementAcceptedAt: 111,
+      agreementVersion: CURRENT_REV,
     });
 
     const ctx = createMockContext('/portal/', { cookie: sessionCookie });
@@ -209,28 +270,31 @@ describe('middleware — sponsor agreement gate', () => {
 
     expect(ctx.locals.requiresAgreement).toBe(false);
     expect(mockD1Prepare).not.toHaveBeenCalledWith(
-      'SELECT agreement_accepted_at FROM user WHERE LOWER(email) = ?',
+      'SELECT agreement_accepted_at, agreement_version FROM user WHERE LOWER(email) = ?',
     );
   });
 
-  it('KV cache missing the field triggers D1 lookup and re-caches', async () => {
+  it('KV cache missing the version field triggers D1 lookup and re-caches', async () => {
     mockEnv.SESSION_CACHE = { get: mockKvGet, put: mockKvPut, delete: mockKvDelete } as unknown;
     mockKvGet.mockResolvedValue({
       email: 's@co.com',
       name: 'Sponsor',
       role: 'sponsor',
-      // agreementAcceptedAt omitted — simulates pre-story cached session
+      agreementAcceptedAt: 111,
+      // agreementVersion omitted — simulates pre-story cached session
     });
-    mockD1First.mockResolvedValueOnce({ agreement_accepted_at: null });
+    mockD1First.mockResolvedValueOnce({ agreement_accepted_at: 111, agreement_version: CURRENT_REV });
 
     const ctx = createMockContext('/portal/', { cookie: sessionCookie });
     await onRequest(ctx as never, mockNext);
 
-    expect(ctx.locals.requiresAgreement).toBe(true);
-    expect(mockD1Prepare).toHaveBeenCalledWith('SELECT agreement_accepted_at FROM user WHERE LOWER(email) = ?');
+    expect(ctx.locals.requiresAgreement).toBe(false);
+    expect(mockD1Prepare).toHaveBeenCalledWith(
+      'SELECT agreement_accepted_at, agreement_version FROM user WHERE LOWER(email) = ?',
+    );
     expect(mockKvPut).toHaveBeenCalledWith(
       'tok',
-      expect.stringContaining('"agreementAcceptedAt":null'),
+      expect.stringContaining(`"agreementVersion":"${CURRENT_REV}"`),
       expect.objectContaining({ expirationTtl: 300 }),
     );
   });
@@ -249,5 +313,22 @@ describe('middleware — sponsor agreement gate', () => {
     expect(ctx.locals.requiresAgreement).toBe(true);
     expect(errSpy).toHaveBeenCalled();
     errSpy.mockRestore();
+  });
+
+  it('caches Sanity rev across requests (only one fetch within TTL)', async () => {
+    mockGetSession.mockResolvedValue({
+      user: { id: '1', email: 's@co.com', name: 'Sponsor', role: 'sponsor' },
+      session: { id: 's1', token: 'tok' },
+    });
+    mockD1First.mockResolvedValue({ agreement_accepted_at: 111, agreement_version: CURRENT_REV });
+
+    const ctx1 = createMockContext('/portal/', { cookie: sessionCookie });
+    await onRequest(ctx1 as never, mockNext);
+    const ctx2 = createMockContext('/portal/', { cookie: sessionCookie });
+    await onRequest(ctx2 as never, mockNext);
+    const ctx3 = createMockContext('/portal/', { cookie: sessionCookie });
+    await onRequest(ctx3 as never, mockNext);
+
+    expect(mockGetRev).toHaveBeenCalledTimes(1);
   });
 });

--- a/astro-app/src/components/portal/SponsorAgreementModal.tsx
+++ b/astro-app/src/components/portal/SponsorAgreementModal.tsx
@@ -45,7 +45,6 @@ export default function SponsorAgreementModal({
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [pdfReady, setPdfReady] = useState(false);
-  const [scrolledToEnd, setScrolledToEnd] = useState(false);
   const dialogRef = useRef<HTMLDivElement>(null);
   const acceptBtnRef = useRef<HTMLButtonElement>(null);
 
@@ -89,10 +88,9 @@ export default function SponsorAgreementModal({
 
   const isConfigured = Boolean(pdfUrl);
   const onPdfReady = useCallback((numPages: number) => setPdfReady(numPages > 0), []);
-  const onScrolledToEnd = useCallback(() => setScrolledToEnd(true), []);
 
   async function onAccept() {
-    if (!accepted || submitting || !pdfReady || !scrolledToEnd) return;
+    if (!accepted || submitting || !pdfReady) return;
     setSubmitting(true);
     setError(null);
     try {
@@ -139,26 +137,11 @@ export default function SponsorAgreementModal({
         </div>
 
         {isConfigured && pdfUrl ? (
-          <SponsorAgreementViewer
-            pdfUrl={pdfUrl}
-            maxHeight="60vh"
-            onReady={onPdfReady}
-            onScrolledToEnd={onScrolledToEnd}
-          />
+          <SponsorAgreementViewer pdfUrl={pdfUrl} maxHeight="60vh" onReady={onPdfReady} />
         ) : (
           <div className="border bg-muted/30 p-6 text-sm text-muted-foreground">
             Sponsor agreement is not yet configured. Please contact your program administrator.
           </div>
-        )}
-
-        {isConfigured && pdfReady && !scrolledToEnd && (
-          <p
-            id="agreement-scroll-hint"
-            className="text-xs text-muted-foreground"
-            data-testid="agreement-scroll-hint"
-          >
-            Scroll to the end of the agreement to enable acceptance.
-          </p>
         )}
 
         {isConfigured && (
@@ -167,8 +150,7 @@ export default function SponsorAgreementModal({
               type="checkbox"
               checked={accepted}
               onChange={(e) => setAccepted(e.target.checked)}
-              disabled={!pdfReady || !scrolledToEnd}
-              aria-describedby={pdfReady && !scrolledToEnd ? 'agreement-scroll-hint' : undefined}
+              disabled={!pdfReady}
               className="mt-1 size-4 shrink-0 border-input disabled:opacity-50"
               data-testid="agreement-checkbox"
             />
@@ -197,7 +179,7 @@ export default function SponsorAgreementModal({
               ref={acceptBtnRef}
               type="button"
               onClick={onAccept}
-              disabled={!accepted || submitting || !pdfReady || !scrolledToEnd}
+              disabled={!accepted || submitting || !pdfReady}
               data-testid="agreement-accept"
               className="bg-primary text-primary-foreground px-6 py-2 text-sm font-semibold uppercase tracking-wide transition-opacity disabled:opacity-50 disabled:cursor-not-allowed"
             >

--- a/astro-app/src/components/portal/SponsorAgreementViewer.tsx
+++ b/astro-app/src/components/portal/SponsorAgreementViewer.tsx
@@ -16,20 +16,15 @@ interface Props {
   /** Fires when the PDF reports its page count. Empty/corrupt PDFs report 0 — caller should
    *  use this to keep the accept checkbox/button disabled. */
   onReady?: (numPages: number) => void;
-  /** Fires once per mount when the user has scrolled to the end of the agreement (8px tolerance).
-   *  Short PDFs that fit entirely in the viewport fire this immediately after `onReady`. */
-  onScrolledToEnd?: () => void;
 }
 
 const DEFAULT_WIDTH = 800;
-const SCROLL_TOLERANCE_PX = 8;
 
 export default function SponsorAgreementViewer({
   pdfUrl,
   maxHeight = '70vh',
   className = '',
   onReady,
-  onScrolledToEnd,
 }: Props) {
   const containerRef = useRef<HTMLDivElement>(null);
   const [numPages, setNumPages] = useState<number | null>(null);
@@ -37,9 +32,6 @@ export default function SponsorAgreementViewer({
   // Default width keeps pages legible before/without ResizeObserver (older browsers).
   const [width, setWidth] = useState<number>(DEFAULT_WIDTH);
   const [reloadKey, setReloadKey] = useState(0);
-  const [scrolledToEnd, setScrolledToEnd] = useState(false);
-  const [renderedPages, setRenderedPages] = useState(0);
-  const hasFiredRef = useRef(false);
 
   // Debounced ResizeObserver: avoid thrashing pdfjs on every resize tick.
   useEffect(() => {
@@ -60,46 +52,8 @@ export default function SponsorAgreementViewer({
     };
   }, []);
 
-  // Scroll listener: fire onScrolledToEnd once when within 8px of the bottom.
-  useEffect(() => {
-    const el = containerRef.current;
-    if (!el || !onScrolledToEnd) return;
-    const onScroll = () => {
-      if (hasFiredRef.current) return;
-      if (el.scrollTop + el.clientHeight >= el.scrollHeight - SCROLL_TOLERANCE_PX) {
-        hasFiredRef.current = true;
-        setScrolledToEnd(true);
-        onScrolledToEnd();
-      }
-    };
-    el.addEventListener('scroll', onScroll, { passive: true });
-    return () => el.removeEventListener('scroll', onScroll);
-  }, [onScrolledToEnd]);
-
-  // Short-PDF auto-fire: once ALL pages have rendered (not just `onLoadSuccess`) and width has
-  // settled, measure scrollHeight. Without waiting for `onRenderSuccess`, the rAF tick can run
-  // while pages are still laying out, making `scrollHeight <= clientHeight` falsely true and
-  // bypassing the scroll gate on multi-page PDFs.
-  useEffect(() => {
-    const el = containerRef.current;
-    if (!el || !numPages || hasFiredRef.current || !onScrolledToEnd) return;
-    if (renderedPages < numPages) return;
-    const id = requestAnimationFrame(() => {
-      if (!el || hasFiredRef.current) return;
-      if (el.scrollHeight <= el.clientHeight + SCROLL_TOLERANCE_PX) {
-        hasFiredRef.current = true;
-        setScrolledToEnd(true);
-        onScrolledToEnd();
-      }
-    });
-    return () => cancelAnimationFrame(id);
-  }, [numPages, renderedPages, width, onScrolledToEnd]);
-
-  const onPageRendered = useCallback(() => setRenderedPages((n) => n + 1), []);
-
   const onDocumentLoadSuccess = useCallback(
     ({ numPages: n }: { numPages: number }) => {
-      setRenderedPages(0);
       setNumPages(n);
       onReady?.(n);
       if (n === 0) setLoadError('PDF is empty. Contact your program administrator.');
@@ -115,15 +69,9 @@ export default function SponsorAgreementViewer({
   const pages = useMemo(() => {
     if (!numPages) return null;
     return Array.from({ length: numPages }, (_, i) => (
-      <Page
-        key={`page-${i + 1}`}
-        pageNumber={i + 1}
-        width={width}
-        className="mb-2"
-        onRenderSuccess={onPageRendered}
-      />
+      <Page key={`page-${i + 1}`} pageNumber={i + 1} width={width} className="mb-2" />
     ));
-  }, [numPages, width, onPageRendered]);
+  }, [numPages, width]);
 
   return (
     <div className={`relative ${className}`}>
@@ -141,9 +89,6 @@ export default function SponsorAgreementViewer({
               onClick={() => {
                 setLoadError(null);
                 setNumPages(null);
-                setRenderedPages(0);
-                hasFiredRef.current = false;
-                setScrolledToEnd(false);
                 setReloadKey((k) => k + 1);
               }}
               className="text-sm underline"
@@ -163,28 +108,6 @@ export default function SponsorAgreementViewer({
           </Document>
         )}
       </div>
-      {!loadError && numPages != null && !scrolledToEnd && onScrolledToEnd && (
-        <span
-          aria-hidden="true"
-          data-testid="agreement-scroll-indicator"
-          className="pointer-events-none absolute bottom-3 right-3 inline-flex items-center gap-1 border bg-background/90 px-2 py-1 text-xs text-muted-foreground shadow"
-        >
-          Keep scrolling
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="12"
-            height="12"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-          >
-            <polyline points="6 9 12 15 18 9" />
-          </svg>
-        </span>
-      )}
     </div>
   );
 }

--- a/astro-app/src/components/portal/__tests__/SponsorAgreementModal.test.tsx
+++ b/astro-app/src/components/portal/__tests__/SponsorAgreementModal.test.tsx
@@ -81,14 +81,27 @@ const BASE_PROPS = {
 };
 
 describe('SponsorAgreementModal', () => {
+  let reloadSpy: ReturnType<typeof vi.fn>;
+
   beforeEach(() => {
     vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout', 'Date'] });
     viewerMockState.numPages = 3;
-    // @ts-expect-error jsdom - assign reload spy
-    window.location = { ...window.location, reload: vi.fn(), origin: 'http://localhost' };
+    // Stub `location` via vi.stubGlobal so vitest restores it cleanly between
+    // tests — direct `window.location =` assignment leaves Location in a broken
+    // state that breaks URL.prototype.toString() in any test sharing the worker
+    // (CI uses singleFork pool, so leakage is observable).
+    reloadSpy = vi.fn();
+    vi.stubGlobal('location', {
+      ...window.location,
+      reload: reloadSpy,
+      origin: window.location.origin,
+      href: window.location.href,
+      toString: () => window.location.href,
+    });
   });
 
   afterEach(() => {
+    vi.unstubAllGlobals();
     vi.useRealTimers();
     vi.restoreAllMocks();
     if (container) unmount();
@@ -147,7 +160,7 @@ describe('SponsorAgreementModal', () => {
       await Promise.resolve();
       await Promise.resolve();
     });
-    expect(window.location.reload).toHaveBeenCalled();
+    expect(reloadSpy).toHaveBeenCalled();
   });
 
   it('shows inline error on non-200/409 response and re-enables accept button', async () => {

--- a/astro-app/src/components/portal/__tests__/SponsorAgreementModal.test.tsx
+++ b/astro-app/src/components/portal/__tests__/SponsorAgreementModal.test.tsx
@@ -6,12 +6,11 @@ import { createRoot, type Root } from 'react-dom/client';
 // Silence React 19's "testing environment not configured for act(...)" warning
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
-// Mock the viewer to skip loading the pdfjs worker in jsdom.
-// Default: synchronously fires onReady (3 pages) AND onScrolledToEnd so existing tests
-// that don't care about the scroll gate work without modification.
-// Tests that exercise the scroll gate flip `viewerMockState.fireScrolledToEnd = false`.
+// Mock the viewer so jsdom doesn't load the pdfjs worker. The mock fires onReady with
+// `viewerMockState.numPages` synchronously on mount; tests that need the PDF to be "not ready"
+// flip the count to 0 (mirrors empty/corrupt PDF -> checkbox/button stay disabled).
 const { viewerMockState } = vi.hoisted(() => ({
-  viewerMockState: { fireScrolledToEnd: true },
+  viewerMockState: { numPages: 3 },
 }));
 
 vi.mock('../SponsorAgreementViewer', () => {
@@ -19,28 +18,14 @@ vi.mock('../SponsorAgreementViewer', () => {
     default: ({
       pdfUrl,
       onReady,
-      onScrolledToEnd,
     }: {
       pdfUrl: string;
       onReady?: (n: number) => void;
-      onScrolledToEnd?: () => void;
     }) => {
-      if (onReady) onReady(3);
-      if (onScrolledToEnd && viewerMockState.fireScrolledToEnd) onScrolledToEnd();
-      return (
-        <div data-testid="agreement-viewer-mock">
-          viewer: {pdfUrl}
-          {onScrolledToEnd && (
-            <button
-              type="button"
-              data-testid="mock-trigger-scroll-end"
-              onClick={() => onScrolledToEnd()}
-            >
-              fire-scroll-end
-            </button>
-          )}
-        </div>
-      );
+      React.useEffect(() => {
+        onReady?.(viewerMockState.numPages);
+      }, [onReady]);
+      return <div data-testid="agreement-viewer-mock">viewer: {pdfUrl}</div>;
     },
   };
 });
@@ -98,7 +83,7 @@ const BASE_PROPS = {
 describe('SponsorAgreementModal', () => {
   beforeEach(() => {
     vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout', 'Date'] });
-    viewerMockState.fireScrolledToEnd = true;
+    viewerMockState.numPages = 3;
     // @ts-expect-error jsdom - assign reload spy
     window.location = { ...window.location, reload: vi.fn(), origin: 'http://localhost' };
   });
@@ -118,14 +103,26 @@ describe('SponsorAgreementModal', () => {
     expect(container.querySelector('[data-testid="agreement-viewer-mock"]')).toBeTruthy();
   });
 
-  it('accept button is disabled until checkbox is checked', async () => {
+  it('checkbox is unchecked by default and accept button is disabled until it is checked', async () => {
     render(<SponsorAgreementModal {...BASE_PROPS} />);
+    const cb = container.querySelector('[data-testid="agreement-checkbox"]') as HTMLInputElement;
     const btn = container.querySelector('[data-testid="agreement-accept"]') as HTMLButtonElement;
+
+    expect(cb.checked).toBe(false);
     expect(btn.disabled).toBe(true);
 
-    const cb = container.querySelector('[data-testid="agreement-checkbox"]') as HTMLInputElement;
     await toggleCheckbox(cb);
+    expect(cb.checked).toBe(true);
     expect(btn.disabled).toBe(false);
+  });
+
+  it('checkbox + accept button are disabled while pdfReady=false (numPages=0)', () => {
+    viewerMockState.numPages = 0;
+    render(<SponsorAgreementModal {...BASE_PROPS} />);
+    const cb = container.querySelector('[data-testid="agreement-checkbox"]') as HTMLInputElement;
+    const btn = container.querySelector('[data-testid="agreement-accept"]') as HTMLButtonElement;
+    expect(cb.disabled).toBe(true);
+    expect(btn.disabled).toBe(true);
   });
 
   it('clicking accept POSTs to /api/portal/agreement/accept then reloads on 200', async () => {
@@ -201,35 +198,11 @@ describe('SponsorAgreementModal', () => {
     expect(document.body.style.overflow).toBe('');
   });
 
-  describe('scroll-to-accept gate', () => {
-    it('checkbox is disabled when pdfReady=true and scrolledToEnd=false', () => {
-      viewerMockState.fireScrolledToEnd = false;
-      render(<SponsorAgreementModal {...BASE_PROPS} />);
-      const cb = container.querySelector('[data-testid="agreement-checkbox"]') as HTMLInputElement;
-      expect(cb.disabled).toBe(true);
-    });
-
-    it('checkbox becomes enabled after the viewer fires onScrolledToEnd', async () => {
-      viewerMockState.fireScrolledToEnd = false;
-      render(<SponsorAgreementModal {...BASE_PROPS} />);
-      const cb = container.querySelector('[data-testid="agreement-checkbox"]') as HTMLInputElement;
-      expect(cb.disabled).toBe(true);
-
-      const trigger = container.querySelector('[data-testid="mock-trigger-scroll-end"]');
-      await click(trigger);
-
-      expect(cb.disabled).toBe(false);
-    });
-
-    it('hint text is visible when !scrolledToEnd, hidden when scrolledToEnd', async () => {
-      viewerMockState.fireScrolledToEnd = false;
-      render(<SponsorAgreementModal {...BASE_PROPS} />);
-      expect(container.querySelector('[data-testid="agreement-scroll-hint"]')).toBeTruthy();
-
-      const trigger = container.querySelector('[data-testid="mock-trigger-scroll-end"]');
-      await click(trigger);
-
-      expect(container.querySelector('[data-testid="agreement-scroll-hint"]')).toBeNull();
-    });
+  it('does not render a scroll hint or scroll-related aria-describedby', () => {
+    render(<SponsorAgreementModal {...BASE_PROPS} />);
+    expect(container.querySelector('[data-testid="agreement-scroll-hint"]')).toBeNull();
+    expect(container.querySelector('#agreement-scroll-hint')).toBeNull();
+    const cb = container.querySelector('[data-testid="agreement-checkbox"]');
+    expect(cb?.getAttribute('aria-describedby')).toBeNull();
   });
 });

--- a/astro-app/src/components/portal/__tests__/SponsorAgreementViewer.test.tsx
+++ b/astro-app/src/components/portal/__tests__/SponsorAgreementViewer.test.tsx
@@ -10,7 +10,7 @@ import { createRoot, type Root } from 'react-dom/client';
 const { documentMock, pageMock, mockState } = vi.hoisted(() => ({
   documentMock: vi.fn(),
   pageMock: vi.fn(),
-  mockState: { forceLoadError: false },
+  mockState: { forceLoadError: false, numPages: 3 },
 }));
 
 vi.mock('react-pdf', () => ({
@@ -29,21 +29,12 @@ vi.mock('react-pdf', () => ({
     documentMock(file);
     React.useEffect(() => {
       if (mockState.forceLoadError) onLoadError?.(new Error('boom'));
-      else onLoadSuccess?.({ numPages: 3 });
+      else onLoadSuccess?.({ numPages: mockState.numPages });
     }, [onLoadSuccess, onLoadError]);
     return <div data-testid="pdf-document">{children}</div>;
   },
-  Page: ({
-    pageNumber,
-    onRenderSuccess,
-  }: {
-    pageNumber: number;
-    onRenderSuccess?: () => void;
-  }) => {
+  Page: ({ pageNumber }: { pageNumber: number }) => {
     pageMock(pageNumber);
-    React.useEffect(() => {
-      onRenderSuccess?.();
-    }, [onRenderSuccess]);
     return <div data-testid="pdf-page" data-page={pageNumber} style={{ height: 600 }} />;
   },
 }));
@@ -81,218 +72,46 @@ async function flush() {
   });
 }
 
-function getViewerEl(): HTMLDivElement {
-  const el = container.querySelector<HTMLDivElement>('[data-testid="agreement-viewer"]');
-  if (!el) throw new Error('viewer container not found');
-  return el;
-}
-
-/** Override scroll metrics on a div so we can drive the scroll listener deterministically. */
-function setScrollMetrics(el: HTMLElement, opts: {
-  scrollTop: number;
-  clientHeight: number;
-  scrollHeight: number;
-}) {
-  Object.defineProperty(el, 'scrollTop', { configurable: true, get: () => opts.scrollTop });
-  Object.defineProperty(el, 'clientHeight', { configurable: true, get: () => opts.clientHeight });
-  Object.defineProperty(el, 'scrollHeight', { configurable: true, get: () => opts.scrollHeight });
-}
-
 beforeEach(() => {
   documentMock.mockClear();
   pageMock.mockClear();
   mockState.forceLoadError = false;
-  // Polyfill rAF for the short-pdf detection path
-  vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
-    return setTimeout(() => cb(performance.now()), 0) as unknown as number;
-  });
-  vi.stubGlobal('cancelAnimationFrame', (id: number) => clearTimeout(id as unknown as ReturnType<typeof setTimeout>));
-  // jsdom defaults scrollHeight/clientHeight to 0, which makes the short-PDF
-  // auto-fire path (scrollHeight <= clientHeight + 8) trigger spuriously
-  // during the rAF/flush race window. Pin prototype-level defaults to a
-  // "tall PDF" shape; tests that need a different shape override locally and
-  // restore via Reflect.deleteProperty in their finally{} block.
-  Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
-    configurable: true,
-    get: () => 1000,
-  });
-  Object.defineProperty(HTMLElement.prototype, 'clientHeight', {
-    configurable: true,
-    get: () => 200,
-  });
-  Object.defineProperty(HTMLElement.prototype, 'scrollTop', {
-    configurable: true,
-    get: () => 0,
-    set: () => {},
-  });
+  mockState.numPages = 3;
 });
 
 afterEach(() => {
-  vi.unstubAllGlobals();
   if (container) unmount();
-  // Tear down the prototype defaults so we don't leak into other test files
-  // that share the jsdom environment.
-  Reflect.deleteProperty(HTMLElement.prototype, 'scrollHeight');
-  Reflect.deleteProperty(HTMLElement.prototype, 'clientHeight');
-  Reflect.deleteProperty(HTMLElement.prototype, 'scrollTop');
 });
 
-describe('SponsorAgreementViewer — onScrolledToEnd', () => {
-  it('fires when scroll position reaches the bottom (within 8px tolerance)', async () => {
-    const onScrolledToEnd = vi.fn();
-    render(
-      <SponsorAgreementViewer
-        pdfUrl="/agreement.pdf"
-        onScrolledToEnd={onScrolledToEnd}
-      />,
-    );
+describe('SponsorAgreementViewer — onReady', () => {
+  it('fires onReady with numPages when the PDF reports its page count', async () => {
+    const onReady = vi.fn();
+    render(<SponsorAgreementViewer pdfUrl="/agreement.pdf" onReady={onReady} />);
     await flush();
-
-    const el = getViewerEl();
-    // Tall content, NOT at bottom → no fire
-    setScrollMetrics(el, { scrollTop: 0, clientHeight: 200, scrollHeight: 1000 });
-    await act(async () => {
-      el.dispatchEvent(new Event('scroll'));
-    });
-    expect(onScrolledToEnd).not.toHaveBeenCalled();
-
-    // Within tolerance (scrollHeight - (top+client) = 5 < 8)
-    setScrollMetrics(el, { scrollTop: 795, clientHeight: 200, scrollHeight: 1000 });
-    await act(async () => {
-      el.dispatchEvent(new Event('scroll'));
-    });
-    expect(onScrolledToEnd).toHaveBeenCalledTimes(1);
+    expect(onReady).toHaveBeenCalledTimes(1);
+    expect(onReady).toHaveBeenCalledWith(3);
   });
 
-  it('fires immediately for short PDFs that fit entirely in the viewport', async () => {
-    const onScrolledToEnd = vi.fn();
-
-    // Pre-set "fits in viewport" metrics on every fresh div the component creates.
-    // Patch at the prototype level for this test.
-    const origScrollHeight = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'scrollHeight');
-    const origClientHeight = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'clientHeight');
-    Object.defineProperty(HTMLElement.prototype, 'scrollHeight', { configurable: true, get: () => 200 });
-    Object.defineProperty(HTMLElement.prototype, 'clientHeight', { configurable: true, get: () => 400 });
-
-    try {
-      render(
-        <SponsorAgreementViewer
-          pdfUrl="/short.pdf"
-          onScrolledToEnd={onScrolledToEnd}
-        />,
-      );
-      // Wait for onLoadSuccess effect + rAF callback
-      await act(async () => {
-        await new Promise((r) => setTimeout(r, 20));
-      });
-      await flush();
-      expect(onScrolledToEnd).toHaveBeenCalledTimes(1);
-    } finally {
-      if (origScrollHeight) Object.defineProperty(HTMLElement.prototype, 'scrollHeight', origScrollHeight);
-      else Reflect.deleteProperty(HTMLElement.prototype, 'scrollHeight');
-      if (origClientHeight) Object.defineProperty(HTMLElement.prototype, 'clientHeight', origClientHeight);
-      else Reflect.deleteProperty(HTMLElement.prototype, 'clientHeight');
-    }
-  });
-
-  it('reload (Try again) resets the once-only guard so the user must scroll again', async () => {
-    const onScrolledToEnd = vi.fn();
-    // Force the container scrollable so the short-PDF auto-fire path doesn't trigger
-    Object.defineProperty(HTMLElement.prototype, 'scrollHeight', { configurable: true, get: () => 1000 });
-    Object.defineProperty(HTMLElement.prototype, 'clientHeight', { configurable: true, get: () => 200 });
-    Object.defineProperty(HTMLElement.prototype, 'scrollTop', { configurable: true, get: () => 0, set: () => {} });
-
-    try {
-      mockState.forceLoadError = true;
-      render(
-        <SponsorAgreementViewer
-          pdfUrl="/agreement.pdf"
-          onScrolledToEnd={onScrolledToEnd}
-        />,
-      );
-      await flush();
-
-      mockState.forceLoadError = false;
-      const btn = container.querySelector('button');
-      expect(btn?.textContent).toMatch(/try again/i);
-      await act(async () => {
-        btn?.click();
-      });
-      await act(async () => {
-        await new Promise((r) => setTimeout(r, 20));
-      });
-      await flush();
-
-      // After reload, onScrolledToEnd has not yet fired (PDF is scrollable, user hasn't scrolled).
-      expect(onScrolledToEnd).not.toHaveBeenCalled();
-
-      const el = getViewerEl();
-      setScrollMetrics(el, { scrollTop: 800, clientHeight: 200, scrollHeight: 1000 });
-      await act(async () => {
-        el.dispatchEvent(new Event('scroll'));
-      });
-      expect(onScrolledToEnd).toHaveBeenCalledTimes(1);
-    } finally {
-      Reflect.deleteProperty(HTMLElement.prototype, 'scrollHeight');
-      Reflect.deleteProperty(HTMLElement.prototype, 'clientHeight');
-      Reflect.deleteProperty(HTMLElement.prototype, 'scrollTop');
-    }
-  });
-
-  it('fires exactly once even when the user scrolls past the threshold multiple times', async () => {
-    const onScrolledToEnd = vi.fn();
-    render(
-      <SponsorAgreementViewer
-        pdfUrl="/agreement.pdf"
-        onScrolledToEnd={onScrolledToEnd}
-      />,
-    );
+  it('fires onReady(0) for empty PDFs and surfaces an error', async () => {
+    const onReady = vi.fn();
+    mockState.numPages = 0;
+    render(<SponsorAgreementViewer pdfUrl="/empty.pdf" onReady={onReady} />);
     await flush();
-
-    const el = getViewerEl();
-    setScrollMetrics(el, { scrollTop: 800, clientHeight: 200, scrollHeight: 1000 });
-    for (let i = 0; i < 5; i++) {
-      await act(async () => {
-        el.dispatchEvent(new Event('scroll'));
-      });
-    }
-    expect(onScrolledToEnd).toHaveBeenCalledTimes(1);
+    expect(onReady).toHaveBeenCalledWith(0);
+    expect(container.textContent).toMatch(/pdf is empty/i);
   });
 
-  it('hides the "Keep scrolling" indicator after onScrolledToEnd fires', async () => {
-    const onScrolledToEnd = vi.fn();
+  it('surfaces a reload UI on PDF load error', async () => {
+    mockState.forceLoadError = true;
+    render(<SponsorAgreementViewer pdfUrl="/agreement.pdf" />);
+    await flush();
+    const btn = container.querySelector('button');
+    expect(btn?.textContent).toMatch(/try again/i);
+  });
 
-    // Ensure scrollable (scrollHeight > clientHeight + tolerance) so the short-PDF auto-fire
-    // doesn't trip and the indicator is visible before the user scrolls.
-    Object.defineProperty(HTMLElement.prototype, 'scrollHeight', { configurable: true, get: () => 1000 });
-    Object.defineProperty(HTMLElement.prototype, 'clientHeight', { configurable: true, get: () => 200 });
-    Object.defineProperty(HTMLElement.prototype, 'scrollTop', { configurable: true, get: () => 0, set: () => {} });
-
-    try {
-      render(
-        <SponsorAgreementViewer
-          pdfUrl="/agreement.pdf"
-          onScrolledToEnd={onScrolledToEnd}
-        />,
-      );
-      await act(async () => {
-        await new Promise((r) => setTimeout(r, 20));
-      });
-      await flush();
-      expect(container.querySelector('[data-testid="agreement-scroll-indicator"]')).toBeTruthy();
-
-      const el = getViewerEl();
-      // Override on this specific element so we can simulate scroll-to-bottom
-      setScrollMetrics(el, { scrollTop: 800, clientHeight: 200, scrollHeight: 1000 });
-      await act(async () => {
-        el.dispatchEvent(new Event('scroll'));
-      });
-
-      expect(container.querySelector('[data-testid="agreement-scroll-indicator"]')).toBeNull();
-    } finally {
-      Reflect.deleteProperty(HTMLElement.prototype, 'scrollHeight');
-      Reflect.deleteProperty(HTMLElement.prototype, 'clientHeight');
-      Reflect.deleteProperty(HTMLElement.prototype, 'scrollTop');
-    }
+  it('does not render any scroll-gate indicator', async () => {
+    render(<SponsorAgreementViewer pdfUrl="/agreement.pdf" />);
+    await flush();
+    expect(container.querySelector('[data-testid="agreement-scroll-indicator"]')).toBeNull();
   });
 });

--- a/astro-app/src/lib/sanity.ts
+++ b/astro-app/src/lib/sanity.ts
@@ -1093,6 +1093,11 @@ export const SPONSOR_AGREEMENT_QUERY = defineQuery(groq`*[_type == "sponsorAgree
   bodyContent[]${PORTABLE_TEXT_PROJECTION}
 }`);
 
+/** Minimal rev-only projection for version pinning — used by accept endpoint + middleware drift check. */
+export const SPONSOR_AGREEMENT_REV_QUERY = defineQuery(
+  groq`*[_type == "sponsorAgreement" && _id == $id][0]{ "rev": _rev }`,
+);
+
 function getSponsorAgreementId(): string {
   // Single agreement document for the capstone workspace. RWC workspaces don't expose a portal,
   // so a site-scoped variant is intentionally not constructed here.
@@ -1117,6 +1122,29 @@ export async function getSponsorAgreement(): Promise<SPONSOR_AGREEMENT_QUERY_RES
     return result ?? null;
   } catch (err) {
     console.error('getSponsorAgreement failed; falling back to null', err);
+    return null;
+  }
+}
+
+/**
+ * Fetch the current sponsor agreement Sanity `_rev`. Used to pin per-user acceptance to a
+ * specific document revision (audit trail) and to detect version drift in middleware.
+ *
+ * Bypasses `loadQuery` (which applies stega + sync tag collection) — neither matters for an
+ * opaque rev string. Hits the Sanity client directly with `useCdn: true` semantics, so the
+ * worst-case staleness is ~60s API CDN edge cache. Returns null on any error so callers
+ * fail-open (accept endpoint writes `agreement_version = NULL`; middleware skips the gate).
+ */
+export async function getSponsorAgreementRev(): Promise<string | null> {
+  const id = getSponsorAgreementId();
+  try {
+    const result = await sanityClient.fetch<{ rev: string | null } | null>(
+      SPONSOR_AGREEMENT_REV_QUERY,
+      { id },
+    );
+    return result?.rev ?? null;
+  } catch (err) {
+    console.error('getSponsorAgreementRev failed; returning null', err);
     return null;
   }
 }

--- a/astro-app/src/middleware.ts
+++ b/astro-app/src/middleware.ts
@@ -17,13 +17,43 @@ const jsonError = (status: number, error: string) =>
     headers: { "content-type": "application/json" },
   });
 
-/** Shape stored in SESSION_CACHE. `agreementAcceptedAt === undefined` means the cache predates the field. */
+/** Shape stored in SESSION_CACHE. `undefined` on either field means the cache predates that field
+ *  and we should re-query D1 (mirrors the original `agreementAcceptedAt === undefined` fallback). */
 type CachedSession = {
   email: string;
   name: string;
   role: string;
   agreementAcceptedAt?: number | null;
+  agreementVersion?: string | null;
 };
+
+/** Module-scope cache of the current Sanity sponsor-agreement `_rev`. Persists across requests
+ *  within a Worker isolate (CF reuses isolates aggressively), so cache hit rate is very high.
+ *  Cold-start penalty is one Sanity API call per isolate, ~50ms. 5-min worst-case lag between
+ *  agreement publish and re-prompt — acceptable for a doc that changes ~1×/year. */
+let _agreementRevCache: { rev: string | null; expiresAt: number } | null = null;
+const AGREEMENT_REV_TTL_MS = 5 * 60 * 1000;
+
+async function getCurrentAgreementRev(): Promise<string | null> {
+  const now = Date.now();
+  if (_agreementRevCache && _agreementRevCache.expiresAt > now) {
+    return _agreementRevCache.rev;
+  }
+  try {
+    const { getSponsorAgreementRev } = await import("@/lib/sanity");
+    const rev = await getSponsorAgreementRev();
+    _agreementRevCache = { rev, expiresAt: now + AGREEMENT_REV_TTL_MS };
+    return rev;
+  } catch (err) {
+    console.warn("[middleware-agreement] rev fetch failed; failing open", err);
+    return null;
+  }
+}
+
+/** Test-only: reset the module-scope rev cache. */
+export function _resetAgreementRevCache(): void {
+  _agreementRevCache = null;
+}
 
 /** Better Auth session user shape including custom additionalFields */
 interface SessionUser {
@@ -204,14 +234,21 @@ export const onRequest = defineMiddleware(async (context, next) => {
       PORTAL_PUBLIC_PATHS.has(cleanPath) || cleanPath === AGREEMENT_ACCEPT_PATH;
     if (userData.role === "sponsor" && !skipsAgreementPath) {
       let agreementAcceptedAt = userData.agreementAcceptedAt ?? null;
-      if (userData.agreementAcceptedAt === undefined && runtimeEnv?.PORTAL_DB) {
+      let agreementVersion = userData.agreementVersion ?? null;
+      const cacheMissesAcceptance = userData.agreementAcceptedAt === undefined;
+      const cacheMissesVersion = userData.agreementVersion === undefined;
+      if ((cacheMissesAcceptance || cacheMissesVersion) && runtimeEnv?.PORTAL_DB) {
         try {
           const row = await runtimeEnv.PORTAL_DB
-            .prepare("SELECT agreement_accepted_at FROM user WHERE LOWER(email) = ?")
+            .prepare(
+              "SELECT agreement_accepted_at, agreement_version FROM user WHERE LOWER(email) = ?",
+            )
             .bind(userData.email)
-            .first<{ agreement_accepted_at: number | null }>();
+            .first<{ agreement_accepted_at: number | null; agreement_version: string | null }>();
           agreementAcceptedAt = row?.agreement_accepted_at ?? null;
+          agreementVersion = row?.agreement_version ?? null;
           userData.agreementAcceptedAt = agreementAcceptedAt;
+          userData.agreementVersion = agreementVersion;
           if (kvCache && sessionToken) {
             kvCache
               .put(sessionToken, JSON.stringify(userData), { expirationTtl: 300 })
@@ -222,9 +259,17 @@ export const onRequest = defineMiddleware(async (context, next) => {
           // A D1 outage blocks portal access rather than letting unaccepted sponsors through.
           console.error("[middleware] agreement lookup failed, failing closed:", e);
           agreementAcceptedAt = null;
+          agreementVersion = null;
         }
       }
-      context.locals.requiresAgreement = agreementAcceptedAt === null;
+      // Re-prompt when never accepted, OR when accepted against a different/null rev than the
+      // current Sanity revision. Rev fetch failure returns null (fail-open) — paired with a
+      // non-null version this short-circuits to "no prompt" so a Sanity outage doesn't lock
+      // sponsors out. Grandfathered rows (acceptedAt != null, version == null) re-prompt once
+      // because currentRev is non-null after first successful fetch.
+      const currentRev = await getCurrentAgreementRev();
+      const versionDrift = currentRev !== null && agreementVersion !== currentRev;
+      context.locals.requiresAgreement = agreementAcceptedAt === null || versionDrift;
     } else {
       context.locals.requiresAgreement = false;
     }

--- a/astro-app/src/pages/api/portal/admin/__tests__/acceptances.test.ts
+++ b/astro-app/src/pages/api/portal/admin/__tests__/acceptances.test.ts
@@ -7,19 +7,23 @@ const ORIGIN = 'https://capstone.sanity.studio';
 // `locals.runtime.env`. Hoist mocks so the cloudflare:workers stub can wire
 // them in before the route module loads. `mockEnv` is the live env object —
 // tests mutate it (or buildEnv overrides) by calling `setEnv` between cases.
-const { mockD1All, mockD1Prepare, mockEnv, defaultEnv } = vi.hoisted(() => {
+const { mockD1All, mockD1Bind, mockD1Prepare, mockEnv, defaultEnv, mockGetRev } = vi.hoisted(() => {
   const mockD1All = vi.fn();
-  const mockD1Prepare = vi.fn().mockReturnValue({ all: mockD1All });
+  // Two-call shape supported: `prepare(sql).all(...)` (no bind) and `prepare(sql).bind(arg).all(...)`.
+  const mockD1Bind = vi.fn().mockImplementation(() => ({ all: mockD1All }));
+  const mockD1Prepare = vi.fn().mockReturnValue({ bind: mockD1Bind, all: mockD1All });
   const defaultEnv: Record<string, unknown> = {
     PORTAL_DB: { prepare: mockD1Prepare },
     STUDIO_ADMIN_TOKEN: 'sat_test_token_value',
     STUDIO_ORIGIN: 'https://capstone.sanity.studio',
   };
   const mockEnv: Record<string, unknown> = { ...defaultEnv };
-  return { mockD1All, mockD1Prepare, mockEnv, defaultEnv };
+  const mockGetRev = vi.fn();
+  return { mockD1All, mockD1Bind, mockD1Prepare, mockEnv, defaultEnv, mockGetRev };
 });
 
 vi.mock('cloudflare:workers', () => ({ env: mockEnv }));
+vi.mock('@/lib/sanity', () => ({ getSponsorAgreementRev: mockGetRev }));
 
 const { GET, OPTIONS, ALL } = await import('../acceptances');
 
@@ -75,16 +79,32 @@ function buildCtx(opts: {
   };
 }
 
+const CURRENT_REV = 'rev-current-xyz';
+
 describe('GET /api/portal/admin/acceptances', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockD1All.mockReset().mockResolvedValue({
       results: [
-        { email: 'a@co.com', name: 'Alice', role: 'sponsor', agreement_accepted_at: 1700000000000 },
-        { email: 'b@co.com', name: 'Bob', role: 'sponsor', agreement_accepted_at: null },
+        {
+          email: 'a@co.com',
+          name: 'Alice',
+          role: 'sponsor',
+          agreement_accepted_at: 1700000000000,
+          agreement_version: CURRENT_REV,
+        },
+        {
+          email: 'b@co.com',
+          name: 'Bob',
+          role: 'sponsor',
+          agreement_accepted_at: null,
+          agreement_version: null,
+        },
       ],
     });
-    mockD1Prepare.mockReset().mockReturnValue({ all: mockD1All });
+    mockD1Bind.mockReset().mockImplementation(() => ({ all: mockD1All }));
+    mockD1Prepare.mockReset().mockReturnValue({ bind: mockD1Bind, all: mockD1All });
+    mockGetRev.mockReset().mockResolvedValue(CURRENT_REV);
   });
 
   it('returns 401 when authorization header is missing', async () => {
@@ -109,17 +129,82 @@ describe('GET /api/portal/admin/acceptances', () => {
     expect(await res.json()).toEqual({ error: 'forbidden_origin' });
   });
 
-  it('returns 200 with acceptances array on valid token + origin', async () => {
+  it('returns 200 with acceptances array on valid token + origin (includes agreementVersion + versionMatch)', async () => {
     const ctx = buildCtx({});
     const res = await GET(ctx as never);
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.acceptances).toEqual([
-      { email: 'a@co.com', name: 'Alice', role: 'sponsor', agreementAcceptedAt: 1700000000000 },
-      { email: 'b@co.com', name: 'Bob', role: 'sponsor', agreementAcceptedAt: null },
+      {
+        email: 'a@co.com',
+        name: 'Alice',
+        role: 'sponsor',
+        agreementAcceptedAt: 1700000000000,
+        agreementVersion: CURRENT_REV,
+        versionMatch: true,
+      },
+      {
+        email: 'b@co.com',
+        name: 'Bob',
+        role: 'sponsor',
+        agreementAcceptedAt: null,
+        agreementVersion: null,
+        versionMatch: null,
+      },
     ]);
+    expect(body.currentVersion).toBe(CURRENT_REV);
     expect(typeof body.generatedAt).toBe('number');
     expect(res.headers.get('access-control-allow-origin')).toBe(ORIGIN);
+  });
+
+  it('versionMatch=false when row has stale rev; null when grandfathered (no rev)', async () => {
+    mockD1All.mockResolvedValue({
+      results: [
+        { email: 'a@co.com', name: 'Alice', role: 'sponsor', agreement_accepted_at: 1, agreement_version: 'rev-old' },
+        { email: 'g@co.com', name: 'Grand', role: 'sponsor', agreement_accepted_at: 2, agreement_version: null },
+        { email: 'p@co.com', name: 'Pend', role: 'sponsor', agreement_accepted_at: null, agreement_version: null },
+      ],
+    });
+    const ctx = buildCtx({});
+    const res = await GET(ctx as never);
+    const body = await res.json();
+    expect(body.acceptances[0].versionMatch).toBe(false);
+    expect(body.acceptances[1].versionMatch).toBeNull();
+    expect(body.acceptances[2].versionMatch).toBeNull();
+  });
+
+  it('SELECT projection includes agreement_version', async () => {
+    const ctx = buildCtx({});
+    await GET(ctx as never);
+    const sql = mockD1Prepare.mock.calls[0][0];
+    expect(sql).toContain('agreement_version');
+  });
+
+  it('?versionDrift=true narrows query to non-null acceptance with mismatched/null version, binds currentRev', async () => {
+    const ctx = buildCtx({ search: '?versionDrift=true' });
+    await GET(ctx as never);
+    const sql = mockD1Prepare.mock.calls[0][0];
+    expect(sql).toContain('agreement_accepted_at IS NOT NULL');
+    expect(sql).toContain('(agreement_version IS NULL OR agreement_version != ?)');
+    expect(mockD1Bind).toHaveBeenCalledWith(CURRENT_REV);
+  });
+
+  it('?versionDrift=true with Sanity rev unavailable falls back to no drift filter (no empty-result trap)', async () => {
+    mockGetRev.mockResolvedValue(null);
+    const ctx = buildCtx({ search: '?versionDrift=true' });
+    await GET(ctx as never);
+    const sql = mockD1Prepare.mock.calls[0][0];
+    expect(sql).not.toContain('agreement_version IS NULL OR agreement_version != ?');
+    expect(mockD1Bind).not.toHaveBeenCalled();
+  });
+
+  it('versionMatch is null on every row when Sanity rev fetch fails (drift state unknown)', async () => {
+    mockGetRev.mockResolvedValue(null);
+    const ctx = buildCtx({});
+    const res = await GET(ctx as never);
+    const body = await res.json();
+    for (const row of body.acceptances) expect(row.versionMatch).toBeNull();
+    expect(body.currentVersion).toBeNull();
   });
 
   it('?accepted=true narrows query to non-null acceptance timestamps', async () => {

--- a/astro-app/src/pages/api/portal/admin/acceptances.ts
+++ b/astro-app/src/pages/api/portal/admin/acceptances.ts
@@ -1,5 +1,6 @@
 import type { APIRoute } from 'astro';
 import { env as workerEnv } from 'cloudflare:workers';
+import { getSponsorAgreementRev } from '@/lib/sanity';
 
 export const prerender = false;
 
@@ -11,6 +12,7 @@ interface AcceptanceRow {
   name: string;
   role: string;
   agreement_accepted_at: number | null;
+  agreement_version: string | null;
 }
 
 interface AdminEnv {
@@ -79,26 +81,54 @@ export const GET: APIRoute = async ({ request, url }) => {
   }
 
   const filter = url.searchParams.get('accepted'); // true | false | all | null
+  const versionDrift = url.searchParams.get('versionDrift') === 'true';
+
+  // Fetch current Sanity rev once per request — needed for both the SQL bind (when versionDrift
+  // filter is requested) and the per-row `versionMatch` derivation. Null on Sanity error → drift
+  // detection cannot happen; report `versionMatch: null` for rows so admins see "unknown" rather
+  // than a misleading "match" / "drift".
+  const currentRev = await getSponsorAgreementRev();
+
   let where = "role = 'sponsor'";
   if (filter === 'true') where += ' AND agreement_accepted_at IS NOT NULL';
   else if (filter === 'false') where += ' AND agreement_accepted_at IS NULL';
 
+  // Drift filter requires currentRev. Without it (Sanity error), we can't compute drift in SQL —
+  // fall back to "no drift filter applied" rather than returning empty results.
+  if (versionDrift && currentRev) {
+    where +=
+      ' AND agreement_accepted_at IS NOT NULL AND (agreement_version IS NULL OR agreement_version != ?)';
+  }
+
   // `agreement_accepted_at IS NULL` first puts NULLs after non-null when sorted DESC,
   // matching `NULLS LAST` semantics across all SQLite versions (D1 backend may vary).
   const sql =
-    `SELECT email, name, role, agreement_accepted_at FROM user WHERE ${where} ` +
+    `SELECT email, name, role, agreement_accepted_at, agreement_version FROM user WHERE ${where} ` +
     `ORDER BY agreement_accepted_at IS NULL, agreement_accepted_at DESC, email ASC`;
 
   try {
-    const rs = await env.PORTAL_DB.prepare(sql).all<AcceptanceRow>();
-    const acceptances = (rs.results ?? []).map((r) => ({
-      email: r.email,
-      name: r.name,
-      role: r.role,
-      agreementAcceptedAt: r.agreement_accepted_at,
-    }));
+    const stmt = env.PORTAL_DB.prepare(sql);
+    const bound = versionDrift && currentRev ? stmt.bind(currentRev) : stmt;
+    const rs = await bound.all<AcceptanceRow>();
+    const acceptances = (rs.results ?? []).map((r) => {
+      const accepted = r.agreement_accepted_at != null;
+      // versionMatch is `null` when there's no acceptance, when Sanity rev fetch failed, or when
+      // the row has no pinned version (grandfathered). Only `false` / `true` indicate a real check.
+      let versionMatch: boolean | null = null;
+      if (accepted && currentRev != null && r.agreement_version != null) {
+        versionMatch = r.agreement_version === currentRev;
+      }
+      return {
+        email: r.email,
+        name: r.name,
+        role: r.role,
+        agreementAcceptedAt: r.agreement_accepted_at,
+        agreementVersion: r.agreement_version,
+        versionMatch,
+      };
+    });
     return json(
-      { acceptances, generatedAt: Date.now() },
+      { acceptances, currentVersion: currentRev, generatedAt: Date.now() },
       200,
       {
         'cache-control': 'private, max-age=0, must-revalidate',

--- a/astro-app/src/pages/api/portal/agreement/__tests__/accept.test.ts
+++ b/astro-app/src/pages/api/portal/agreement/__tests__/accept.test.ts
@@ -14,6 +14,7 @@ const {
   mockKvPut,
   mockKvDelete,
   mockEnv,
+  mockGetRev,
 } = vi.hoisted(() => {
   const mockD1Run = vi.fn();
   const mockD1First = vi.fn();
@@ -22,14 +23,26 @@ const {
   const mockKvGet = vi.fn();
   const mockKvPut = vi.fn().mockResolvedValue(undefined);
   const mockKvDelete = vi.fn().mockResolvedValue(undefined);
+  const mockGetRev = vi.fn();
   const mockEnv: Record<string, unknown> = {
     PORTAL_DB: { prepare: mockD1Prepare },
     SESSION_CACHE: { get: mockKvGet, put: mockKvPut, delete: mockKvDelete },
   };
-  return { mockD1Run, mockD1First, mockD1Bind, mockD1Prepare, mockKvGet, mockKvPut, mockKvDelete, mockEnv };
+  return {
+    mockD1Run,
+    mockD1First,
+    mockD1Bind,
+    mockD1Prepare,
+    mockKvGet,
+    mockKvPut,
+    mockKvDelete,
+    mockEnv,
+    mockGetRev,
+  };
 });
 
 vi.mock('cloudflare:workers', () => ({ env: mockEnv }));
+vi.mock('@/lib/sanity', () => ({ getSponsorAgreementRev: mockGetRev }));
 
 const { POST, ALL } = await import('../accept');
 
@@ -53,6 +66,8 @@ function buildCtx(opts: {
   referer?: string | null;
   user?: { email: string; role: 'sponsor' | 'student' } | null;
   cookie?: string;
+  ip?: string | null;
+  userAgent?: string | null;
   env?: ReturnType<typeof buildEnv> | null;
   method?: string;
 }) {
@@ -62,6 +77,8 @@ function buildCtx(opts: {
   if (opts.requestOrigin !== null) headers.origin = opts.requestOrigin ?? origin;
   if (opts.referer) headers.referer = opts.referer;
   if (opts.cookie) headers.cookie = opts.cookie;
+  if (opts.ip) headers['cf-connecting-ip'] = opts.ip;
+  if (opts.userAgent) headers['user-agent'] = opts.userAgent;
 
   // Adapter v13: env now comes from the cloudflare:workers mock, not locals.
   if (opts.env === null) {
@@ -93,6 +110,7 @@ describe('POST /api/portal/agreement/accept', () => {
     mockKvGet.mockReset().mockResolvedValue(null);
     mockKvPut.mockReset().mockResolvedValue(undefined);
     mockKvDelete.mockReset().mockResolvedValue(undefined);
+    mockGetRev.mockReset().mockResolvedValue('rev-abc123');
   });
 
   it('returns 403 when both Origin and Referer are missing', async () => {
@@ -148,8 +166,8 @@ describe('POST /api/portal/agreement/accept', () => {
     expect(mockD1Run).not.toHaveBeenCalled();
   });
 
-  it('returns 409 when row exists with non-null acceptance', async () => {
-    mockD1First.mockResolvedValue({ agreement_accepted_at: 1690000000000 });
+  it('returns 409 only when row is accepted AND version matches current Sanity rev', async () => {
+    mockD1First.mockResolvedValue({ agreement_accepted_at: 1690000000000, agreement_version: 'rev-abc123' });
     const ctx = buildCtx({});
     const res = await POST(ctx as never);
     expect(res.status).toBe(409);
@@ -157,17 +175,41 @@ describe('POST /api/portal/agreement/accept', () => {
     expect(mockD1Run).not.toHaveBeenCalled();
   });
 
-  it('returns 200 on sponsor with NULL acceptance, lowercases email, refreshes KV with new timestamp', async () => {
+  it('allows re-acceptance (200) when row is accepted but version is NULL (grandfathered drift)', async () => {
+    mockD1First.mockResolvedValue({ agreement_accepted_at: 1690000000000, agreement_version: null });
+    const ctx = buildCtx({ cookie: 'better-auth.session_token=tok-xyz; Path=/' });
+    const res = await POST(ctx as never);
+    expect(res.status).toBe(200);
+    expect(mockD1Run).toHaveBeenCalledTimes(1);
+    expect(mockKvDelete).toHaveBeenCalledWith('tok-xyz');
+  });
+
+  it('allows re-acceptance (200) when version is stale (drift against current rev)', async () => {
+    mockD1First.mockResolvedValue({ agreement_accepted_at: 1690000000000, agreement_version: 'rev-stale-old' });
+    const ctx = buildCtx({});
+    const res = await POST(ctx as never);
+    expect(res.status).toBe(200);
+    expect(mockD1Run).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns 409 when accepted with NULL version AND Sanity rev fetch fails (cannot prove drift)', async () => {
+    mockGetRev.mockResolvedValue(null);
+    mockD1First.mockResolvedValue({ agreement_accepted_at: 1690000000000, agreement_version: null });
+    const ctx = buildCtx({});
+    const res = await POST(ctx as never);
+    // Without current rev, can't distinguish "real drift" from "Sanity outage on already-accepted user".
+    // Fail safe: keep the legacy timestamp-only semantics so we don't double-write on every request.
+    expect(res.status).toBe(409);
+    expect(mockD1Run).not.toHaveBeenCalled();
+  });
+
+  it('writes acceptedAt + agreementVersion + IP + UA, lowercases email, and invalidates KV', async () => {
     const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(1700000000000);
-    mockKvGet.mockResolvedValue({
-      email: 's@co.com',
-      name: 'Sponsor',
-      role: 'sponsor',
-      agreementAcceptedAt: null,
-    });
     const ctx = buildCtx({
       cookie: 'better-auth.session_token=tok-xyz; Path=/',
       user: { email: 'S@CO.com', role: 'sponsor' },
+      ip: '203.0.113.7',
+      userAgent: 'Mozilla/5.0 (Test)',
     });
 
     const res = await POST(ctx as never);
@@ -175,36 +217,51 @@ describe('POST /api/portal/agreement/accept', () => {
     expect(await res.json()).toEqual({ acceptedAt: 1700000000000 });
 
     expect(mockD1Prepare).toHaveBeenCalledWith(
-      'SELECT agreement_accepted_at FROM user WHERE LOWER(email) = ?',
+      'SELECT agreement_accepted_at, agreement_version FROM user WHERE LOWER(email) = ?',
     );
     expect(mockD1Prepare).toHaveBeenCalledWith(
-      'UPDATE user SET agreement_accepted_at = ? WHERE LOWER(email) = ?',
+      'UPDATE user SET agreement_accepted_at = ?, agreement_version = ?, agreement_accepted_ip = ?, agreement_accepted_user_agent = ? WHERE LOWER(email) = ?',
     );
     // Email is normalized to lowercase before binding
     expect(mockD1Bind).toHaveBeenCalledWith('s@co.com');
-    expect(mockD1Bind).toHaveBeenCalledWith(1700000000000, 's@co.com');
-    // KV is rewritten with the fresh timestamp, not deleted (avoids stale-cache reprompt)
-    expect(mockKvPut).toHaveBeenCalledWith(
-      'tok-xyz',
-      expect.stringContaining('"agreementAcceptedAt":1700000000000'),
-      expect.objectContaining({ expirationTtl: 300 }),
+    expect(mockD1Bind).toHaveBeenCalledWith(
+      1700000000000,
+      'rev-abc123',
+      '203.0.113.7',
+      'Mozilla/5.0 (Test)',
+      's@co.com',
     );
-    expect(mockKvDelete).not.toHaveBeenCalled();
+    // KV invalidation: delete the cached session so middleware re-reads D1 next request.
+    expect(mockKvDelete).toHaveBeenCalledWith('tok-xyz');
+    expect(mockKvPut).not.toHaveBeenCalled();
     nowSpy.mockRestore();
   });
 
-  it('deletes KV entry when no cached session was present (nothing to refresh)', async () => {
-    mockKvGet.mockResolvedValue(null);
+  it('writes NULL agreement_version when Sanity rev fetch fails (fail-open)', async () => {
+    mockGetRev.mockResolvedValue(null);
     const ctx = buildCtx({
       cookie: 'better-auth.session_token=tok-xyz; Path=/',
+      ip: '203.0.113.7',
+      userAgent: 'UA',
     });
+
     const res = await POST(ctx as never);
     expect(res.status).toBe(200);
-    expect(mockKvPut).not.toHaveBeenCalled();
-    expect(mockKvDelete).toHaveBeenCalledWith('tok-xyz');
+    // Second bind() call is the UPDATE — version arg must be null.
+    const updateBind = mockD1Bind.mock.calls.find((args) => args.length === 5);
+    expect(updateBind).toBeDefined();
+    expect(updateBind?.[1]).toBeNull();
   });
 
-  it('succeeds even when cookie is missing — KV refresh skipped', async () => {
+  it('binds NULL when cf-connecting-ip and user-agent headers are missing (local dev)', async () => {
+    const ctx = buildCtx({ cookie: 'better-auth.session_token=tok-xyz; Path=/' });
+    await POST(ctx as never);
+    const updateBind = mockD1Bind.mock.calls.find((args) => args.length === 5);
+    expect(updateBind?.[2]).toBeNull();
+    expect(updateBind?.[3]).toBeNull();
+  });
+
+  it('succeeds even when cookie is missing — KV invalidation skipped', async () => {
     const ctx = buildCtx({});
     const res = await POST(ctx as never);
     expect(res.status).toBe(200);

--- a/astro-app/src/pages/api/portal/agreement/accept.ts
+++ b/astro-app/src/pages/api/portal/agreement/accept.ts
@@ -1,6 +1,7 @@
 import type { APIRoute } from 'astro';
 import { env } from 'cloudflare:workers';
 import { extractSessionToken, normalizeEmail } from '@/middleware';
+import { getSponsorAgreementRev } from '@/lib/sanity';
 
 export const prerender = false;
 
@@ -24,7 +25,7 @@ function isSameOrigin(request: Request, expectedOrigin: string): boolean {
   }
 }
 
-export const POST: APIRoute = async ({ request, locals, url }) => {  // eslint-disable-line @typescript-eslint/no-unused-vars
+export const POST: APIRoute = async ({ request, locals, url }) => {
   // `locals` retained for `locals.user` (set by middleware); env now imported from cloudflare:workers.
   if (!isSameOrigin(request, url.origin)) {
     return json({ error: 'forbidden_origin' }, 403);
@@ -39,50 +40,55 @@ export const POST: APIRoute = async ({ request, locals, url }) => {  // eslint-d
   const email = normalizeEmail(user.email);
   const acceptedAt = Date.now();
 
-  // Read existing acceptance state first so we can distinguish three outcomes:
-  //   row missing      → 404 user_not_found
-  //   already accepted → 409 already_accepted
-  //   accepted now     → 200
+  // Read existing acceptance state first. With version pinning, "already accepted" means
+  //   "accepted against the CURRENT revision" — drift (NULL version, or stale rev) is a valid
+  //   re-acceptance path that the middleware actively re-prompts for.
+  //   row missing                                    → 404 user_not_found
+  //   accepted AND version matches current Sanity rev → 409 already_accepted
+  //   accepted but version differs/null OR not accepted yet → 200 (write fresh acceptance)
   const existing = await env.PORTAL_DB
-    .prepare('SELECT agreement_accepted_at FROM user WHERE LOWER(email) = ?')
+    .prepare('SELECT agreement_accepted_at, agreement_version FROM user WHERE LOWER(email) = ?')
     .bind(email)
-    .first<{ agreement_accepted_at: number | null }>();
+    .first<{ agreement_accepted_at: number | null; agreement_version: string | null }>();
 
   if (!existing) return json({ error: 'user_not_found' }, 404);
+
+  // Audit fields. `cf-connecting-ip` is Cloudflare-injected and trusted; falsifiable only by the
+  // originating client. UA is best-effort. Sanity rev is fail-open: a Sanity outage writes NULL
+  // rather than blocking acceptance — the row will trigger version-drift on next request and
+  // re-prompt once Sanity is reachable again.
+  const ip = request.headers.get('cf-connecting-ip');
+  const ua = request.headers.get('user-agent');
+  const rev = await getSponsorAgreementRev();
+
+  // 409 only when the user has truly already accepted the current published revision. Without a
+  // current rev (Sanity outage) we can't prove drift, so fall back to the old timestamp-only
+  // semantics rather than allowing accidental double-accepts.
   if (existing.agreement_accepted_at != null) {
-    return json({ error: 'already_accepted' }, 409);
+    const upToDate =
+      rev === null
+        ? true
+        : existing.agreement_version != null && existing.agreement_version === rev;
+    if (upToDate) return json({ error: 'already_accepted' }, 409);
   }
 
   await env.PORTAL_DB
-    .prepare('UPDATE user SET agreement_accepted_at = ? WHERE LOWER(email) = ?')
-    .bind(acceptedAt, email)
+    .prepare(
+      'UPDATE user SET agreement_accepted_at = ?, agreement_version = ?, agreement_accepted_ip = ?, agreement_accepted_user_agent = ? WHERE LOWER(email) = ?',
+    )
+    .bind(acceptedAt, rev, ip, ua, email)
     .run();
 
-  // Refresh KV session cache with the new acceptance timestamp. Writing rather than deleting
-  // means a propagation delay or write failure leaves a stale-but-still-correct entry, never a
-  // stale "unaccepted" entry that re-prompts the modal.
+  // Invalidate the cached session so middleware re-reads D1 on the next request and sees the new
+  // acceptance + version. Delete (rather than refresh) avoids smuggling a stale agreementVersion
+  // into the cached blob and keeps the gate behavior driven by D1.
   const sessionToken = extractSessionToken(request.headers.get('cookie'));
   if (sessionToken && env.SESSION_CACHE) {
     try {
-      const cached = await env.SESSION_CACHE.get<{
-        email: string;
-        name: string;
-        role: string;
-        agreementAcceptedAt?: number | null;
-      }>(sessionToken, { type: 'json' });
-      if (cached) {
-        await env.SESSION_CACHE.put(
-          sessionToken,
-          JSON.stringify({ ...cached, agreementAcceptedAt: acceptedAt }),
-          { expirationTtl: 300 },
-        );
-      } else {
-        await env.SESSION_CACHE.delete(sessionToken);
-      }
+      await env.SESSION_CACHE.delete(sessionToken);
     } catch (e) {
-      console.error('[agreement/accept] KV refresh failed:', e);
-      // Fall through — the D1 write succeeded, the modal will re-prompt up to 5 min until
-      // KV TTL expires. Log so ops can correlate user reports.
+      console.error('[agreement/accept] KV invalidation failed:', e);
+      // Fall through — D1 write succeeded; KV entry will TTL out within 5 min.
     }
   }
 

--- a/studio/src/tools/SponsorAcceptancesTool.tsx
+++ b/studio/src/tools/SponsorAcceptancesTool.tsx
@@ -28,6 +28,8 @@ interface Acceptance {
   name: string
   role: string
   agreementAcceptedAt: number | null
+  agreementVersion: string | null
+  versionMatch: boolean | null
 }
 
 interface SponsorDoc {
@@ -66,6 +68,11 @@ function formatAcceptedAt(value: number | null): string {
   } catch {
     return '—'
   }
+}
+
+function formatVersion(value: string | null): string {
+  if (!value) return '—'
+  return value.length > 8 ? value.slice(0, 8) : value
 }
 
 export function SponsorAcceptancesView(props: ToolConfig = {}) {
@@ -265,6 +272,9 @@ export function SponsorAcceptancesView(props: ToolConfig = {}) {
                   <Text size={1} weight="medium">Accepted At</Text>
                 </Box>
                 <Box flex={1}>
+                  <Text size={1} weight="medium">Version</Text>
+                </Box>
+                <Box flex={1}>
                   <Text size={1} weight="medium">Sponsor Doc</Text>
                 </Box>
               </Flex>
@@ -300,6 +310,18 @@ export function SponsorAcceptancesView(props: ToolConfig = {}) {
                       <Text size={1} muted={!accepted}>
                         {formatAcceptedAt(row.agreementAcceptedAt)}
                       </Text>
+                    </Box>
+                    <Box flex={1}>
+                      <Inline space={2}>
+                        <Text size={1} muted={!row.agreementVersion} data-testid="acceptances-version">
+                          <code>{formatVersion(row.agreementVersion)}</code>
+                        </Text>
+                        {row.versionMatch === false && (
+                          <Badge tone="caution" mode="outline" data-testid="acceptances-drift-badge">
+                            Drift
+                          </Badge>
+                        )}
+                      </Inline>
                     </Box>
                     <Box flex={1}>
                       {doc ? (


### PR DESCRIPTION
## What this changes (in plain English)

The sponsor portal shows a one-time agreement modal the first time a sponsor signs in. This PR rewrites that modal in three ways:

1. **No more scrolling required.** The old version made you scroll to the bottom of the PDF before the "Accept" button would unlock. That pattern is illegal-ish (US e-sign case law calls it a "dark pattern"), broken for screen readers, and was actually bypassing itself on widescreen monitors anyway. We just show an unchecked checkbox now — you tick it, click Accept, you're in.

2. **Each acceptance is pinned to a specific version of the agreement document.** Today, when an editor publishes a new version of the agreement in Sanity Studio, every existing sponsor's "I accepted" timestamp silently transfers to the new document — which is bad if a court ever asks "which version of this agreement did Jay actually agree to?" Now we record the Sanity document's `_rev` (a unique ID for that exact version) on every acceptance, plus the sponsor's IP address and browser. If the document changes later, the sponsor sees the modal again on their next portal visit and has to re-accept.

3. **Admins can see who's behind on agreement versions.** The Sanity Studio "Sponsor Acceptances" tool now shows a "Version" column for each sponsor and a yellow "Drift" badge when their accepted version doesn't match the currently published one.

## Why now

While verifying story 15.10 (the Workers cutover), the existing scroll gate failed on a wide monitor — the PDF fit entirely in view, so the auto-fire kicked in and the Accept button enabled before a real human would have read anything. That was the trigger to rip the gate out. While we were in there, version pinning + audit capture were already on the "should add eventually" list, so we did them in the same PR.

## Files changed (and what each one does)

| File | What changed |
|---|---|
| `astro-app/src/components/portal/SponsorAgreementViewer.tsx` | Rewritten: dropped all scroll/render-counting logic, just renders the PDF and reports page count. ~50 lines removed. |
| `astro-app/src/components/portal/SponsorAgreementModal.tsx` | Disabled-checkbox logic simplified to "is the PDF loaded?" — no more scroll-end tracking. Checkbox unchecked by default (court-tested per *Specht v. Netscape*). |
| `astro-app/migrations/0009_add_agreement_version_and_audit.sql` | **New** D1 migration. Adds three NULL-able TEXT columns: `agreement_version`, `agreement_accepted_ip`, `agreement_accepted_user_agent`. **Already applied to prod D1** before this PR (schema-then-code, safe). |
| `astro-app/src/lib/sanity.ts` | New helper `getSponsorAgreementRev()` + a focused GROQ query that pulls just the `_rev` field. Used by the accept endpoint and by middleware. |
| `astro-app/src/pages/api/portal/agreement/accept.ts` | When a sponsor clicks Accept, we now also record IP, user-agent, and the current Sanity rev. Returns 409 only when the user has already accepted **the current** version (re-acceptance against drift is allowed). KV cache is deleted on success so middleware re-reads D1. |
| `astro-app/src/middleware.ts` | New 5-minute module-scope cache of the current Sanity rev. The "do we need to show the modal?" check is now `acceptedAt is NULL OR cached_version doesn't match current_version`. Falls open if Sanity is down (so a Sanity outage doesn't lock people out of the portal). |
| `astro-app/src/pages/api/portal/admin/acceptances.ts` | Admin endpoint now returns `agreementVersion` + `versionMatch` per row, and a `currentVersion` header. New `?versionDrift=true` query filter narrows to sponsors who need to re-accept. |
| `studio/src/tools/SponsorAcceptancesTool.tsx` | New "Version" column showing the truncated rev (first 8 chars). Yellow "Drift" badge when the sponsor's accepted version is stale. |
| `__tests__/*` (5 test files) | 62 tests total — viewer/modal scroll-gate tests removed, version-pinning + drift + audit-capture tests added. Type-check baseline (115/0/37) preserved. |

## How this rolls out

- **D1 schema is already on prod** (applied via `wrangler d1 execute --remote`). The three new columns are NULL on every existing row.
- The deployed Worker still runs the old code, which ignores the new columns. **Prod is unbroken right now.**
- **Once this PR merges and deploys**: every sponsor with a non-null `agreement_accepted_at` (currently 1 person — js426@njit.edu) will be re-prompted to accept on their next portal visit, because their `agreement_version` is NULL → counts as drift. This is intentional; first roll-out resets everyone to "agreed against the currently published revision."
- Sponsor `jol@njit.edu` has never accepted, so they get the same prompt they would have gotten anyway.

## Test plan

### Already verified locally before this PR

- [x] `npm run test:unit` — 1888 passed, 1 pre-existing failure unrelated to this change
- [x] `npm run check -w astro-app` — 115/0/37 baseline preserved (zero new errors)
- [x] `npm run build -w astro-app` (capstone env) — clean build
- [x] **End-to-end local walkthrough**: snapshotted prod D1 → applied migration locally → ran `wrangler dev` → signed in via Google OAuth as a real sponsor (js426@njit.edu) → modal rendered → unchecked checkbox confirmed → click Accept → modal cleared → DB row inspected, `agreement_version` populated with the live Sanity rev, `agreement_accepted_user_agent` captured

### Reviewer checklist

- [ ] Pull this branch, run `npm run test:unit`, confirm green
- [ ] Eyeball the diff on `accept.ts` — the 409 logic was changed once during local testing (story explains; bug fix not regression)
- [ ] Confirm migration 0009 already applied to remote D1: `npx wrangler d1 execute ywcc-capstone-portal --remote --env capstone --command="PRAGMA table_info(user)"` should show `agreement_version` at cid 9
- [ ] After merge + deploy, sign in to https://www.ywcccapstone1.com/portal as a sponsor — expect to see the modal once (version drift), accept, confirm it doesn't re-prompt on refresh

## Out of scope (intentionally not in this PR)

- Sending an email heads-up to active sponsors about the re-acceptance prompt — only 2 sponsors total, low-impact, can be done after the fact
- Multi-version acceptance history (we only track the *current* accepted version, not a full audit log) — separate story if needed
- Geolocation in the audit row — IP alone is sufficient per story scope

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Sponsor agreements now include version tracking to detect when users must re-accept updated agreements.
  * Admin portal displays agreement version information with drift detection indicators.

* **Bug Fixes**
  * Removed the requirement to scroll to the end of the PDF before accepting sponsor agreements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->