### PR TITLE
fix(5.15): code review patches for site-wide search

### DIFF
--- a/astro-app/astro.config.mjs
+++ b/astro-app/astro.config.mjs
@@ -207,6 +207,7 @@ export default defineConfig({
             exclude: [
               '404', '404.html', '_astro', '**.xml', '**.txt', 'node_modules',
               '**/portal/**', '**/auth/**', '**/student/**', '**/demo/**',
+              'search', '**/search/**',
             ],
             generateIndividualMd: true,
             generateLlmsTxt: true,

--- a/astro-app/src/components/Header.astro
+++ b/astro-app/src/components/Header.astro
@@ -38,8 +38,10 @@ const settings = await getSiteSettings();
 const { navigationItems, ctaButton, siteName, logo, aiSearch } = settings;
 const currentPath = Astro.url.pathname;
 
-// Compute search modal visibility
-const searchEnabled = Boolean(aiSearch?.searchModalEnabled && aiSearch?.apiUrl);
+// Compute search modal visibility — stega-clean + trim so a stega-decoded-empty apiUrl
+// doesn't render a dead trigger that opens nothing.
+const cleanedSearchApiUrl = stegaClean(aiSearch?.apiUrl ?? '').trim();
+const searchEnabled = Boolean(aiSearch?.searchModalEnabled && cleanedSearchApiUrl);
 
 const logoUrl = safeUrlFor(logo)?.width(160).height(40).fit('max').url() ?? '/logos/njit-logo-plain.svg';
 const logoAlt = logo?.alt || 'NJIT';

--- a/astro-app/src/components/SearchModal.astro
+++ b/astro-app/src/components/SearchModal.astro
@@ -28,8 +28,17 @@ interface Props {
 
 const { apiUrl, placeholder, theme, seeMore = "/search?q=" } = Astro.props;
 
-// Sanitize inputs and reject empty apiUrl (render nothing if not provided).
-const cleanApiUrl = stegaClean(apiUrl);
+// Sanitize inputs and reject empty / non-HTTPS / non-URL apiUrl (mirror ChatBubble.astro).
+const rawApiUrl = stegaClean(apiUrl).trim();
+const cleanApiUrl = (() => {
+  if (!rawApiUrl) return "";
+  try {
+    const u = new URL(rawApiUrl);
+    return u.protocol === "http:" || u.protocol === "https:" ? rawApiUrl : "";
+  } catch {
+    return "";
+  }
+})();
 const cleanPlaceholder = stegaClean(placeholder ?? "Search the site…");
 const cleanTheme = stegaClean(theme ?? "auto");
 const cleanSeeMore = stegaClean(seeMore);
@@ -95,6 +104,8 @@ const resolvedTheme = cleanTheme === "auto" ? siteThemeAttr : cleanTheme;
     /* States: error uses destructive, focus ring matches site ring. */
     --search-snippet-error-background: var(--secondary);
     --search-snippet-error-color: var(--destructive);
+    --search-snippet-warning-background: var(--secondary);
+    --search-snippet-warning-color: var(--destructive);
     --search-snippet-focus-ring: 2px solid var(--ring);
   }
 </style>
@@ -105,8 +116,9 @@ const resolvedTheme = cleanTheme === "auto" ? siteThemeAttr : cleanTheme;
   // elements: chat-bubble-snippet, search-modal-snippet, search-bar-snippet, chat-page-snippet.
   import "@cloudflare/ai-search-snippet";
 
-  // Track initialized shells to avoid re-binding on SPA navigation.
-  const initializedShells = new WeakSet<HTMLElement>();
+  // AbortController is reset on every (re)bind so the prior nav's document listeners
+  // are removed before new ones are attached — prevents N-fold leak across SPA nav.
+  let abortController: AbortController | null = null;
 
   function openModal(source: "click" | "shortcut"): void {
     const modal = document.querySelector<
@@ -115,14 +127,20 @@ const resolvedTheme = cleanTheme === "auto" ? siteThemeAttr : cleanTheme;
     if (!modal?.open) return;
 
     (window as any).dataLayer = (window as any).dataLayer || [];
-    (window as any).dataLayer.push({
-      event: "site_search_open",
-      source,
-    });
+    (window as any).dataLayer.push({ event: "site_search_open", source });
     modal.open();
+
+    // Close any open mobile Sheet drawer so the modal isn't stacked behind it.
+    document
+      .querySelector<HTMLDialogElement>("[data-slot='sheet-dialog'][open]")
+      ?.close();
   }
 
   function bindTriggers(): void {
+    abortController?.abort();
+    abortController = new AbortController();
+    const { signal } = abortController;
+
     // Delegated click handler for [data-search-trigger] elements (desktop + mobile).
     document.addEventListener(
       "click",
@@ -134,49 +152,44 @@ const resolvedTheme = cleanTheme === "auto" ? siteThemeAttr : cleanTheme;
         e.preventDefault();
         openModal("click");
       },
-      { capture: false },
+      { signal },
     );
 
-    // Keyboard shortcut handler for ⌘K / Ctrl+K.
-    // The snippet's shortcut="k" use-meta-key="" handles the global keydown,
-    // but we need to push the GTM dataLayer event BEFORE it opens, at capture
-    // phase to ensure our event fires first.
+    // ⌘K / Ctrl+K — the snippet handles the actual open() via shortcut="k" use-meta-key="".
+    // We only push the GTM event, but ONLY if the snippet has registered AND the modal
+    // actually opens (deferred one frame so the vendor's listener runs first). This avoids
+    // overcounting on toggles, pre-registration shortcuts, and IME/focus-ignored events.
     document.addEventListener(
       "keydown",
       (e) => {
         const isMac = navigator.platform.toLowerCase().includes("mac");
         const metaKey = isMac ? e.metaKey : e.ctrlKey;
-        if (metaKey && e.key.toLowerCase() === "k") {
+        if (!metaKey || e.key.toLowerCase() !== "k") return;
+
+        requestAnimationFrame(() => {
+          const modal = document.querySelector<
+            HTMLElement & { isModalOpen?: () => boolean }
+          >("search-modal-snippet");
+          if (!modal?.isModalOpen?.()) return;
+
           (window as any).dataLayer = (window as any).dataLayer || [];
           (window as any).dataLayer.push({
             event: "site_search_open",
             source: "shortcut",
           });
-          // Do NOT call openModal() here — the snippet already handles the open()
-          // call internally when it detects the shortcut. Calling it twice would
-          // cause a double-open or race condition. The dataLayer push above is
-          // sufficient for GTM tracking.
-        }
+        });
       },
-      { capture: true },
+      { capture: true, signal },
     );
   }
 
-  // Re-bind triggers on page load and SPA navigation (astro:page-load).
-  // Use a guard to prevent duplicate listeners on repeated navigation.
-  let bindingInitialized = false;
-
-  function initSearchModal(): void {
-    if (bindingInitialized) return;
-    bindingInitialized = true;
-
+  // astro:page-load fires on initial render + every SPA nav (when ClientRouter is on the page).
+  // DOMContentLoaded is the fallback for routes without ViewTransitions; the AbortController
+  // dedup guarantees only one set of listeners is active regardless of which fires first.
+  document.addEventListener("astro:page-load", bindTriggers);
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", bindTriggers, { once: true });
+  } else {
     bindTriggers();
   }
-
-  document.addEventListener("DOMContentLoaded", initSearchModal);
-  document.addEventListener("astro:page-load", () => {
-    // Reset flag on SPA nav so re-navigation rebinds (old listeners are GC'd).
-    bindingInitialized = false;
-    initSearchModal();
-  });
 </script>

--- a/astro-app/src/components/__tests__/SearchModal.test.ts
+++ b/astro-app/src/components/__tests__/SearchModal.test.ts
@@ -110,4 +110,32 @@ describe('SearchModal', () => {
 
     expect(html).toContain('see-more="/search?q="');
   });
+
+  test('returns empty output when apiUrl is whitespace-only', async () => {
+    const html = await renderSearchModal({ apiUrl: '   ' });
+
+    expect(html).not.toContain('search-modal-shell');
+    expect(html).not.toContain('search-modal-snippet');
+  });
+
+  test('rejects non-http(s) protocols (e.g. javascript:)', async () => {
+    const html = await renderSearchModal({ apiUrl: 'javascript:alert(1)' });
+
+    expect(html).not.toContain('search-modal-shell');
+    expect(html).not.toContain('search-modal-snippet');
+  });
+
+  test('rejects scheme-less / malformed URLs', async () => {
+    const html = await renderSearchModal({ apiUrl: 'worker.dev/api' });
+
+    expect(html).not.toContain('search-modal-shell');
+    expect(html).not.toContain('search-modal-snippet');
+  });
+
+  test('accepts plain http:// (allowlist matches ChatBubble)', async () => {
+    const html = await renderSearchModal({ apiUrl: 'http://worker.dev' });
+
+    expect(html).toContain('search-modal-shell');
+    expect(html).toContain('api-url="http://worker.dev"');
+  });
 });

--- a/astro-app/src/pages/robots.txt.ts
+++ b/astro-app/src/pages/robots.txt.ts
@@ -9,7 +9,7 @@ Disallow: /portal/
 Disallow: /auth/
 Disallow: /student/
 Disallow: /demo/
-Disallow: /search/
+Disallow: /search
 
 User-agent: Cloudflare-AI-Search
 Allow: /
@@ -17,7 +17,7 @@ Disallow: /portal/
 Disallow: /auth/
 Disallow: /student/
 Disallow: /demo/
-Disallow: /search/
+Disallow: /search
 
 # LLMs: ${siteUrl}/llms.txt
 Sitemap: ${siteUrl}/sitemap-index.xml`;

--- a/astro-app/src/pages/search.astro
+++ b/astro-app/src/pages/search.astro
@@ -18,8 +18,17 @@ import { PUBLIC_SITE_THEME } from "astro:env/client";
 const settings = await getSiteSettings();
 const aiSearch = settings.aiSearch;
 
-// Sanitize inputs — reject empty apiUrl (render unavailable state).
-const cleanApiUrl = stegaClean(aiSearch?.apiUrl ?? "");
+// Sanitize inputs — reject empty / non-HTTPS / non-URL apiUrl (mirror SearchModal/ChatBubble).
+const rawApiUrl = stegaClean(aiSearch?.apiUrl ?? "").trim();
+const cleanApiUrl = (() => {
+  if (!rawApiUrl) return "";
+  try {
+    const u = new URL(rawApiUrl);
+    return u.protocol === "http:" || u.protocol === "https:" ? rawApiUrl : "";
+  } catch {
+    return "";
+  }
+})();
 const cleanPlaceholder = stegaClean(aiSearch?.placeholder ?? "Search the site…");
 const cleanTheme = stegaClean(aiSearch?.theme ?? "auto");
 
@@ -101,6 +110,8 @@ const searchAvailable = Boolean(aiSearch?.searchModalEnabled && cleanApiUrl);
     /* States: error uses destructive, focus ring matches site ring. */
     --search-snippet-error-background: var(--secondary);
     --search-snippet-error-color: var(--destructive);
+    --search-snippet-warning-background: var(--secondary);
+    --search-snippet-warning-color: var(--destructive);
     --search-snippet-focus-ring: 2px solid var(--ring);
   }
 </style>

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -29,10 +29,10 @@ export default defineConfig({
   },
 
   webServer: {
-    command: 'sh -c "npm run build --workspace=astro-app && cd astro-app/dist && python3 -m http.server 4321"',
+    command: 'sh -c "npm run build --workspace=astro-app && npm run preview --workspace=astro-app"',
     url: BASE_URL,
     reuseExistingServer: !process.env.CI,
-    timeout: 300_000,
+    timeout: 120_000,
     stdout: 'pipe',
   },
 


### PR DESCRIPTION
## What this PR does

This PR applies the **code review fixes** for Story 5.15 (site-wide search modal) found during a three-layer adversarial review of #692. It targets `feat/5-15-site-wide-search` directly so the patches can be folded into PR #692 before it merges to `preview`.

**TL;DR:** seven small fixes that close real bugs the original implementation shipped with — listener leaks, unvalidated URLs, missing CSS tokens, an analytics double-count, a static-server workaround that broke the E2E suite, and a search page that wasn't excluded from the AI-crawler corpus.

## Background — what is "site-wide search"?

Story 5.15 adds an AI-powered search modal to the nav bar (⌘K / Ctrl+K) and a `/search?q=` deep-link page. Both wrap the same Cloudflare web component (`@cloudflare/ai-search-snippet`) that ChatBubble.astro already uses, theming the vendor's Shadow DOM via documented `--search-snippet-*` CSS custom properties (the "Path A" pattern from Story 5.18).

Sanity editors enable it per-site via `siteSettings.aiSearch.searchModalEnabled` + `apiUrl`. Default is **off**, so RWC sites stay hidden until an editor flips it.

## What changed and why

### 1. Validate the search API URL before emitting it
**Files:** `SearchModal.astro`, `pages/search.astro`, `Header.astro`, `SearchModal.test.ts`

**Before:** the `apiUrl` from Sanity was only checked for "is the string truthy?". A misconfigured or malicious URL like `javascript:alert(1)`, a whitespace-only string, or a scheme-less `worker.dev` would all flow through to the snippet's `api-url=` attribute.

**After:** wrap with `new URL()` and assert protocol is `http:` or `https:`, mirroring `ChatBubble.astro:46-55`. Anything else returns empty → no trigger button, no snippet. Added 4 unit tests for the rejected inputs + the `http://` allowlist case.

### 2. Stop leaking event listeners across SPA navigation
**File:** `SearchModal.astro` script block

**Before:** the script bound a `click` and a `keydown` listener on `document` from BOTH `DOMContentLoaded` and `astro:page-load`. Each SPA navigation reset the "already-bound" flag and added another pair of listeners. After 5 page nav, every ⌘K press fired GTM events 6 times and every trigger-click called `openModal()` 6 times. Even on first load, both events fired so listeners doubled before any nav happened.

**After:** a single `AbortController` is reset on every (re)bind — calling `.abort()` removes the prior nav's listeners deterministically, then the next call attaches fresh ones. Always exactly two listeners on `document`.

### 3. Don't double-count `site_search_open` GTM events
**File:** `SearchModal.astro` keydown handler

**Before:** every `Cmd/Ctrl+K` keypress unconditionally pushed a `site_search_open` event — even when the snippet hadn't loaded yet, when the modal toggled closed, or when the vendor ignored the shortcut due to focus/IME state.

**After:** the push is deferred one frame via `requestAnimationFrame` so the vendor's listener runs first, then we check `modal.isModalOpen()` and only push if the modal actually opened. No more phantom opens in analytics.

### 4. Mobile drawer: close the sheet when Search is tapped
**File:** `SearchModal.astro` `openModal()`

**Before:** tapping Search in the mobile drawer opened the modal *behind* the still-open drawer — visually confusing and traps the user.

**After:** `openModal()` now finds any open `[data-slot='sheet-dialog']` and calls `.close()` on it before the modal animates in.

### 5. Add the two missing Path-A vendor tokens
**Files:** `SearchModal.astro`, `pages/search.astro`

**Before:** copied most of `ChatBubble.astro:123-165`'s vendor token list but missed `--search-snippet-warning-background` and `--search-snippet-warning-color`. AC 5 of the story explicitly says "Mirror the exact token list."

**After:** both tokens added to both files. Vendor warning states now match the rest of the Swiss palette.

### 6. Trim stega-encoded `apiUrl` in the Header guard
**File:** `Header.astro`

**Before:** `searchEnabled = Boolean(searchModalEnabled && apiUrl)` — but in Visual Editing mode `apiUrl` can be a stega-encoded string that's truthy yet decodes to empty. Result: the trigger button rendered but the modal didn't, so clicking did nothing silently.

**After:** `searchEnabled = Boolean(searchModalEnabled && stegaClean(apiUrl).trim())`. Header and modal agree on whether search is actually configured.

### 7. Exclude `/search` from the AI-crawler corpus
**Files:** `astro.config.mjs`, `robots.txt.ts`

**Before:** `/search` had `noIndex` meta but was still in `sitemap-index.xml`, generated a `/search.md` twin in `llms-full.txt`, and `robots.txt` only disallowed `/search/` (not the bare `/search` path or `/search?q=`).

**After:** `astro-llms-md` `exclude` list grew `'search', '**/search/**'`; `robots.txt` Disallow tightened to `Disallow: /search` (prefix-match catches both bare and child paths). Sitemap filter already excluded it.

### 8. Revert Playwright webServer to `astro preview`
**File:** `playwright.config.ts`

**Before:** webServer was swapped to `cd astro-app/dist && python3 -m http.server 4321` (a workaround for a `.wrangler` ownership error that blocked `astro preview`).

**Why this was a problem:** Astro 6 + the Cloudflare adapter outputs an SSR Worker. The static Python server can't run server routes — `/search` (which awaits `getSiteSettings()`) returns 404, `[slug]` detail routes 404. Combined with the suite's "skip if modal not in DOM" pattern, most E2E tests silently `test.skip()` on every CI run, so the suite passes without exercising anything.

**After:** reverted to `npm run preview --workspace=astro-app` (timeout 300s → 120s). The proper fix for the original `.wrangler` error is `chown -R \$USER astro-app/.wrangler` (already noted in the Dev Agent Record).

## Things I deliberately did NOT change (deferred)

11 lower-priority findings tracked in `_bmad-output/implementation-artifacts/deferred-work.md`:

- `theme="auto"` always resolves to `light` because `PUBLIC_SITE_THEME` enum has no `dark` value — mirrors ChatBubble; project-wide theme change.
- Sanity Studio may not re-validate `apiUrl` when only `searchModalEnabled` toggles (Studio behavior, pre-existing pattern).
- Vendor `shortcut="k"` collides with text-input ⌘K in some apps — vendor-controlled.
- E2E skip-if-missing pattern can false-positive when the snippet 503s — matches `cookie-consent.spec.ts` baseline.
- Typegen drift: `socialLinks.platform` enum lost `"facebook"` (unrelated to search).
- A few minor edge cases around `bar.search()` race, `navigator.platform` deprecation, missing try/catch on `getSiteSettings()`.

Plus 14 dismissed as noise (formatter newline-at-EOF, cosmetic, false positives).

## Test plan

- [x] `npm run test:unit` — 1910 passed / 27 skipped / 0 failed (after `CLOUDFLARE_ENV=capstone npm run build -w astro-app`)
- [x] `SearchModal.test.ts` — 11/11 (4 new URL-validation cases)
- [x] `Header.test.ts` — 9/9 (existing `searchEnabled` cases still green with the new stega-trim guard)
- [x] `robots-llms.test.ts` — 4/4 (the `/search` Disallow change is checked by these tests)
- [ ] `npm run test:chromium` against the reverted webServer — can run after merge of this PR + #692 (needs `chown -R \$USER astro-app/.wrangler` first if hitting the workerd sqlite error)
- [ ] Manual smoke on a `*-preview` deploy with `searchModalEnabled=true` — pending merge

## Findings tracking

Full review log lives at `_bmad-output/implementation-artifacts/5-15-site-wide-search.md#review-findings` (gitignored, local-only). Counts: **2 decisions resolved, 7 patches applied, 1 dismissed as false positive, 11 deferred, 14 dismissed.**