### PR TITLE
chore(infra): pin per-env compat config on capstone Workers

### DIFF
--- a/astro-app/wrangler.jsonc
+++ b/astro-app/wrangler.jsonc
@@ -49,6 +49,15 @@
 	"env": {
 		"capstone": {
 			"name": "ywcc-capstone",
+			// Explicit per-env compat config — defense against accidental drift if a
+			// future override on one flag forgets the others. Mirrors top-level
+			// values; keep both in sync. Inheritable keys per CF docs, so removing
+			// these lines reverts to top-level inheritance with identical effect.
+			"compatibility_date": "2026-04-01",
+			"compatibility_flags": [
+				"nodejs_compat",
+				"global_fetch_strictly_public"
+			],
 			"routes": [
 				{ "pattern": "ywcccapstone1.com", "custom_domain": true },
 				{ "pattern": "www.ywcccapstone1.com", "custom_domain": true }
@@ -186,6 +195,15 @@
 		},
 		"capstone_preview": {
 			"name": "ywcc-capstone-preview",
+			// Explicit per-env compat config — mirrors capstone production so the
+			// preview Worker exercises the same runtime semantics editors will see
+			// in prod (drafts perspective + stega differ from prod, but compat
+			// flags MUST match to avoid "works in preview, breaks in prod" gaps).
+			"compatibility_date": "2026-04-01",
+			"compatibility_flags": [
+				"nodejs_compat",
+				"global_fetch_strictly_public"
+			],
 			"vars": {
 				// Capstone preview Worker — content-only (no D1/KV/DO bindings).
 				// Drafts perspective + stega via PUBLIC_SANITY_VISUAL_EDITING_ENABLED=true.


### PR DESCRIPTION
## Summary

Restate `compatibility_date` and `compatibility_flags` inside the `capstone` and `capstone_preview` env blocks in `astro-app/wrangler.jsonc` instead of relying on inheritance from the top-level config. This is a no-op today — purely defensive against future drift.

## Why

Cloudflare's `wrangler.jsonc` lets per-env blocks inherit top-level values for `compatibility_date` and `compatibility_flags`. That works fine — until someone needs to override _one_ flag in a single env. The moment a per-env block declares `compatibility_flags: [...]`, **the entire array replaces the inherited one** — any flags not restated are silently lost.

That's a sharp edge waiting to bite us. We currently rely on `nodejs_compat` and `global_fetch_strictly_public` being active on every env. If a future PR adds, say, `streams_enable_constructors` to just `capstone` for an experiment, both inherited flags would silently drop and the deploy would behave subtly differently — `nodejs_compat` controls a lot of polyfills (Buffer, process, crypto), so losing it without warning is a recipe for a midnight-page-out incident.

The `capstone_preview` block has an extra reason to pin: preview Workers MUST exercise the same runtime semantics as prod so editors don't see "works in preview, breaks in prod" gaps. The only intentional preview vs prod divergence is `PUBLIC_SANITY_VISUAL_EDITING_ENABLED=true` (drafts perspective + stega for click-to-edit) — runtime flags must match.

## What this PR does (and doesn't do)

**Does:**
- Adds explicit `compatibility_date: "2026-04-01"` to `env.capstone` and `env.capstone_preview`
- Adds explicit `compatibility_flags: ["nodejs_compat", "global_fetch_strictly_public"]` to both envs
- Adds inline comments explaining the intent so the next maintainer doesn't try to "clean up" the duplication

**Does not:**
- Change any runtime behavior (the values match the inherited ones byte-for-byte)
- Touch `rwc-us` or `rwc-intl` env blocks (those `*.workers.dev` envs are content-only and a separate review of their posture is appropriate)
- Touch the top-level `compatibility_date` / `compatibility_flags` — those stay as the source of truth, and the per-env values must be kept in sync with them

## Why duplication > a helper

Wrangler's config schema does not support `extends` or any kind of include — JSONC is JSONC. So the only way to make this defensive is to restate the values inline. The comment at each call site flags the intent.

## Test plan

- [ ] `npx wrangler types -C astro-app` runs clean (no schema regression)
- [ ] `CLOUDFLARE_ENV=capstone npm run build -w astro-app` succeeds with no warnings
- [ ] `CLOUDFLARE_ENV=capstone_preview npm run build -w astro-app` succeeds with no warnings
- [ ] (Optional) Diff the bundled `dist/` output before vs after this PR — should be byte-identical for `capstone`