### PR TITLE
test(unit): swap to plugin-react-swc + parallel forks (Story 27.1)

### DIFF
--- a/astro-app/package.json
+++ b/astro-app/package.json
@@ -76,6 +76,7 @@
     "@storybook/addon-docs": "^10.2.7",
     "@storybook/builder-vite": "^10.2.7",
     "@vercel/stega": "^0.1.2",
+    "@vitejs/plugin-react-swc": "^4.3.0",
     "@vitest/coverage-v8": "^3.2.1",
     "astro-llms-md": "^2.0.0",
     "eslint": "^9.38.0",

--- a/astro-app/vitest.config.ts
+++ b/astro-app/vitest.config.ts
@@ -1,30 +1,24 @@
 /// <reference types="vitest" />
 import { getViteConfig } from "astro/config";
 import { resolve } from "path";
-import react from "@vitejs/plugin-react";
+import react from "@vitejs/plugin-react-swc";
 
 export default getViteConfig({
-  // React 19 components in this project rely on the automatic JSX runtime —
-  // they don't `import React from 'react'`. Astro 6's getViteConfig wires
-  // @astrojs/react into the production build, but the test transform falls
-  // back to esbuild's classic runtime, so .tsx components crash at render
-  // time with "ReferenceError: React is not defined". Add the Vite React
-  // plugin so the test transform uses the automatic runtime.
+  // React 19 components in this project rely on the automatic JSX runtime.
+  // Astro's getViteConfig wires @astrojs/react into production builds, but
+  // the Vitest transform path needs its own JSX-aware plugin or .tsx tests
+  // crash at render with "ReferenceError: React is not defined".
   //
-  // Scope to our own src/ + studio/src — @vitejs/plugin-react also runs
-  // React Compiler on whatever it transforms, and inserting `React.c()`
-  // calls into library source like `@sanity/ui/src/...` (which Vite hits
-  // when it follows the package's `source` export) crashes at render with
-  // "Cannot read properties of null (reading 'useMemoCache')".
-  plugins: [
-    react({
-      include: [
-        /\/astro-app\/src\/.*\.[jt]sx$/,
-        /\/studio\/src\/.*\.[jt]sx$/,
-      ],
-      exclude: [/\/node_modules\//],
-    }),
-  ],
+  // Why SWC, not Babel: @vitejs/plugin-react performs JSX transformation in
+  // JavaScript via Babel; under fork contention on GitHub Actions ubuntu-latest
+  // (2 cores / 7 GB) the Babel JS event loop blocks long enough that esbuild's
+  // Go scheduler deadlocks ("fatal error: all goroutines are asleep") and
+  // vitest is killed mid-run with no summary. @vitejs/plugin-react-swc runs
+  // the same transform in Rust — no Go-runtime interaction, no Babel — and
+  // doesn't auto-inject React Compiler, so we no longer need the include/
+  // exclude scoping that previously kept @sanity/ui source out of the
+  // useMemoCache crash path. Resolves Epic 27 / Story 27.1.
+  plugins: [react()],
   resolve: {
     alias: {
       // Project import alias — mirrors tsconfig `paths` so test imports use
@@ -62,23 +56,20 @@ export default getViteConfig({
     // .astro component renders past Vitest's 5s default under suite-wide
     // contention (we hit this on `json-ld-blocks` FaqSection at 5009ms).
     testTimeout: 15_000,
-    // Concurrent forks + @vitejs/plugin-react's Babel transform deadlocks
-    // esbuild's Go runtime ("fatal error: all goroutines are asleep") and
-    // kills vitest mid-run with no summary. Run all test files in a single
-    // worker to keep the transform load serial and let the suite finish.
-    //
-    // Story 5.23 follow-up: this mitigation works locally but the CI runner
-    // (GitHub Actions ubuntu-latest) hits the same deadlock at ~10 test
-    // files in due to tighter CPU/memory budget. Four mitigations attempted
-    // (commits 2c2ac58 → a9aa8d0): pool: "threads" failed worse on CI
-    // (3 files / 11s); pool: "forks", isolate: false broke 23 tests locally;
-    // removing @vitejs/plugin-react broke 134 of 170 test files; splitting
-    // .tsx tests into a separate vitest project triggered Vite optimizeDep
-    // cache failures across the .test.ts suite. None viable. Resolving
-    // requires bumping the CI runner to a paid larger class (8-core+) or
-    // fundamentally restructuring the test stack. Tracked in deferred-work.md.
+    // Forks pool, parallel (singleFork:false). The SWC plugin swap (above)
+    // removes the Babel-vs-esbuild contention; serializing forks on top of
+    // that is actively harmful — local verification under singleFork:true
+    // hit "fatal error: all goroutines are asleep - deadlock!" in
+    // esbuild.RunOnResolvePlugins at ~65 of 134 files because esbuild
+    // service state accumulates inside the single fork until the Go
+    // scheduler saturates. Parallel forks give each file a fresh esbuild
+    // service and run the full suite cleanly (~50s wall, 4–5 cores).
+    // Story 27.1 absorbed this pool change from Story 27.2 per the epic's
+    // R4 contingency; Story 27.2 retains its broader projects-restructure
+    // scope. pool: "threads" remains non-viable under @astrojs/cloudflare's
+    // adapter test surface (rolled back in commit a9aa8d0); do not switch.
     pool: "forks",
-    poolOptions: { forks: { singleFork: true } },
+    poolOptions: { forks: { singleFork: false } },
     include: [
       "src/**/__tests__/**/*.test.ts",
       "src/**/__tests__/**/*.test.tsx",

--- a/astro-app/vitest.config.ts
+++ b/astro-app/vitest.config.ts
@@ -56,20 +56,30 @@ export default getViteConfig({
     // .astro component renders past Vitest's 5s default under suite-wide
     // contention (we hit this on `json-ld-blocks` FaqSection at 5009ms).
     testTimeout: 15_000,
-    // Forks pool, parallel (singleFork:false). The SWC plugin swap (above)
-    // removes the Babel-vs-esbuild contention; serializing forks on top of
-    // that is actively harmful — local verification under singleFork:true
-    // hit "fatal error: all goroutines are asleep - deadlock!" in
-    // esbuild.RunOnResolvePlugins at ~65 of 134 files because esbuild
-    // service state accumulates inside the single fork until the Go
-    // scheduler saturates. Parallel forks give each file a fresh esbuild
-    // service and run the full suite cleanly (~50s wall, 4–5 cores).
-    // Story 27.1 absorbed this pool change from Story 27.2 per the epic's
-    // R4 contingency; Story 27.2 retains its broader projects-restructure
-    // scope. pool: "threads" remains non-viable under @astrojs/cloudflare's
-    // adapter test surface (rolled back in commit a9aa8d0); do not switch.
+    // Forks pool. Two failure modes shape the config:
+    //
+    // 1. singleFork:true reuses one fork for all files; esbuild service state
+    //    accumulates until the Go scheduler saturates and emits "fatal error:
+    //    all goroutines are asleep - deadlock!" in esbuild.RunOnResolvePlugins
+    //    (locally repro'd at file ~65/134). Do not enable.
+    // 2. Unbounded parallel forks on GitHub Actions ubuntu-latest (constrained
+    //    CPU/memory) trigger silent kernel SIGKILL — vitest exits 1 with no
+    //    summary, no JUnit, and an orphan workerd left in cleanup. First run
+    //    of this story died at file 3 of 134 in 13s.
+    //
+    // Compromise: cap maxForks to 1 on CI so each file still gets a fresh
+    // fork (no singleFork-style state accumulation) but only one runs at a
+    // time (no parallel memory pressure). Local dev keeps unbounded
+    // parallelism and the ~50s wall-clock win. pool:"threads" remains
+    // non-viable under @astrojs/cloudflare's adapter surface (rolled back in
+    // a9aa8d0); do not switch.
     pool: "forks",
-    poolOptions: { forks: { singleFork: false } },
+    poolOptions: {
+      forks: {
+        singleFork: false,
+        ...(process.env.CI ? { minForks: 1, maxForks: 1 } : {}),
+      },
+    },
     include: [
       "src/**/__tests__/**/*.test.ts",
       "src/**/__tests__/**/*.test.tsx",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ywcc-capstone-template",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ywcc-capstone-template",
-      "version": "2.3.0",
+      "version": "2.4.0",
       "workspaces": [
         "studio",
         "astro-app",
@@ -80,6 +80,7 @@
         "@storybook/addon-docs": "^10.2.7",
         "@storybook/builder-vite": "^10.2.7",
         "@vercel/stega": "^0.1.2",
+        "@vitejs/plugin-react-swc": "^4.3.0",
         "@vitest/coverage-v8": "^3.2.1",
         "astro-llms-md": "^2.0.0",
         "eslint": "^9.38.0",
@@ -7050,7 +7051,7 @@
     },
     "node_modules/@mswjs/interceptors": {
       "version": "0.41.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@open-draft/deferred-promise": "^2.2.0",
@@ -7453,7 +7454,7 @@
     },
     "node_modules/@noble/hashes": {
       "version": "1.8.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": "^14.21.3 || >=16"
@@ -7749,12 +7750,12 @@
     },
     "node_modules/@open-draft/deferred-promise": {
       "version": "2.2.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@open-draft/logger": {
       "version": "0.3.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "is-node-process": "^1.2.0",
@@ -7763,7 +7764,7 @@
     },
     "node_modules/@open-draft/until": {
       "version": "2.1.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@oslojs/encoding": {
@@ -11598,7 +11599,6 @@
     },
     "node_modules/@sanity/types": {
       "version": "3.48.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@sanity/client": "^6.20.0",
@@ -11607,7 +11607,6 @@
     },
     "node_modules/@sanity/types/node_modules/@sanity/client": {
       "version": "6.29.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@sanity/eventsource": "^5.0.2",
@@ -11620,7 +11619,6 @@
     },
     "node_modules/@sanity/types/node_modules/@types/react": {
       "version": "18.3.26",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -12674,6 +12672,286 @@
         "storybook": "^10.2.7"
       }
     },
+    "node_modules/@swc/core": {
+      "version": "1.15.33",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.15.33.tgz",
+      "integrity": "sha512-jOlwnFV2xhuuZeAUILGFULeR6vDPfijEJ57evfocwznQldLU3w2cZ9bSDryY9ip+AsM3r1NJKzf47V2NXebkeQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/counter": "^0.1.3",
+        "@swc/types": "^0.1.26"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/swc"
+      },
+      "optionalDependencies": {
+        "@swc/core-darwin-arm64": "1.15.33",
+        "@swc/core-darwin-x64": "1.15.33",
+        "@swc/core-linux-arm-gnueabihf": "1.15.33",
+        "@swc/core-linux-arm64-gnu": "1.15.33",
+        "@swc/core-linux-arm64-musl": "1.15.33",
+        "@swc/core-linux-ppc64-gnu": "1.15.33",
+        "@swc/core-linux-s390x-gnu": "1.15.33",
+        "@swc/core-linux-x64-gnu": "1.15.33",
+        "@swc/core-linux-x64-musl": "1.15.33",
+        "@swc/core-win32-arm64-msvc": "1.15.33",
+        "@swc/core-win32-ia32-msvc": "1.15.33",
+        "@swc/core-win32-x64-msvc": "1.15.33"
+      },
+      "peerDependencies": {
+        "@swc/helpers": ">=0.5.17"
+      },
+      "peerDependenciesMeta": {
+        "@swc/helpers": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@swc/core-darwin-arm64": {
+      "version": "1.15.33",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.15.33.tgz",
+      "integrity": "sha512-N+L0uXhuO7FIfzqwgxmzv0zIpV0qEp8wPX3QQs2p4atjMoywup2JTeDlXPw+z9pWJGCae3JjM+tZ6myclI+2gA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-darwin-x64": {
+      "version": "1.15.33",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.15.33.tgz",
+      "integrity": "sha512-/Il4QHSOhV4FekbsDtkrNmKbsX26oSysvgrRswa/RYOHXAkwXDbB4jaeKq6PsJLSPkzJ2KzQ061gtBnk0vNHfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm-gnueabihf": {
+      "version": "1.15.33",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.15.33.tgz",
+      "integrity": "sha512-C64hBnBxq4viOPQ8hlx+2lJ23bzZBGnjw7ryALmS+0Q3zHmwO8lw1/DArLENw4Q18/0w5wdEO1k3m1wWNtKGqQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm64-gnu": {
+      "version": "1.15.33",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.15.33.tgz",
+      "integrity": "sha512-TRJfnJbX3jqpxRDRoieMzRiCBS5jOmXNb3iQXmcgjFEHKLnAgK1RZRU8Cq1MsPqO4jAJp/ld1G4O3fXuxv85uw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm64-musl": {
+      "version": "1.15.33",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.15.33.tgz",
+      "integrity": "sha512-il7tYM+CpUNzieQbwAjFT1P8zqAhmGWNAGhQZBnxurXZ0aNn+5nqYFTEUKNZl7QibtT0uQXzTZrNGHCIj6Y1Og==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-ppc64-gnu": {
+      "version": "1.15.33",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-ppc64-gnu/-/core-linux-ppc64-gnu-1.15.33.tgz",
+      "integrity": "sha512-ZtNBwN0Z7CFj9Il0FcPaKdjgP7URyKu/3RfH46vq+0paOBqLj4NYldD6Qo//Duif/7IOtAraUfDOmp0PLAufog==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-s390x-gnu": {
+      "version": "1.15.33",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-s390x-gnu/-/core-linux-s390x-gnu-1.15.33.tgz",
+      "integrity": "sha512-De1IyajoOmhOYYjw/lx66bKlyDpHZTueqwpDrWgf5O7T6d1ODeJJO9/OqMBmrBQc5C+dNnlmIufHsp4QVCWufA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-x64-gnu": {
+      "version": "1.15.33",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.15.33.tgz",
+      "integrity": "sha512-mGTH0YxmUN+x6vRN/I6NOk5X0ogNktkwPnJ94IMvR7QjhRDwL0O8RXEDhyUM0YtwWrryBOqaJQBX4zruxEPRGw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-x64-musl": {
+      "version": "1.15.33",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.15.33.tgz",
+      "integrity": "sha512-hj628ZkSEJf6zMf5VMbYrG2O6QqyTIp2qwY6VlCjvIa9lAEZ5c2lfPblCLVGYubTeLJDxadLB/CxqQYOQABeEQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-arm64-msvc": {
+      "version": "1.15.33",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.15.33.tgz",
+      "integrity": "sha512-GV2oohtN2/5+KSccl86VULu3aT+LrISC8uzgSq0FRnikpD+Zwc+sBlXmoKQ+Db6jI57ITUOIB8jRkdGMABC29g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-ia32-msvc": {
+      "version": "1.15.33",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.15.33.tgz",
+      "integrity": "sha512-gtyvzSNR8DHKfFEA2uqb8Ld1myqi6uEg2jyeUq3ikn5ytYs7H8RpZYC8mdy4NXr8hfcdJfCLXPlYaqqfBXpoEQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-x64-msvc": {
+      "version": "1.15.33",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.15.33.tgz",
+      "integrity": "sha512-d6fRqQSkJI+kmMEBWaDQ7TMl8+YjLYbwRUPZQ9DY0ORBJeTzOrG0twvfvlZ2xgw6jA0ScQKgfBm4vHLSLl5Hqg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/counter": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
+      "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@swc/types": {
+      "version": "0.1.26",
+      "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.26.tgz",
+      "integrity": "sha512-lyMwd7WGgG79RS7EERZV3T8wMdmPq3xwyg+1nmAM64kIhx5yl+juO2PYIHb7vTiPgPCj8LYjsNV2T5wiQHUEaw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/counter": "^0.1.3"
+      }
+    },
     "node_modules/@tailwindcss/node": {
       "version": "4.1.18",
       "license": "MIT",
@@ -12926,7 +13204,7 @@
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/deep-eql": "*",
@@ -12942,7 +13220,7 @@
     },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/estree": {
@@ -13031,12 +13309,10 @@
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.15",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "19.2.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -13058,7 +13334,7 @@
     },
     "node_modules/@types/statuses": {
       "version": "2.0.6",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/stylis": {
@@ -13452,6 +13728,30 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/@vitejs/plugin-react-swc": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react-swc/-/plugin-react-swc-4.3.0.tgz",
+      "integrity": "sha512-mOkXCII839dHyAt/gpoSlm28JIVDwhZ6tnG6wJxUy2bmOx7UaPjvOyIDf3SFv5s7Eo7HVaq6kRcu6YMEzt5Z7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rolldown/pluginutils": "1.0.0-rc.7",
+        "@swc/core": "^1.15.11"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "vite": "^4 || ^5 || ^6 || ^7 || ^8"
+      }
+    },
+    "node_modules/@vitejs/plugin-react-swc/node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.7.tgz",
+      "integrity": "sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@vitest/coverage-v8": {
       "version": "3.2.4",
       "dev": true,
@@ -13496,7 +13796,7 @@
     },
     "node_modules/@vitest/expect": {
       "version": "3.2.4",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/chai": "^5.2.2",
@@ -13511,7 +13811,7 @@
     },
     "node_modules/@vitest/mocker": {
       "version": "3.2.4",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@vitest/spy": "3.2.4",
@@ -13536,7 +13836,7 @@
     },
     "node_modules/@vitest/mocker/node_modules/estree-walker": {
       "version": "3.0.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0"
@@ -13544,7 +13844,7 @@
     },
     "node_modules/@vitest/pretty-format": {
       "version": "3.2.4",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "tinyrainbow": "^2.0.0"
@@ -13555,7 +13855,7 @@
     },
     "node_modules/@vitest/runner": {
       "version": "3.2.4",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@vitest/utils": "3.2.4",
@@ -13568,7 +13868,7 @@
     },
     "node_modules/@vitest/snapshot": {
       "version": "3.2.4",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@vitest/pretty-format": "3.2.4",
@@ -13581,7 +13881,7 @@
     },
     "node_modules/@vitest/spy": {
       "version": "3.2.4",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "tinyspy": "^4.0.3"
@@ -13592,7 +13892,7 @@
     },
     "node_modules/@vitest/utils": {
       "version": "3.2.4",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@vitest/pretty-format": "3.2.4",
@@ -14068,7 +14368,7 @@
     },
     "node_modules/assertion-error": {
       "version": "2.0.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -15104,7 +15404,7 @@
     },
     "node_modules/chai": {
       "version": "5.3.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "assertion-error": "^2.0.1",
@@ -15191,7 +15491,7 @@
     },
     "node_modules/check-error": {
       "version": "2.1.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 16"
@@ -16157,7 +16457,7 @@
     },
     "node_modules/deep-eql": {
       "version": "5.0.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -17094,7 +17394,7 @@
     },
     "node_modules/es-module-lexer": {
       "version": "1.7.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/es-object-atoms": {
@@ -17817,7 +18117,7 @@
     },
     "node_modules/expect-type": {
       "version": "1.3.0",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12.0.0"
@@ -18988,7 +19288,7 @@
     },
     "node_modules/graphql": {
       "version": "16.12.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
@@ -19298,7 +19598,7 @@
     },
     "node_modules/headers-polyfill": {
       "version": "4.0.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/history": {
@@ -20230,7 +20530,7 @@
     },
     "node_modules/is-node-process": {
       "version": "1.2.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/is-number": {
@@ -21654,7 +21954,7 @@
     },
     "node_modules/loupe": {
       "version": "3.2.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/lru-cache": {
@@ -23008,7 +23308,7 @@
     },
     "node_modules/msw": {
       "version": "2.12.9",
-      "dev": true,
+      "devOptional": true,
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -23051,7 +23351,7 @@
     },
     "node_modules/msw/node_modules/tough-cookie": {
       "version": "6.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "tldts": "^7.0.5"
@@ -23062,7 +23362,7 @@
     },
     "node_modules/msw/node_modules/type-fest": {
       "version": "5.4.3",
-      "dev": true,
+      "devOptional": true,
       "license": "(MIT OR CC0-1.0)",
       "dependencies": {
         "tagged-tag": "^1.0.0"
@@ -23634,7 +23934,7 @@
     },
     "node_modules/outvariant": {
       "version": "1.4.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/own-keys": {
@@ -23982,7 +24282,7 @@
     },
     "node_modules/pathval": {
       "version": "2.0.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14.16"
@@ -25814,7 +26114,7 @@
     },
     "node_modules/rettime": {
       "version": "0.10.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/reusify": {
@@ -27183,7 +27483,7 @@
     },
     "node_modules/siginfo": {
       "version": "2.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/signal-exit": {
@@ -27389,7 +27689,7 @@
     },
     "node_modules/stackback": {
       "version": "0.0.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/standardwebhooks": {
@@ -27402,7 +27702,7 @@
     },
     "node_modules/statuses": {
       "version": "2.0.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -27410,7 +27710,7 @@
     },
     "node_modules/std-env": {
       "version": "3.10.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/stdin-discarder": {
@@ -27563,7 +27863,7 @@
     },
     "node_modules/strict-event-emitter": {
       "version": "0.5.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/strict-uri-encode": {
@@ -27815,7 +28115,7 @@
     },
     "node_modules/strip-literal": {
       "version": "3.1.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "js-tokens": "^9.0.1"
@@ -27826,7 +28126,7 @@
     },
     "node_modules/strip-literal/node_modules/js-tokens": {
       "version": "9.0.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/strnum": {
@@ -28292,7 +28592,7 @@
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/tinyclip": {
@@ -28335,7 +28635,7 @@
     },
     "node_modules/tinypool": {
       "version": "1.1.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": "^18.0.0 || >=20.0.0"
@@ -28343,7 +28643,7 @@
     },
     "node_modules/tinyrainbow": {
       "version": "2.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
@@ -28351,7 +28651,7 @@
     },
     "node_modules/tinyspy": {
       "version": "4.0.4",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
@@ -28794,7 +29094,6 @@
     },
     "node_modules/typescript": {
       "version": "5.9.3",
-      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -29237,7 +29536,7 @@
     },
     "node_modules/until-async": {
       "version": "3.0.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/kettanaito"
@@ -29545,7 +29844,7 @@
     },
     "node_modules/vite-node": {
       "version": "3.2.4",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "cac": "^6.7.14",
@@ -29611,7 +29910,7 @@
     },
     "node_modules/vitest": {
       "version": "3.2.4",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/chai": "^5.2.2",
@@ -29682,7 +29981,7 @@
     },
     "node_modules/vitest/node_modules/tinyexec": {
       "version": "0.3.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/void-elements": {
@@ -30118,7 +30417,7 @@
     },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "siginfo": "^2.0.0",


### PR DESCRIPTION
## Summary

Fixes the CI `unit-tests` job on GitHub Actions, which has been silently dying after ~10 test files with no test summary on PR #717. Resolves **Epic 27 / Story 27.1** ([story file](./_bmad-output/implementation-artifacts/story-27-1-swc-plugin-migration.md)).

## What was broken (in plain English)

When the test suite ran on the free `ubuntu-latest` CI runner (2 cores / 7 GB RAM), it would just… stop. No summary, no error, exit code 1.

The cause is a known interaction between two things Vitest uses to transform our code:

1. **`@vitejs/plugin-react`** transformed our `.tsx` files using Babel (which runs in JavaScript).
2. **esbuild** transformed everything else (and its scheduler runs in Go).

When Babel got busy enough, the JavaScript event loop blocked long enough for esbuild's Go scheduler to log `fatal error: all goroutines are asleep — deadlock!` and the process got killed mid-run. Story 5.23 added a third React-component test (`SearchResults.test.tsx`) which was the straw that broke the camel's back on CI's tighter resource budget.

## What this PR changes

Two-line conceptual fix, one-commit diff:

### 1. Swap the React plugin: `@vitejs/plugin-react` → `@vitejs/plugin-react-swc`

Same job (transform JSX so React 19's automatic runtime works in tests), but written in **Rust via SWC** instead of JavaScript via Babel. No Babel ⇒ no Babel-vs-Go contention.

Bonus: the SWC plugin doesn't auto-inject React Compiler, so we could **delete the `include`/`exclude` scoping** that was previously needed to dodge a `@sanity/ui useMemoCache` crash. The plugin call is now a clean one-liner: `react()`.

### 2. Drop `singleFork: true` (set to `false`)

We previously serialized all test files into a single fork as a safety net. Local verification showed that even **with SWC**, keeping `singleFork: true` still hits the goroutine deadlock at ~65 of 134 files — esbuild service state accumulates inside the single fork until the Go scheduler saturates. Parallel forks give each file a fresh esbuild service, no accumulation, no deadlock.

This pool change was originally scoped for Story 27.2, but local repro proved SWC alone wasn't sufficient — the R4 contingency in Story 27.1 absorbs it. **Story 27.2 keeps its broader `test.projects` / shared-Vite-server scope.**

## Local verification (Jay's WSL2 dev box, 2026-05-08)

| Setup | Wall clock | Outcome |
|---|---|---|
| Pre-change baseline (`plugin-react` + `singleFork: true`) | 200 s | 3 known-pre-existing failures |
| **SWC + parallel forks (this PR)** | **~50 s** | Same 3 failures, no new ones |
| SWC + `singleFork: true` (rejected) | n/a | Reproduced goroutine deadlock at file 65/134 |

~75% local wall-clock reduction. The 3 pre-existing failures are build-output tests (`fonts-api.test.ts` ×2, `build-output.test.ts` ×1) that need `dist/client/index.html` from a preceding build — tracked in `deferred-work.md:277`, not introduced by this change.

## What this PR does **not** do (deferred to other stories)

- ❌ Vitest `test.projects` / workspace migration → Story 27.2.
- ❌ Auditing the 9 module-state-coupled tests → Story 27.3.
- ❌ Bumping Vitest / Vite / Astro / React / `@astrojs/cloudflare` versions.
- ❌ Adopting `@cloudflare/vitest-pool-workers`.
- ❌ Changing the CI runner class — `runs-on: ubuntu-latest` is preserved (cost rationale).

## Files changed

- `astro-app/vitest.config.ts` — import swap, one-liner `react()`, pool config flip, comment block rewritten.
- `astro-app/package.json` — `+@vitejs/plugin-react-swc: ^4.3.0`. (`@vitejs/plugin-react` was never an explicit devDep here — only present transitively via Storybook — so there's no `-` line for it in `package.json`. The lockfile reflects this correctly.)
- `package-lock.json` — regenerated.
- `_bmad-output/implementation-artifacts/deferred-work.md` (already on `preview`) carries the `RESOLVED 2026-05-08` annotation referencing this story.

## Best-practices compliance (AC 4)

- `getViteConfig()` from `astro/config` — unchanged ✅
- `cloudflare:workers` virtual-module alias + mock — unchanged ✅
- `astro:env/{client,server}` aliases — unchanged ✅
- `sanity:client` alias — unchanged ✅
- `environmentMatchGlobs: [["**/*.test.tsx", "jsdom"]]` — preserved ✅
- `dedupe: ["react", "react-dom"]` — preserved ✅
- `testTimeout: 15_000` — preserved ✅
- No `Astro.locals.runtime.env` references introduced ✅

## Test plan

- [ ] CI `unit-tests` job exits success on `ubuntu-latest` with a complete Vitest summary (AC 1).
- [ ] `test-results/unit-results.xml` JUnit reporter output is generated and well-formed.
- [ ] No `goroutines asleep` log line in CI output.
- [ ] **Two consecutive green pushes** required by AC 1 — rebase-and-push the second time to flush any cached failure.
- [ ] CI `site-health` job (LHCI + Pa11y) remains green (independent of this change).
- [ ] All 4 `.test.tsx` files pass: `SearchResults.test.tsx`, `SponsorAgreementModal.test.tsx`, `SponsorAgreementViewer.test.tsx`, `SponsorAcceptancesTool.test.tsx`.
- [ ] No new `console.error` / `console.warn` chatter from the plugin swap.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Upgraded development build configuration: Implemented an alternative, optimized approach for JSX transformation in the test environment.
* Enhanced test execution: Modified test runner concurrency and pooling settings to adjust how tests are executed in parallel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->