### PR TITLE
feat(portal): platform-api client helper (Story 12.8a)

### DIFF
--- a/astro-app/astro.config.mjs
+++ b/astro-app/astro.config.mjs
@@ -169,6 +169,15 @@ export default defineConfig({
         access: "public",
         default: "",
       }),
+      // Bridges the astro-app portal to platform-api (Epic 12 / Story 12.8a). Optional
+      // because RWC + *-preview Workers don't carry the var; the helper in
+      // src/lib/platform-api-client.ts short-circuits with PlatformApiAuthError
+      // when unset, so callers fail loudly instead of hitting `undefined` at runtime.
+      PUBLIC_PLATFORM_API_BASE_URL: envField.string({
+        context: "client",
+        access: "public",
+        optional: true,
+      }),
 
       // --- Server-side public vars (capstone-only — optional for rwc parity) ---
       // rwc_us / rwc_intl wrangler blocks don't carry these. optional:true

--- a/astro-app/src/lib/__tests__/__mocks__/astro-env-client.ts
+++ b/astro-app/src/lib/__tests__/__mocks__/astro-env-client.ts
@@ -16,3 +16,4 @@ export const PUBLIC_SITE_THEME = "red";
 export const PUBLIC_SANITY_STUDIO_PROJECT_ID = "test-project-id";
 export const PUBLIC_SANITY_STUDIO_DATASET = "production";
 export const PUBLIC_TURNSTILE_SITE_KEY = "";
+export const PUBLIC_PLATFORM_API_BASE_URL: string | undefined = undefined;

--- a/astro-app/src/lib/__tests__/platform-api-client.test.ts
+++ b/astro-app/src/lib/__tests__/platform-api-client.test.ts
@@ -1,0 +1,189 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { AstroGlobal } from 'astro';
+
+// astro:env/client is mocked via vitest's __mocks__ alias; per-case overrides use vi.doMock.
+// `vi.hoisted` keeps the dynamic-import pattern compatible with the hoisted mock setup.
+
+function buildAstro(opts: {
+  cookieHeader?: string | null;
+  email?: string | null;
+}): AstroGlobal {
+  return {
+    request: new Request('http://localhost/portal', {
+      headers: opts.cookieHeader != null ? { cookie: opts.cookieHeader } : {},
+    }),
+    locals: opts.email !== undefined ? { user: opts.email == null ? undefined : { email: opts.email, name: 'X', role: 'sponsor' } } : {},
+  } as unknown as AstroGlobal;
+}
+
+describe('createPlatformApiClient', () => {
+  let fetchSpy: ReturnType<typeof vi.fn>;
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    fetchSpy = vi.fn(async () => new Response(null, { status: 204 }));
+    vi.stubGlobal('fetch', fetchSpy);
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.resetModules();
+    vi.doUnmock('astro:env/client');
+    logSpy.mockRestore();
+    warnSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+
+  it('happy path → injects Authorization: Bearer <token> on outbound request', async () => {
+    vi.doMock('astro:env/client', () => ({
+      PUBLIC_PLATFORM_API_BASE_URL: 'https://platform-api.example.com',
+    }));
+    const { createPlatformApiClient } = await import('../platform-api-client');
+
+    const astro = buildAstro({
+      cookieHeader: 'better-auth.session_token=tok-abc-123; other=ignored',
+      email: 'sponsor@example.com',
+    });
+
+    const client = createPlatformApiClient(astro);
+    const resp = await client.fetch('/api/v1/platform/health');
+
+    expect(resp.status).toBe(204);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('https://platform-api.example.com/api/v1/platform/health');
+    expect((init.headers as Record<string, string>).Authorization).toBe('Bearer tok-abc-123');
+    expect((init.headers as Record<string, string>).Accept).toBe('application/json');
+  });
+
+  it('handles __Secure- prefixed cookie name (production cookie config)', async () => {
+    vi.doMock('astro:env/client', () => ({
+      PUBLIC_PLATFORM_API_BASE_URL: 'https://platform-api.example.com',
+    }));
+    const { createPlatformApiClient } = await import('../platform-api-client');
+
+    const astro = buildAstro({
+      cookieHeader: '__Secure-better-auth.session_token=secure-tok-456',
+      email: 'sponsor@example.com',
+    });
+
+    const client = createPlatformApiClient(astro);
+    await client.fetch('/api/v1/forms/submissions');
+
+    const init = fetchSpy.mock.calls[0]![1] as RequestInit;
+    expect((init.headers as Record<string, string>).Authorization).toBe('Bearer secure-tok-456');
+  });
+
+  it('strips a trailing slash from the base URL before joining the path', async () => {
+    vi.doMock('astro:env/client', () => ({
+      PUBLIC_PLATFORM_API_BASE_URL: 'https://platform-api.example.com/',
+    }));
+    const { createPlatformApiClient } = await import('../platform-api-client');
+
+    const astro = buildAstro({
+      cookieHeader: 'better-auth.session_token=tok',
+      email: 'sponsor@example.com',
+    });
+
+    createPlatformApiClient(astro).fetch('/api/v1/x');
+
+    const [url] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('https://platform-api.example.com/api/v1/x');
+  });
+
+  it('no_session → throws PlatformApiAuthError when cookie is absent', async () => {
+    vi.doMock('astro:env/client', () => ({
+      PUBLIC_PLATFORM_API_BASE_URL: 'https://platform-api.example.com',
+    }));
+    const { createPlatformApiClient, PlatformApiAuthError } = await import('../platform-api-client');
+
+    const astro = buildAstro({ cookieHeader: null, email: 'sponsor@example.com' });
+
+    expect(() => createPlatformApiClient(astro)).toThrow(PlatformApiAuthError);
+    try {
+      createPlatformApiClient(astro);
+    } catch (err) {
+      expect((err as InstanceType<typeof PlatformApiAuthError>).code).toBe('no_session');
+    }
+  });
+
+  it('no_email → throws PlatformApiAuthError when locals.user is missing', async () => {
+    vi.doMock('astro:env/client', () => ({
+      PUBLIC_PLATFORM_API_BASE_URL: 'https://platform-api.example.com',
+    }));
+    const { createPlatformApiClient, PlatformApiAuthError } = await import('../platform-api-client');
+
+    const astro = buildAstro({
+      cookieHeader: 'better-auth.session_token=tok-abc',
+      email: null,
+    });
+
+    try {
+      createPlatformApiClient(astro);
+      throw new Error('expected throw');
+    } catch (err) {
+      expect(err).toBeInstanceOf(PlatformApiAuthError);
+      expect((err as InstanceType<typeof PlatformApiAuthError>).code).toBe('no_email');
+    }
+  });
+
+  it('not_configured → throws PlatformApiAuthError when env var is unset', async () => {
+    vi.doMock('astro:env/client', () => ({
+      PUBLIC_PLATFORM_API_BASE_URL: undefined,
+    }));
+    const { createPlatformApiClient, PlatformApiAuthError } = await import('../platform-api-client');
+
+    const astro = buildAstro({
+      cookieHeader: 'better-auth.session_token=tok',
+      email: 'sponsor@example.com',
+    });
+
+    try {
+      createPlatformApiClient(astro);
+      throw new Error('expected throw');
+    } catch (err) {
+      expect(err).toBeInstanceOf(PlatformApiAuthError);
+      expect((err as InstanceType<typeof PlatformApiAuthError>).code).toBe('not_configured');
+    }
+  });
+
+  it('never logs the raw token value', async () => {
+    vi.doMock('astro:env/client', () => ({
+      PUBLIC_PLATFORM_API_BASE_URL: 'https://platform-api.example.com',
+    }));
+    const { createPlatformApiClient } = await import('../platform-api-client');
+
+    const sensitiveToken = 'super-secret-bearer-token-value-do-not-log';
+
+    // no_session path emits log.warn — verify the warn call doesn't include any token
+    try {
+      createPlatformApiClient(buildAstro({ cookieHeader: null, email: 'a@b.com' }));
+    } catch {
+      /* expected throw */
+    }
+
+    // Happy path: should not log at all
+    const client = createPlatformApiClient(
+      buildAstro({
+        cookieHeader: `better-auth.session_token=${sensitiveToken}`,
+        email: 'a@b.com',
+      }),
+    );
+    await client.fetch('/api/v1/platform/health');
+
+    const allLogCalls = [
+      ...logSpy.mock.calls,
+      ...warnSpy.mock.calls,
+      ...errorSpy.mock.calls,
+    ].map(args => JSON.stringify(args));
+
+    for (const line of allLogCalls) {
+      expect(line).not.toContain(sensitiveToken);
+    }
+  });
+});

--- a/astro-app/src/lib/platform-api-client.ts
+++ b/astro-app/src/lib/platform-api-client.ts
@@ -1,0 +1,69 @@
+/**
+ * Authenticated client for platform-api (Epic 12 / Story 12.8a).
+ *
+ * Bridges astro-app's Better Auth session cookie to platform-api's
+ * OAuth2 password-grant scaffold. The cookie value IS the bearer token —
+ * platform-api validates it against the shared D1 `session` row.
+ *
+ * Helper short-circuits with PlatformApiAuthError when:
+ *   - PUBLIC_PLATFORM_API_BASE_URL is unset (RWC + *-preview Workers)
+ *   - the request carries no Better Auth session cookie
+ *   - middleware did not populate Astro.locals.user
+ *
+ * Never logs the raw token value.
+ */
+import { PUBLIC_PLATFORM_API_BASE_URL } from 'astro:env/client';
+import { log } from '@/lib/log';
+import type { AstroGlobal } from 'astro';
+
+export type PlatformApiAuthErrorCode = 'no_session' | 'not_configured' | 'no_email';
+
+export class PlatformApiAuthError extends Error {
+  constructor(public readonly code: PlatformApiAuthErrorCode) {
+    super(`platform-api auth: ${code}`);
+    this.name = 'PlatformApiAuthError';
+  }
+}
+
+export interface PlatformApiClient {
+  fetch: (path: string, init?: RequestInit) => Promise<Response>;
+}
+
+/** Mirrors middleware.ts:extractSessionToken — handles `__Secure-` prefix. */
+function readSessionToken(cookieHeader: string | null): string | null {
+  if (!cookieHeader) return null;
+  const match = cookieHeader.match(/(?:__Secure-)?better-auth\.session_token=([^;]+)/);
+  return match?.[1] ?? null;
+}
+
+export function createPlatformApiClient(astro: AstroGlobal): PlatformApiClient {
+  if (!PUBLIC_PLATFORM_API_BASE_URL) {
+    throw new PlatformApiAuthError('not_configured');
+  }
+
+  const token = readSessionToken(astro.request.headers.get('cookie'));
+  const email = astro.locals.user?.email ?? null;
+
+  if (!token) {
+    log.warn('platform-api-no-session', { email });
+    throw new PlatformApiAuthError('no_session');
+  }
+  if (!email) {
+    log.warn('platform-api-no-email');
+    throw new PlatformApiAuthError('no_email');
+  }
+
+  const base = PUBLIC_PLATFORM_API_BASE_URL.replace(/\/$/, '');
+
+  return {
+    fetch: (path, init = {}) =>
+      fetch(`${base}${path}`, {
+        ...init,
+        headers: {
+          ...(init.headers ?? {}),
+          Authorization: `Bearer ${token}`,
+          Accept: 'application/json',
+        },
+      }),
+  };
+}


### PR DESCRIPTION
## Summary

- New `createPlatformApiClient(astro)` helper in `astro-app/src/lib/platform-api-client.ts` — injects the Better Auth session cookie as `Authorization: Bearer <token>` for outbound calls to `platform-api`
- Typed `PlatformApiAuthError` with `not_configured` / `no_session` / `no_email` codes for the three short-circuit paths
- New `PUBLIC_PLATFORM_API_BASE_URL` declared in `astro:env/client` schema as `optional: true`
- 7 vitest cases (happy path, `__Secure-` prefixed cookie, trailing-slash base URL, all three error codes, regex assertion that the token is never logged)

**No consumers wired in this PR.** The helper ships as infrastructure so pac27's companion Story 12.8 (platform-api side, branch `feat/oauth2-integration`) can land without cross-workspace coordination. The helper is dead code in production until `PUBLIC_PLATFORM_API_BASE_URL` is set in `wrangler.jsonc` (deferred to Story 12.8b — a 5-min config-only follow-up after pac27 deploys).

## Why now

Splits the OAuth2 bridge work along team lines:
- **12.8a (this PR, Team A / Jay):** astro-app helper + env schema declaration
- **12.8 (Team B / pac27-cloud):** platform-api real D1+KV bindings, CORS prod origins, drop unused pyjwt dep, split `require_admin` from `require_sponsor`, pytest coverage
- **12.8b (Team A, post-pac27):** flip `PUBLIC_PLATFORM_API_BASE_URL` value in `astro-app/wrangler.jsonc` `[env.capstone]` + `[env.capstone_preview]`

Cookie regex mirrors `middleware.ts:extractSessionToken` (line 374) verbatim — handles both `better-auth.session_token=` and `__Secure-better-auth.session_token=` (the latter is set when Better Auth's `advanced.useSecureCookies` is on). Did NOT extract to a shared utility because importing from `middleware.ts` would pull its full dependency tree (Better Auth, Drizzle, KV) into the helper's bundle.

## Test plan

- [x] `npx vitest run --root astro-app astro-app/src/lib/__tests__/platform-api-client.test.ts` → 7/7 pass
- [x] `npm run test:unit` → 2164 pass / 1 baseline fail / 27 skip. The single failure (`ImageGallery > renders JSON-LD with creator Organization from siteSettings`) reproduces on clean `preview` and is **unrelated to this PR** — separate fix in flight
- [x] `npx wrangler types` from `astro-app/` → no diff in `worker-configuration.d.ts` (expected — `astro:env` schema additions don't propagate to wrangler types)
- [ ] CI green (modulo the pre-existing `ImageGallery` baseline failure)
- [ ] Visual confirmation: helper has zero callers (`grep -rn 'platform-api-client' astro-app/src/` returns only the helper file + its test)

## Story files

- `_bmad-output/implementation-artifacts/12-8a-astro-app-platform-api-client.md` (this story, status: done)
- `_bmad-output/implementation-artifacts/12-8-platform-api-session-token-bridge.md` (companion, pac27 owns)

(Both are gitignored — referenced for context only.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added platform API client integration for authenticated requests to the platform API service, with automatic session-based authentication.
  * Introduced configurable platform API base URL support with optional configuration and clear error messaging for missing dependencies.

* **Tests**
  * Added comprehensive test suite for platform API client authentication and error handling, including security validation to prevent token logging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->