### PR TITLE
fix(search): 5.15 third-pass review patches — 9 hardening fixes

### DIFF
--- a/astro-app/src/components/Header.astro
+++ b/astro-app/src/components/Header.astro
@@ -38,14 +38,17 @@ const settings = await getSiteSettings();
 const { navigationItems, ctaButton, siteName, logo, aiSearch } = settings;
 const currentPath = Astro.url.pathname;
 
-// Compute search modal visibility — stega-clean + trim, then validate as an https URL.
-// Without the URL/protocol gate, a non-https or malformed apiUrl renders the trigger
-// button but SearchModal rejects internally → click goes nowhere (dead trigger).
+// Compute search modal visibility — stega-clean + trim, then validate as an https URL
+// with no embedded credentials. Must mirror SearchModal.astro's acceptance gate exactly,
+// otherwise the trigger renders but SearchModal rejects internally → click goes nowhere.
 const cleanedSearchApiUrl = stegaClean(aiSearch?.apiUrl ?? '').trim();
 const searchApiUrlValid = (() => {
   if (!cleanedSearchApiUrl) return false;
   try {
-    return new URL(cleanedSearchApiUrl).protocol === 'https:';
+    const u = new URL(cleanedSearchApiUrl);
+    if (u.protocol !== 'https:') return false;
+    if (u.username !== '' || u.password !== '') return false;
+    return true;
   } catch {
     return false;
   }

--- a/astro-app/src/components/Header.astro
+++ b/astro-app/src/components/Header.astro
@@ -38,10 +38,19 @@ const settings = await getSiteSettings();
 const { navigationItems, ctaButton, siteName, logo, aiSearch } = settings;
 const currentPath = Astro.url.pathname;
 
-// Compute search modal visibility — stega-clean + trim so a stega-decoded-empty apiUrl
-// doesn't render a dead trigger that opens nothing.
+// Compute search modal visibility — stega-clean + trim, then validate as an https URL.
+// Without the URL/protocol gate, a non-https or malformed apiUrl renders the trigger
+// button but SearchModal rejects internally → click goes nowhere (dead trigger).
 const cleanedSearchApiUrl = stegaClean(aiSearch?.apiUrl ?? '').trim();
-const searchEnabled = Boolean(aiSearch?.searchModalEnabled && cleanedSearchApiUrl);
+const searchApiUrlValid = (() => {
+  if (!cleanedSearchApiUrl) return false;
+  try {
+    return new URL(cleanedSearchApiUrl).protocol === 'https:';
+  } catch {
+    return false;
+  }
+})();
+const searchEnabled = Boolean(aiSearch?.searchModalEnabled && searchApiUrlValid);
 
 const logoUrl = safeUrlFor(logo)?.width(160).height(40).fit('max').url() ?? '/logos/njit-logo-plain.svg';
 const logoAlt = logo?.alt || 'NJIT';

--- a/astro-app/src/components/SearchModal.astro
+++ b/astro-app/src/components/SearchModal.astro
@@ -35,7 +35,9 @@ const cleanApiUrl = (() => {
   if (!rawApiUrl) return "";
   try {
     const u = new URL(rawApiUrl);
-    return u.protocol === "https:" ? rawApiUrl : "";
+    if (u.protocol !== "https:") return "";
+    if (u.username || u.password) return "";
+    return u.origin + u.pathname;
   } catch {
     return "";
   }
@@ -165,9 +167,10 @@ const resolvedTheme = allowedThemes.has(cleanTheme) ? cleanTheme : siteThemeAttr
       "keydown",
       (e) => {
         if (e.repeat) return;
+        if (e.isComposing) return;
         const isMac = navigator.platform.toLowerCase().includes("mac");
         const metaKey = isMac ? e.metaKey : e.ctrlKey;
-        if (!metaKey || e.key.toLowerCase() !== "k") return;
+        if (!metaKey || e.code !== "KeyK") return;
 
         requestAnimationFrame(() => {
           const modal = document.querySelector<

--- a/astro-app/src/components/__tests__/SearchModal.test.ts
+++ b/astro-app/src/components/__tests__/SearchModal.test.ts
@@ -38,7 +38,8 @@ describe('SearchModal', () => {
     expect(html).toContain('class="search-modal-shell"');
     expect(html).toContain('data-search-modal-root');
     expect(snippet).toContain('<search-modal-snippet');
-    expect(snippet).toContain('api-url="https://worker.dev"');
+    // URL is normalized to origin+pathname; bare host gets a trailing slash from URL.pathname.
+    expect(snippet).toContain('api-url="https://worker.dev/"');
     expect(snippet).toContain('placeholder="Search the site…"');
     expect(snippet).toContain('max-results="8"');
     expect(snippet).toContain('debounce-ms="200"');
@@ -64,7 +65,7 @@ describe('SearchModal', () => {
     });
 
     expect(html).not.toContain(stegaSuffix);
-    expect(html).toContain('api-url="https://worker.dev"');
+    expect(html).toContain('api-url="https://worker.dev/"');
     expect(html).toContain('placeholder="Search the site…"');
     expect(html).toContain('theme="dark"');
     expect(html).toContain('see-more="/search?q="');

--- a/astro-app/src/layouts/Layout.astro
+++ b/astro-app/src/layouts/Layout.astro
@@ -62,13 +62,19 @@ const liveContentEnabled = PUBLIC_SANITY_LIVE_CONTENT_ENABLED;
 
 const syncTags = liveContentEnabled || visualEditingEnabled ? getSyncTags() : [];
 
-// Extract AI Search worker origin for CSP connect-src (scoped, not wildcard)
+// Extract AI Search worker origin for CSP connect-src (scoped, not wildcard).
+// new URL() throws on malformed input — guard so a misconfigured apiUrl doesn't 500 every page.
 const aiSearchApiUrl = (siteSettings?.aiSearch?.enabled || siteSettings?.aiSearch?.searchModalEnabled)
   ? stegaClean(siteSettings.aiSearch.apiUrl ?? "")
   : "";
-const aiSearchWorkerOrigin = aiSearchApiUrl
-  ? new URL(aiSearchApiUrl).origin
-  : "";
+let aiSearchWorkerOrigin = "";
+if (aiSearchApiUrl) {
+  try {
+    aiSearchWorkerOrigin = new URL(aiSearchApiUrl).origin;
+  } catch {
+    aiSearchWorkerOrigin = "";
+  }
+}
 
 const cspConnectSrc = [
   "'self'",

--- a/astro-app/src/pages/search.astro
+++ b/astro-app/src/pages/search.astro
@@ -25,7 +25,9 @@ const cleanApiUrl = (() => {
   if (!rawApiUrl) return "";
   try {
     const u = new URL(rawApiUrl);
-    return u.protocol === "https:" ? rawApiUrl : "";
+    if (u.protocol !== "https:") return "";
+    if (u.username || u.password) return "";
+    return u.origin + u.pathname;
   } catch {
     return "";
   }
@@ -50,7 +52,7 @@ const searchAvailable = Boolean(aiSearch?.searchModalEnabled && cleanApiUrl);
       <h1 class="label-caps mb-8">Search</h1>
 
       {!searchAvailable ? (
-        <div class="rounded border-2 border-foreground bg-secondary p-6 text-center">
+        <div class="border-2 border-foreground bg-secondary p-6 text-center">
           <p class="text-foreground">
             Search is currently unavailable. Please try again later.
           </p>

--- a/astro-app/src/sanity.types.ts
+++ b/astro-app/src/sanity.types.ts
@@ -2590,7 +2590,13 @@ export type SiteSettings = {
     copyrightText?: string;
   };
   socialLinks?: Array<{
-    platform?: "github" | "linkedin" | "twitter" | "instagram" | "youtube";
+    platform?:
+      | "github"
+      | "linkedin"
+      | "twitter"
+      | "instagram"
+      | "youtube"
+      | "facebook";
     url?: string;
     _key: string;
   }>;
@@ -3602,6 +3608,7 @@ export type SITE_SETTINGS_QUERY_RESULT = {
   socialLinks: Array<{
     _key: string;
     platform:
+      | "facebook"
       | "github"
       | "instagram"
       | "linkedin"

--- a/tests/e2e/site-search-modal.spec.ts
+++ b/tests/e2e/site-search-modal.spec.ts
@@ -118,10 +118,16 @@ test.describe('Site Search Modal', () => {
 
     const href = await firstResult.getAttribute('href');
     expect(href).toBeTruthy();
+    expect(href!.trim().length).toBeGreaterThan(0);
+
+    // Resolve href against the current page so relative result URLs (e.g. "/about")
+    // produce a concrete pathname rather than a regex that vacuously matches anything.
+    const targetPath = new URL(href!, page.url()).pathname;
+    expect(targetPath).not.toBe('/');
 
     await firstResult.focus();
     await Promise.all([
-      page.waitForURL(new RegExp(href!.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))),
+      page.waitForURL((url) => url.pathname === targetPath),
       page.keyboard.press('Enter'),
     ]);
   });


### PR DESCRIPTION
## Summary

This PR follows up on **Story 5.15 (Site-Wide Search)** which shipped in PR #692. After that PR merged, we ran a fresh adversarial **three-layer code review** (Blind Hunter + Edge Case Hunter + Acceptance Auditor) and found 9 things worth fixing on top of what was already there. This PR applies all 9. Nothing is a new feature — these are hardening / correctness fixes.

If you're new to the codebase, the short version is: the search modal in the nav bar (⌘K) and the `/search` page both work, but the previous version of the code had some sharp edges (dead buttons in some configs, a way to crash every page render, a URL leak risk, and a few keyboard layout / IME bugs). This PR sands them down.

## What changed (in plain English)

### 1. No more "dead" search buttons in the nav

**Before:** if a Sanity editor saved an `apiUrl` that wasn't a valid `https://` URL, the search button would still appear in the nav, but clicking it did nothing — the modal silently refused to open.

**After:** the nav now uses the same URL/HTTPS check as the modal, so the button is hidden whenever the modal would refuse to open. No dead buttons.

📁 `astro-app/src/components/Header.astro`

### 2. A bad `apiUrl` can no longer crash every page

**Before:** `Layout.astro` called `new URL(apiUrl).origin` to set the Content Security Policy. If `apiUrl` was malformed, `new URL()` threw — and because `Layout.astro` runs on **every** page, every page would 500.

**After:** wrapped in a `try/catch`. A bad URL just means no CSP entry; the rest of the page still renders.

📁 `astro-app/src/layouts/Layout.astro`

### 3. URLs with embedded credentials can't leak into the DOM

**Before:** the URL validator accepted `https://user:pass@host/api` as a valid URL. The username/password would be sent to the browser DOM and into the CSP `connect-src`.

**After:** we now (a) reject any URL with `username` or `password`, and (b) only emit `origin + pathname`, which strips userinfo, query strings, and fragments.

📁 `astro-app/src/components/SearchModal.astro`, `astro-app/src/pages/search.astro`

### 4. Better keyboard support — IME and non-Latin layouts

**Before:** the ⌘K / Ctrl+K handler used `e.key.toLowerCase() === "k"`. That breaks two things:
- IME users (e.g. typing in Japanese / Chinese / Korean) could trigger the shortcut mid-composition.
- Users on Cyrillic, Greek, or Hebrew keyboards typing the physical "K" key produce a non-Latin character (`к`, `κ`, etc.), so the shortcut detection would silently miss — but the vendor's snippet (which uses keycode-based detection) would still open the modal, leaving our analytics blind.

**After:** added `if (e.isComposing) return;` for IME, and switched to `e.code === "KeyK"` for layout-independent matching.

📁 `astro-app/src/components/SearchModal.astro`

### 5. E2E "Enter on result navigates" is no longer vacuous

**Before:** the Playwright test built a regex from the result's `href` and called `page.waitForURL(regex)`. If `href` was empty or whitespace, the regex matched basically anything, so the test passed on a stale page.

**After:** the test resolves the href against the current page URL and asserts the exact `pathname`.

📁 `tests/e2e/site-search-modal.spec.ts`

### 6. Swiss-design parity on the disabled-state panel

**Before:** when search is turned off, `/search` shows an "unavailable" panel that used Tailwind's `rounded` class (`border-radius: 0.25rem`), which violates the project's flat / Swiss-design rule of `--radius: 0` everywhere else.

**After:** dropped the `rounded` class.

📁 `astro-app/src/pages/search.astro`

### 7. `socialLinks.platform` enum got `"facebook"` back

**Before:** when 5.15's PR was prepared, `npm run typegen` ran against a stale deployed Sanity schema, which silently dropped `"facebook"` from the generated `socialLinks.platform` union. Existing content with `platform: "facebook"` was now type-invalid.

**After:** ran `npm run typegen` against the local schema files (which always had `"facebook"`); the enum is restored.

📁 `astro-app/src/sanity.types.ts`

### 8. Test assertions updated for URL normalization

Because of fix #3 above, `https://worker.dev` is now normalized to `https://worker.dev/` (`URL.pathname` returns `/` for bare hosts and that gets concatenated). Two SearchModal tests needed their expected strings bumped.

📁 `astro-app/src/components/__tests__/SearchModal.test.ts`

## What was already fixed in earlier PRs (not in this PR, but listed for the audit trail)

The original Story 5.15 spec had a list of "Patch (apply now)" items from the **second-pass** review — 6 items. All 6 actually shipped in commits `1faa037` and `01279b7` (still on `preview`); only the spec's checkboxes were stale. The story file's checkboxes are now updated locally (in `_bmad-output/`, gitignored).

## What was deferred

23 lower-severity findings were captured in the local `_bmad-output/implementation-artifacts/deferred-work.md` log (gitignored). Highlights of what's NOT in this PR:

- AC 8 LHCI Performance ≥ 0.89 — environment-blocked locally (no Chrome); the PR-CI gate covers it.
- AC 6 module-load dedup — relies on Vite ESM behavior; no direct test.
- `navigator.platform` is deprecated — works fine on all current browsers; project-wide migration.
- Sticky `HeaderUI` parent could clip the modal if a future ancestor adds `transform`/`filter` — defensive only; vendor uses native `<dialog>` top-layer today.
- Various test-coverage gaps (multibyte queries, full-token CSS, mobile-sheet-close after modal-open) — rolled up as a follow-up coverage story.

## What was decided NOT to fix here

One UX issue from the review surfaced a deeper design problem rather than a code bug: ⌘K on `/search` opens the modal stacked over the inline `<search-bar-snippet>`. The fix isn't a one-liner because the bar primitive is the wrong tool for a dedicated search page. This is being tracked as a **new follow-up story (5.23)** to redesign `/search` as a proper full-page results experience using the headless `AISearchClient` API.

## Test plan

- [ ] CI: `test:unit` — should report **2048 passed, 27 skipped, 1 failed** (the 1 failure is the pre-existing Storybook build timeout, unrelated to this PR; documented in 5.15 dev-agent record).
- [ ] CI: `lhci autorun` — confirm Performance ≥ 0.89 + LCP ≤ 2000ms on the sitemap-driven URL set.
- [ ] CI: `pa11y-ci` — no new violations.
- [ ] Manual smoke (after deploy):
  - [ ] On the homepage, click the nav search button → modal opens.
  - [ ] On the homepage, press ⌘K (or Ctrl+K) → modal opens.
  - [ ] In the modal, type a query → results render.
  - [ ] On `/search?q=test`, the page renders with the results inside the search bar.
  - [ ] In Sanity Studio, save an `apiUrl` like `http://x.com` (non-https) → reload the site → nav search button is **hidden** (was visible-but-dead before).
  - [ ] In Sanity Studio, save an empty/garbled `apiUrl` → site still renders without 500s (was crashing before in the searchModalEnabled=true case).

## How to review

Each commit is a logical unit. The diff is small (49 +, 15 −) across 7 files. Open the files in the order listed in section 1–8 above and the changes line up with the explanations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Facebook as a new supported social media platform for user profiles and sharing.

* **Bug Fixes**
  * Improved search security and reliability through enhanced validation of search API endpoints.
  * Refined search keyboard shortcut activation to work more reliably across different operating systems and input methods, ensuring consistent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->