### PR TITLE
fix(env): mark portal-only secrets optional on non-capstone envs

### DIFF
--- a/astro-app/astro.config.mjs
+++ b/astro-app/astro.config.mjs
@@ -212,18 +212,33 @@ export default defineConfig({
         optional: true,
       }),
 
-      // --- Server-side secrets (production) ---
-      // Required on capstone deploys; rwc Workers don't carry these and are
-      // expected to fail validateSecrets unless rwc deploy is revived (see
-      // story 5.20 Gotcha #8). GOOGLE_CLIENT_ID lives in CF dashboard secrets,
-      // hence access:"secret" matches its storage location.
-      BETTER_AUTH_SECRET: envField.string({ context: "server", access: "secret" }),
-      GITHUB_CLIENT_SECRET: envField.string({ context: "server", access: "secret" }),
-      GOOGLE_CLIENT_ID: envField.string({ context: "server", access: "secret" }),
-      GOOGLE_CLIENT_SECRET: envField.string({ context: "server", access: "secret" }),
-      RESEND_API_KEY: envField.string({ context: "server", access: "secret" }),
-      TURNSTILE_SECRET_KEY: envField.string({ context: "server", access: "secret" }),
-      SANITY_API_WRITE_TOKEN: envField.string({ context: "server", access: "secret" }),
+      // --- Server-side secrets (portal / auth / write paths) ---
+      // Only the prod `capstone` Worker carries these — the rwc + *-preview
+      // Workers are content-only (no D1/KV/DO bindings) and portal/auth/api
+      // routes return 503 there. Marking these `optional` for non-prod envs
+      // lets `astro:env/server` return undefined at runtime instead of
+      // throwing EnvInvalidVariables on every request when the bundle imports
+      // `actions/index.ts` (which transitively reads these). Prod stays strict
+      // so a missing secret still fails the build immediately.
+      ...(process.env.CLOUDFLARE_ENV === "capstone"
+        ? {
+            BETTER_AUTH_SECRET: envField.string({ context: "server", access: "secret" }),
+            GITHUB_CLIENT_SECRET: envField.string({ context: "server", access: "secret" }),
+            GOOGLE_CLIENT_ID: envField.string({ context: "server", access: "secret" }),
+            GOOGLE_CLIENT_SECRET: envField.string({ context: "server", access: "secret" }),
+            RESEND_API_KEY: envField.string({ context: "server", access: "secret" }),
+            TURNSTILE_SECRET_KEY: envField.string({ context: "server", access: "secret" }),
+            SANITY_API_WRITE_TOKEN: envField.string({ context: "server", access: "secret" }),
+          }
+        : {
+            BETTER_AUTH_SECRET: envField.string({ context: "server", access: "secret", optional: true }),
+            GITHUB_CLIENT_SECRET: envField.string({ context: "server", access: "secret", optional: true }),
+            GOOGLE_CLIENT_ID: envField.string({ context: "server", access: "secret", optional: true }),
+            GOOGLE_CLIENT_SECRET: envField.string({ context: "server", access: "secret", optional: true }),
+            RESEND_API_KEY: envField.string({ context: "server", access: "secret", optional: true }),
+            TURNSTILE_SECRET_KEY: envField.string({ context: "server", access: "secret", optional: true }),
+            SANITY_API_WRITE_TOKEN: envField.string({ context: "server", access: "secret", optional: true }),
+          }),
       DISCORD_WEBHOOK_URL: envField.string({ context: "server", access: "secret", optional: true }),
     },
     validateSecrets: true,


### PR DESCRIPTION
## Summary
- The 7 portal secrets (`BETTER_AUTH_SECRET`, `GITHUB_CLIENT_SECRET`, `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `RESEND_API_KEY`, `TURNSTILE_SECRET_KEY`, `SANITY_API_WRITE_TOKEN`) only exist on the prod \`capstone\` Worker — \`rwc-us\` / \`rwc-intl\` / \`*-preview\` Workers are content-only with no portal secrets bound.
- Before this change, the bundled Worker called \`_internalGetSecret\` for these on every request (transitively imported via \`src/actions/index.ts\`) and threw \`EnvInvalidVariables\` → HTTP 500 for every request on \`ywcc-capstone-preview\` (likely also \`rwc-us\` / \`rwc-intl\`).
- The build-time \`validateSecrets: true\` masked the issue locally because \`.dev.vars\` seeded the values; the deployed Worker had no such fallback.
- Branching on \`process.env.CLOUDFLARE_ENV === "capstone"\` keeps prod strict (missing secret = build fails immediately) while non-prod envs return \`undefined\` at runtime. Portal/auth routes already 503 on those Workers per the existing architecture, so \`undefined\` values never reach Better Auth / Resend in normal traffic.

## Root cause trail
1. PR #697 (\`feat(env): complete astro:env migration\`) declared 7 new non-optional server secrets and set \`validateSecrets: true\`.
2. Workers Build for \`ywcc-capstone-preview\` (build \`c9d34914-d0b6-44e5-8756-62362635bbd6\`) failed at \`astro build\` start with \`EnvInvalidVariables: BETTER_AUTH_SECRET is missing\` (+ 6 others).
3. After seeding all 8 vars into Workers Builds env + \`.dev.vars\` (build \`983e3d4f-6578-4a1a-b9f7-aa783fb52dcd\`), build + deploy succeeded — but the deployed Worker still 500s with \`EnvInvalidVariables: BETTER_AUTH_SECRET is missing\` at \`_internalGetSecret\` on **every** request, because \`.dev.vars\` is a build-time-only construct; the runtime Worker has no such bindings.
4. This change makes the schema runtime-tolerant for content-only Workers without weakening prod's fail-fast guarantee.

## Test plan
- [ ] Workers Build auto-fires on merge to \`preview\` and succeeds end-to-end.
- [ ] \`curl https://ywcc-capstone-preview.js426.workers.dev/\` returns 200 (no longer error code 1101).
- [ ] Workers observability shows zero \`EnvInvalidVariables\` errors after deploy.
- [ ] Production (\`ywcc-capstone\`) build still passes — strict secret validation preserved.
- [ ] Studio Presentation iframe at preview URL renders correctly with visual editing on.
- [ ] \`/portal/login\` on the preview Worker still 503s (intended — not a regression).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated server configuration to conditionally manage authentication and service credentials based on the deployment environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->