### PR TITLE
fix(blocks): align ImageGallery test mock with siteSettings.siteName schema

### DIFF
--- a/astro-app/src/components/__tests__/ImageGallery.test.ts
+++ b/astro-app/src/components/__tests__/ImageGallery.test.ts
@@ -9,10 +9,13 @@ import {
   imageGalleryMinimal,
 } from './__fixtures__/image-gallery';
 
-// Mock getSiteSettings to avoid Sanity API dependency
+// Mock getSiteSettings to avoid Sanity API dependency.
+// Field name MUST match the Sanity schema (`siteName`) — GalleryGrid.astro reads
+// siteSettings.siteName for the JSON-LD creator. The earlier `title` shape was a
+// fixture-vs-schema drift that masked a passing test under stale TypeGen output.
 vi.mock('@/lib/sanity', () => ({
   getSiteSettings: vi.fn().mockResolvedValue({
-    title: 'YWCC Industry Capstone',
+    siteName: 'YWCC Industry Capstone',
   }),
 }));
 


### PR DESCRIPTION
## Summary

- One-line fixture fix to restore the green vitest baseline on `preview`.
- The `ImageGallery > renders JSON-LD with creator Organization from siteSettings` case in `astro-app/src/components/__tests__/ImageGallery.test.ts` was failing on `preview` baseline because the mock for `getSiteSettings()` returned `{ title: '...' }` while `GalleryGrid.astro` reads `siteSettings.siteName`.

## Root cause

`siteName` is the canonical field on the Sanity `siteSettings` schema and the canonical projection in `SITE_SETTINGS_QUERY`. The fixture used the stale `title` shape — drift from commit `d2a2719` (Story 22.4 — image gallery code review fixes). With `siteName` undefined the component branch sets `creatorOrg = null`, the spread `...(creatorOrg && { creator: creatorOrg })` resolves to nothing, and the test assertion on `jsonLd.creator` fails.

Added an inline comment so a future contributor doesn't reintroduce the same drift.

## Test plan

- [x] `npx vitest run --root astro-app src/components/__tests__/ImageGallery.test.ts` → 21/21 pass
- [x] `npm run test:unit` → 130/130 test files pass, 2158 tests pass, 27 skipped, **0 failures**, exit 0

No production code changed — fixture-only.