### PR TITLE
fix(blocks): harden gallery auto-curate from code review (Story 22.11)

### DIFF
--- a/astro-app/src/components/blocks/custom/_partials/GalleryGrid.astro
+++ b/astro-app/src/components/blocks/custom/_partials/GalleryGrid.astro
@@ -344,23 +344,26 @@ const hasFilters = years.length > 0 || categories.length > 0;
   import PhotoSwipeLightbox from 'photoswipe/lightbox';
   import 'photoswipe/style.css';
 
-  let lightbox: InstanceType<typeof PhotoSwipeLightbox> | null = null;
+  // One PhotoSwipeLightbox per `.pswp-gallery` container so multiple
+  // GalleryGrid instances on the same page don't share state.
+  const lightboxes = new Map<string, InstanceType<typeof PhotoSwipeLightbox>>();
 
-  function initLightbox() {
-    if (lightbox) {
-      lightbox.destroy();
-      lightbox = null;
+  function initLightbox(galleryId: string) {
+    const existing = lightboxes.get(galleryId);
+    if (existing) {
+      existing.destroy();
+      lightboxes.delete(galleryId);
     }
 
-    lightbox = new PhotoSwipeLightbox({
-      gallery: '.pswp-gallery',
+    const lightbox = new PhotoSwipeLightbox({
+      gallery: `#${galleryId}`,
       children: 'a:not([hidden])',
       pswpModule: () => import('photoswipe'),
     });
 
     // Caption overlay
     lightbox.on('uiRegister', () => {
-      lightbox!.pswp!.ui.registerElement({
+      lightbox.pswp!.ui.registerElement({
         name: 'caption',
         order: 9,
         isButton: false,
@@ -368,8 +371,8 @@ const hasFilters = years.length > 0 || categories.length > 0;
         html: '',
         onInit: (el) => {
           el.style.cssText = 'position:absolute;bottom:0;left:0;right:0;padding:16px 24px;background:linear-gradient(transparent,rgba(0,0,0,.6));color:#fff;font-size:14px;text-align:center;pointer-events:none;';
-          lightbox!.pswp!.on('change', () => {
-            const slide = lightbox!.pswp!.currSlide?.data.element;
+          lightbox.pswp!.on('change', () => {
+            const slide = lightbox.pswp!.currSlide?.data.element;
             const caption = slide?.closest('figure')?.querySelector('figcaption')?.textContent || '';
             el.textContent = caption;
             el.style.display = caption ? '' : 'none';
@@ -378,7 +381,7 @@ const hasFilters = years.length > 0 || categories.length > 0;
       });
 
       // Share button
-      lightbox!.pswp!.ui.registerElement({
+      lightbox.pswp!.ui.registerElement({
         name: 'share-button',
         order: 8,
         isButton: true,
@@ -404,7 +407,7 @@ const hasFilters = years.length > 0 || categories.length > 0;
 
     // Set ?img= on first open (before any change event fires)
     lightbox.on('afterInit', () => {
-      const index = lightbox!.pswp!.currIndex;
+      const index = lightbox.pswp!.currIndex;
       const url = new URL(window.location.href);
       url.searchParams.set('img', String(index + 1));
       history.replaceState(null, '', url.toString());
@@ -412,7 +415,7 @@ const hasFilters = years.length > 0 || categories.length > 0;
 
     // Deep linking: update URL on slide change
     lightbox.on('change', () => {
-      const index = lightbox!.pswp!.currIndex;
+      const index = lightbox.pswp!.currIndex;
       const url = new URL(window.location.href);
       url.searchParams.set('img', String(index + 1));
       history.replaceState(null, '', url.toString());
@@ -426,18 +429,27 @@ const hasFilters = years.length > 0 || categories.length > 0;
     });
 
     lightbox.init();
+    lightboxes.set(galleryId, lightbox);
+    return lightbox;
   }
 
-  initLightbox();
+  // Initialize a lightbox for every gallery container on the page
+  document.querySelectorAll<HTMLElement>('.pswp-gallery').forEach((container) => {
+    if (container.id) initLightbox(container.id);
+  });
 
-  // Deep linking: open to ?img=N on page load (with bounds check)
+  // Deep linking: open the first gallery to ?img=N on page load (with bounds check)
   const params = new URLSearchParams(window.location.search);
   const imgParam = params.get('img');
-  if (imgParam && lightbox) {
-    const imgIndex = parseInt(imgParam, 10) - 1;
-    const totalItems = document.querySelectorAll('.pswp-gallery a').length;
-    if (imgIndex >= 0 && imgIndex < totalItems) {
-      lightbox.loadAndOpen(imgIndex);
+  if (imgParam) {
+    const firstGallery = document.querySelector<HTMLElement>('.pswp-gallery[id]');
+    const firstLightbox = firstGallery ? lightboxes.get(firstGallery.id) : null;
+    if (firstGallery && firstLightbox) {
+      const imgIndex = parseInt(imgParam, 10) - 1;
+      const totalItems = firstGallery.querySelectorAll('a:not([hidden])').length;
+      if (imgIndex >= 0 && imgIndex < totalItems) {
+        firstLightbox.loadAndOpen(imgIndex);
+      }
     }
   }
 
@@ -467,8 +479,8 @@ const hasFilters = years.length > 0 || categories.length > 0;
         }
       });
 
-      // Reinitialize PhotoSwipe to update its item list after filtering
-      initLightbox();
+      // Reinitialize only this gallery's lightbox so the item list refreshes
+      initLightbox(targetId!);
     }
 
     filterBar.querySelectorAll('.gallery-filter-pill').forEach(pill => {

--- a/astro-app/src/lib/__tests__/sanity.test.ts
+++ b/astro-app/src/lib/__tests__/sanity.test.ts
@@ -1332,6 +1332,51 @@ describe("getGalleryAssets() (Story 22.11)", () => {
     expect(items).toEqual([]);
   });
 
+  it("skips null/non-string tag entries from broken media.tag references", async () => {
+    // Broken/unpublished media.tag refs deref to null in the GROQ projection;
+    // tag.match() on null would throw — verify the helper survives.
+    const mockAssets = [
+      mockAsset({
+        _id: 'a-broken-ref',
+        tags: ['gallery', null, 'gallery-2026', undefined, 42, 'gallery-web-apps'],
+      }),
+    ];
+    vi.mocked(sanityClient.fetch).mockResolvedValueOnce({ result: mockAssets } as never);
+
+    resetAllCaches();
+    const items = await getGalleryAssets();
+    expect(items).toHaveLength(1);
+    expect(items[0]).toMatchObject({ year: 2026, category: 'web-apps' });
+  });
+
+  it("strips stega markers before regex matching tag values", async () => {
+    // Visual-editing previews wrap string values with stega zero-width markers;
+    // raw tag strings would no longer match /^gallery-(\d{4})$/. Spec Task 2
+    // CRITICAL note required this assertion.
+    const { vercelStegaCombine } = await import("@vercel/stega");
+    const sourcePath = { origin: 'sanity.io', href: '/x', kind: 'asset' };
+    const wrap = (s: string) => vercelStegaCombine(s, sourcePath);
+    const mockAssets = [
+      mockAsset({
+        _id: 'a-stega',
+        tags: [wrap('gallery'), wrap('gallery-2026'), wrap('gallery-web-apps'), wrap('gallery-featured')],
+      }),
+    ];
+    vi.mocked(sanityClient.fetch).mockResolvedValueOnce({ result: mockAssets } as never);
+
+    resetAllCaches();
+    const items = await getGalleryAssets();
+    expect(items).toHaveLength(1);
+    expect(items[0]).toMatchObject({ featured: true, year: 2026, category: 'web-apps' });
+  });
+
+  it("returns [] and does not throw when loadQuery rejects", async () => {
+    vi.mocked(sanityClient.fetch).mockRejectedValueOnce(new Error('sanity outage') as never);
+    resetAllCaches();
+    const items = await getGalleryAssets();
+    expect(items).toEqual([]);
+  });
+
   it("returns cached result on subsequent calls without additional API calls", async () => {
     vi.resetModules();
     vi.doMock("astro:env/client", () => ({

--- a/astro-app/src/lib/sanity.ts
+++ b/astro-app/src/lib/sanity.ts
@@ -1021,7 +1021,11 @@ const GALLERY_CATEGORY_SLUGS: ReadonlySet<string> = new Set([
  * Non-canonical category-shaped tags (e.g. `gallery-typo`) are ignored.
  */
 function parseGalleryAssetTags(asset: GalleryAsset): Pick<GalleryItem, 'featured' | 'year' | 'category'> {
-  const tags = asset.tags ?? [];
+  // Filter out null entries from broken/unpublished media.tag references and
+  // strip stega markers so regex matching survives visual-editing previews.
+  const tags = (asset.tags ?? [])
+    .map((t) => (typeof t === 'string' ? (stegaClean(t) ?? t) : null))
+    .filter((t): t is string => typeof t === 'string');
   const featured = tags.includes('gallery-featured');
   let year: number | null = null;
   let category: string | null = null;
@@ -1048,30 +1052,35 @@ let _galleryAssetsCache: GalleryItem[] | null = null;
 
 export async function getGalleryAssets(): Promise<GalleryItem[]> {
   if (!visualEditingEnabled && _galleryAssetsCache) return _galleryAssetsCache;
-  const { result } = await loadQuery<GalleryAsset[]>({ query: GALLERY_ASSETS_QUERY });
-  const assets: GalleryAsset[] = result ?? [];
-  const items: GalleryItem[] = assets.map((a) => {
-    const { featured, year, category } = parseGalleryAssetTags(a);
-    const caption = a.description ?? a.title ?? null;
-    const alt = a.altText ?? null;
-    return {
-      _key: a._id,
-      image: {
-        asset: {
-          _id: a._id,
-          url: a.url ?? '',
-          metadata: a.metadata ?? null,
+  try {
+    const { result } = await loadQuery<GalleryAsset[]>({ query: GALLERY_ASSETS_QUERY });
+    const assets: GalleryAsset[] = result ?? [];
+    const items: GalleryItem[] = assets.map((a) => {
+      const { featured, year, category } = parseGalleryAssetTags(a);
+      const caption = a.description ?? a.title ?? null;
+      const alt = a.altText ?? null;
+      return {
+        _key: a._id,
+        image: {
+          asset: {
+            _id: a._id,
+            url: a.url ?? '',
+            metadata: a.metadata ?? null,
+          },
+          alt,
         },
-        alt,
-      },
-      caption,
-      featured,
-      year,
-      category,
-    };
-  });
-  _galleryAssetsCache = items;
-  return items;
+        caption,
+        featured,
+        year,
+        category,
+      };
+    });
+    _galleryAssetsCache = items;
+    return items;
+  } catch (err) {
+    console.warn('[getGalleryAssets] failed; returning empty list', err);
+    return [];
+  }
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What this PR does

Story 22.11 (the auto-curated `/gallery`) shipped in PR #699. A 3-layer code review (Blind Hunter + Edge Case Hunter + Acceptance Auditor) ran against that diff afterward and surfaced four patches worth applying. This PR is just those four fixes — no new features, no scope changes.

## The four fixes (in beginner-friendly terms)

### 1. Broken Sanity tag references no longer crash `/gallery`

In Sanity's media plugin, every image tag (e.g. `gallery`, `gallery-2026`, `gallery-web-apps`) is its own document. If a tag document is **deleted or unpublished** while an image still points at it, the GROQ query brings back a `null` entry in the asset's `tags` array.

Before this PR, the code did `tag.match(/^gallery-(\d{4})$/)` on every entry. Calling `.match()` on `null` throws a `TypeError` — and that crashes the `/gallery` build (or the SSR render in preview).

We now filter the array to keep only strings. While we're there, we also `stegaClean` each tag (the visual-editing preview wraps text values with hidden marker characters so editors can click them in the live preview — those markers would otherwise sneak into the regex and prevent matches like `gallery-2026` from succeeding).

`astro-app/src/lib/sanity.ts:1024-1041`

### 2. Two galleries on one page no longer fight over PhotoSwipe

PhotoSwipe is the lightbox library that opens the full-size image when you click a thumbnail. The original script bound a **single** lightbox to every `.pswp-gallery` container on the page using one shared CSS selector.

Today only one gallery renders per page, so this works in production. But the system **could** put two on one page — e.g. the `/gallery` listing also rendering an `imageGallery` block inside `listingPage.headerBlocks`. With the old code, both galleries would share one lightbox, click events would double-bind, and filter changes on one gallery would destroy and rebuild the other.

The fix: keep a `Map<galleryId, lightbox>` and instantiate **one PhotoSwipe lightbox per `.pswp-gallery` container**. Filter reinit only touches its own gallery (we know which one because each filter bar carries `data-gallery-target`). The `?img=N` deep-link opens the first gallery on the page — same behavior as before in the single-gallery case.

`astro-app/src/components/blocks/custom/_partials/GalleryGrid.astro:343-497`

### 3. Sanity outages no longer break the build

`getGalleryAssets()` calls `loadQuery()` to fetch the tagged image list. If Sanity is unreachable (network blip, auth error, rate limit), that promise rejects and the rejection bubbles up — crashing the prerender at build time, or returning a 500 in preview SSR.

We now wrap the fetch + map in a `try / catch`. On failure we `console.warn` and return `[]`. The page already has empty-state UI ("No gallery photos yet. Check back soon."), so a transient Sanity outage now degrades gracefully instead of taking the route down.

`astro-app/src/lib/sanity.ts:1049-1080`

### 4. Three new tests cover the fixes above

- **Broken-ref test** — feeds `parseGalleryAssetTags` a tag array with `null`, `undefined`, and a stray number mixed in. Asserts it still parses the real `gallery-2026` and `gallery-web-apps` tags.
- **Stega-encoded test** — uses the actual `vercelStegaCombine` from `@vercel/stega` (the same library `@sanity/client/stega` uses) to wrap each tag with real visual-editing markers, then asserts `featured`/`year`/`category` are still derived correctly. This satisfies the **Task 2 CRITICAL note** in the story spec, which was overlooked in the original PR.
- **`loadQuery` rejection test** — mocks the Sanity client to throw and asserts `getGalleryAssets()` returns `[]` instead of propagating the error.

`astro-app/src/lib/__tests__/sanity.test.ts:1335-1381`

## What this PR does NOT change

- No schema changes, no GROQ query changes, no public API changes.
- No new files. All edits are inside the three files Story 22.11 already touched.
- `ImageGallery.astro` (the page-builder block path) is untouched — it goes through the same `parseGalleryAssetTags` / `GalleryGrid` partials, so it benefits from the fixes for free.
- `prerender = true` on `/gallery` is preserved.
- No CI / wrangler / env / deploy changes.

## Findings that were dismissed or deferred

The full triage is in the story file's **Review Findings** section at `_bmad-output/implementation-artifacts/22-11-gallery-auto-curate-from-asset-tags.md`. Highlights:

- ~25 findings dismissed as false positives or design choices already covered by ACs (e.g. `urlFor` uses `_id` not `url` so the empty-string coercion is harmless; `dateCreated` from earliest year tag is per AC 14; `gallery-12345` cannot misparse because the regex is anchored to 4 digits).
- 4 findings deferred to `deferred-work.md`: cache cold-start race, lightbox-open-during-filter UX, missing E2E for `?img=N` out-of-range + combined filters + `/gallery.md` agent-discovery twin, variant-audit partial+wrapper conflation. None block this PR.

## Test plan

- [x] `npm run test:unit` from project root → 2091 passed / 27 skipped / 0 failed (was 2088; net +3)
- [x] `npx astro check` from `astro-app/` → 114 errors / 0 warnings / 37 hints (was 115; net **−1**, zero new errors)
- [ ] Reviewer: load `/gallery` on `feat/22-11-gallery-review-patches` preview, click a thumbnail (lightbox opens), navigate with arrow keys, copy `?img=N` URL, reload — confirm same image opens
- [ ] Reviewer: click a year filter pill — confirm only matching figures stay visible and lightbox respects the filter
- [ ] Reviewer: spot-check `/sponsors` or another page that uses an `imageGallery` block — confirm lightbox still works there (single-instance case)

## Story status

Story 22.11 in `_bmad-output/implementation-artifacts/sprint-status.yaml` flipped `review` → `done` after these patches were applied + tests + typecheck verified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Gallery page with year and category filtering
  * PhotoSwipe lightbox for gallery image viewing
  * Deep-linking support for gallery images via URL parameters

* **Improvements**
  * Enhanced request validation and error handling on API endpoints
  * Better form submission reliability with improved background task handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->